### PR TITLE
Fixing broken calculations in spacing values.

### DIFF
--- a/packages/design-tokens/properties/size/spacing.json
+++ b/packages/design-tokens/properties/size/spacing.json
@@ -7,9 +7,9 @@
       "16"    : { "value": "1" },
       "24"    : { "value": "1.5" },
       "32"    : { "value": "2" },
-      "48"    : { "value": "2.5" },
-      "64"    : { "value": "3" },
-      "128"   : { "value": "6" },
+      "48"    : { "value": "3" },
+      "64"    : { "value": "4" },
+      "128"   : { "value": "8" },
       "base"  : { "value": "{size.padding.medium.value}" },
       "2xs"   : { "value": "0.0125" },
       "xs"    : { "value": "0.25" },
@@ -17,9 +17,9 @@
       "md"    : { "value": "1" },
       "lg"    : { "value": "1.5" },
       "xl"    : { "value": "2" },
-      "2xl"   : { "value": "2.5" },
-      "3xl"   : { "value": "3" },
-      "4xl"   : { "value": "6" }
+      "2xl"   : { "value": "3" },
+      "3xl"   : { "value": "4" },
+      "4xl"   : { "value": "8" }
     }
   }
 }


### PR DESCRIPTION
The math didn't line up in the naming. I assumed the Tshirt sizes should also correspond and updated them, accordingly.