### PR TITLE
Updated list elements. Restrict styles to specific use cases.

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extras/_list.scss
+++ b/packages/bootstrap4-theme/src/scss/extras/_list.scss
@@ -20,66 +20,21 @@ $list-brand-light: $uds-color-brand-light;
 $list-font-weight: $font-weight-normal;
 $list-font-weight-bold: $font-weight-bold;
 
-ul,
-ol {
-  // General list spacing.
+@mixin uds-list-spacing {
   padding: $list-space-48 $list-space-80;
+  list-style: none;
+
   li {
     max-width: 75ch; // TODO Revisit.
     margin-bottom: $list-space-base;
-    &:last-of-type,
+
     &:last-of-type {
       margin-bottom: 0;
     }
   }
-  ol,
-  ul {
-    padding: $list-space-base $list-space-24 0px;
-  }
-  &.maroon li:before {
-    color: $maroon;
-  }
-  // Dark mode.
-  &.darkmode {
-    margin-left: 0;
-    margin-bottom: 0;
-    background-color: $dark;
-    color: $list-darkmode-font-light;
-    // Default white list bullets (for dark mode)
-    li:before {
-      color: $list-darkmode-font-light;
-    }
-    // Gold list icon bullets (for dark mode)
-    &.gold li .fa-li {
-      color: $gold;
-    }
-    background-color: $dark;
-    color: $list-darkmode-font-light;
-    // Default white list bullets (for dark mode)
-    li:before {
-      color: $list-darkmode-font-light;
-    }
-    // Gold list bullets (for dark mode)
-    &.gold li:before {
-      color: $gold;
-    }
-    &.uds-steplist li:before {
-      background-color: $list-darkmode-font-light;
-      color: $dark;
-    }
-  }
-  // Smoke mode (gray background).
-  &.smokemode {
-    margin-left: 0;
-    margin-bottom: 0;
-    background-color: $list-smoke;
-  }
 }
 
-ul {
-  // Unordered list base styles
-  list-style: none;
-
+@mixin uds-ul-list-styles {
   li:before,
   ul ul li:before,
   ul ul ul ul li:before {
@@ -90,45 +45,118 @@ ul {
     padding-right: $list-space-20;
     margin-left: -$list-space-32;
   }
+
   ul li:before,
   ul ul ul li:before {
     content: '\25E6 ';
   }
 
-  // Icon bullets styles
-  &.fa-ul {
-    list-style-type: none;
-    margin-left: 0;
-    margin-bottom: 0;
-    padding: $list-space-48 $list-space-80;
-    li .fa-li {
-      left: -$list-space-40;
-    }
-    li:before {
-      content: none;
-      font-size: $list-font-xxl;
-      vertical-align: middle;
-      line-height: $list-line-height;
-      padding-right: $list-space-base;
-      margin-left: -$list-space-24;
-    }
-    // Maroon icon bullets
-    &.maroon li .fa-li {
-      color: $maroon;
-    }
+  ol,
+  ul {
+    padding: $list-space-base $list-space-24 0px;
+  }
+}
+
+// UL with no class or class=""
+ul:not([class]),
+ul[class=''],
+ul.maroon,
+ul.darkmode,
+ul.smokemode {
+  @include uds-list-spacing;
+  @include uds-ul-list-styles;
+}
+
+// Maroon lists
+ul.maroon,
+ol.maroon {
+  li:before {
+    color: $maroon;
+  }
+}
+
+// Dark Mode
+ul.darkmode,
+ol.darkmode {
+  @include uds-list-spacing;
+
+  margin-left: 0;
+  margin-bottom: 0;
+  background-color: $dark;
+  color: $list-darkmode-font-light;
+  // Default white list bullets (for dark mode)
+  li:before {
+    color: $list-darkmode-font-light;
+  }
+  // Gold list icon bullets (for dark mode)
+  &.gold li .fa-li {
+    color: $gold;
+  }
+  background-color: $dark;
+  color: $list-darkmode-font-light;
+  // Default white list bullets (for dark mode)
+  li:before {
+    color: $list-darkmode-font-light;
+  }
+  // Gold list bullets (for dark mode)
+  &.gold li:before {
+    color: $gold;
+  }
+  &.uds-steplist li:before {
+    background-color: $list-darkmode-font-light;
+    color: $dark;
+  }
+}
+
+// Smoke mode (gray background).
+ul.smokemode,
+ol.smokemode {
+  @include uds-list-spacing;
+
+  margin-left: 0;
+  margin-bottom: 0;
+  background-color: $list-smoke;
+}
+
+ul.fa-ul {
+  @include uds-list-spacing;
+
+  margin-left: 0;
+  margin-bottom: 0;
+  padding: $list-space-48 $list-space-80;
+  li .fa-li {
+    left: -$list-space-40;
+  }
+  li:before {
+    content: none;
+    font-size: $list-font-xxl;
+    vertical-align: middle;
+    line-height: $list-line-height;
+    padding-right: $list-space-base;
+    margin-left: -$list-space-24;
+  }
+  // Maroon icon bullets
+  &.maroon li .fa-li {
+    color: $maroon;
   }
 }
 
 // Ordered list base styles.
 // We manually manage the counter since we need to remove the trailing periods.
 ol {
-  list-style-type: none;
+  @include uds-list-spacing;
   counter-reset: listcounter;
+
+  li ol {
+    padding: 1rem 1.5rem 0px;
+  }
+
   li:before {
     line-height: $list-line-height;
     padding-right: $list-space-base;
     margin-left: -$list-space-32;
   }
+
   li:before,
   ol ol li:before,
   ol ol ol ol li:before {

--- a/packages/bootstrap4-theme/stories/components/list/list.stories.js
+++ b/packages/bootstrap4-theme/stories/components/list/list.stories.js
@@ -6,7 +6,7 @@ storiesOf('Components/List', module)
     happo: false,
   })
 
-.add('Unodered list', () => `
+.add('Unordered list', () => `
 <ul>
   <li>Lorem ipsum dolor sit amet</li>
   <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
@@ -15,12 +15,53 @@ storiesOf('Components/List', module)
 </ul>
 `)
 
-.add('Unodered list, darkmode', () => `
+.add('Unordered list, Maroon', () => `
+<ul class="maroon">
+  <li>Lorem ipsum dolor sit amet</li>
+  <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+  <li>Ipsum dolor sit amet, consectetur adipiscing elit.</li>
+  <li>Sed do eiusmod tempor incididunt ut lorem ipsum dolor sit amet</li>
+</ul>
+`)
+
+.add('Unordered list, Smoke', () => `
+<ul class="smokemode">
+  <li>Lorem ipsum dolor sit amet</li>
+  <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+  <li>Ipsum dolor sit amet, consectetur adipiscing elit.</li>
+  <li>Sed do eiusmod tempor incididunt ut lorem ipsum dolor sit amet</li>
+</ul>
+`)
+
+.add('Unordered list, Dark', () => `
 <ul class="darkmode">
   <li>Lorem ipsum dolor sit amet</li>
   <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
   <li>Ipsum dolor sit amet, consectetur adipiscing elit.</li>
   <li>Sed do eiusmod tempor incididunt ut lorem ipsum dolor sit amet</li>
+</ul>
+`)
+
+.add('Unordered list, Multi-level', () => `
+<ul>
+  <li>Lorem ipsum dolor sit amet
+    <ul>
+      <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        <ul>
+          <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            <ul>
+              <li>Lorem ipsum dolor sit amet
+              <ul>
+                <li>Lorem ipsum dolor sit amet</li>
+                <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              </ul>
+            </li>
+          </ul>
+        </li>
+      <li>Lorem ipsum dolor sit amet</li>
+    </ul>
+  </li>
+  <li>Lorem ipsum dolor sit amet</li>
 </ul>
 `)
 
@@ -41,20 +82,55 @@ storiesOf('Components/List', module)
 </ol>
 `)
 
-.add('Ordered list, smokemode', () => `
+.add('Ordered list, Maroon', () => `
+<ol class="maroon">
+  <li>Lorem ipsum dolor sit amet</li>
+  <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+  <li>Ipsum dolor sit amet, consectetur adipiscing elit.</li>
+  <li>Sed do eiusmod tempor incididunt ut lorem ipsum dolor sit amet</li>
+</ol>
+`)
+
+.add('Ordered list, Smoke', () => `
 <ol class="smokemode">
   <li>Lorem ipsum dolor sit amet</li>
   <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
   <li>Ipsum dolor sit amet, consectetur adipiscing elit.</li>
   <li>Sed do eiusmod tempor incididunt ut lorem ipsum dolor sit amet</li>
+</ol>
+`)
+
+.add('Ordered list, Dark', () => `
+<ol class="darkmode">
   <li>Lorem ipsum dolor sit amet</li>
-  <li>Eiusmod tempor lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
+  <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
+  <li>Ipsum dolor sit amet, consectetur adipiscing elit.</li>
+  <li>Sed do eiusmod tempor incididunt ut lorem ipsum dolor sit amet</li>
+</ol>
+`)
+
+.add('Ordered List, Multi-Level', () => `
+<ol>
+  <li>Lorem ipsum dolor sit amet
+      <ol>
+          <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              <ol>
+                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                      <ol>
+                          <li>Lorem ipsum dolor sit amet
+                              <ol>
+                                  <li>Lorem ipsum dolor sit amet</li>
+                                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                              </ol>
+                          </li>
+                      </ol>
+                  </li>
+                  <li>Lorem ipsum dolor sit amet</li>
+              </ol>
+          </li>
+      </ol>
+  </li>
   <li>Lorem ipsum dolor sit amet</li>
-  <li>Adipiscing elit lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
-  <li>Ipsum dolor sit amet</li>
-  <li>Lorem ipsum dolor sit amet</li>
-  <li>Adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
-  <li>Dolor sit amet, consectetur adipiscing elit.</li>
 </ol>
 `)
 
@@ -67,23 +143,6 @@ storiesOf('Components/List', module)
 </ul>
 `)
 
-.add('Unodered list, maroon', () => `
-<ul class="maroon">
-  <li>Lorem ipsum dolor sit amet</li>
-  <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
-  <li>Ipsum dolor sit amet, consectetur adipiscing elit.</li>
-  <li>Sed do eiusmod tempor incididunt ut lorem ipsum dolor sit amet</li>
-</ul>
-`)
-
-.add('Ordered list, maroon', () => `
-<ol class="maroon">
-  <li>Lorem ipsum dolor sit amet</li>
-  <li>Consectetur adipiscing lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</li>
-  <li>Ipsum dolor sit amet, consectetur adipiscing elit.</li>
-  <li>Sed do eiusmod tempor incididunt ut lorem ipsum dolor sit amet</li>
-</ol>
-`)
 
 .add('Icon list, maroon', () => `
 <ul class="fa-ul maroon">
@@ -112,52 +171,7 @@ storiesOf('Components/List', module)
 </ul>
 `)
 
-.add('Multilevel unordered list', () => `
-<ul>
-  <li>Lorem ipsum dolor sit amet
-      <ul>
-          <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              <ul>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                      <ul>
-                          <li>Lorem ipsum dolor sit amet
-                              <ul>
-                                  <li>Lorem ipsum dolor sit amet</li>
-                              </ul>
-                          </li>
-                      </ul>
-                  </li>
-              </ul>
-          </li>
-      </ul>
-  </li>
-</ul>
-`)
 
-.add('Multilevel ordered list', () => `
-<ol>
-  <li>Lorem ipsum dolor sit amet
-      <ol>
-          <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              <ol>
-                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                      <ol>
-                          <li>Lorem ipsum dolor sit amet
-                              <ol>
-                                  <li>Lorem ipsum dolor sit amet</li>
-                                  <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                              </ol>
-                          </li>
-                      </ol>
-                  </li>
-                  <li>Lorem ipsum dolor sit amet</li>
-              </ol>
-          </li>
-      </ol>
-  </li>
-  <li>Lorem ipsum dolor sit amet</li>
-</ol>
-`)
 
 // Should this be implemented as a list-group?
 .add('Step list', () => `


### PR DESCRIPTION
This request adjusts the committed code from PR #37 so that the styles applied within are targeted to specific use cases.

The problem with the existing code pertained to the use of the basic `<ul class="something"><li></li></ul>` markup which is prevalent in Bootstrap. By applying styles to a "naked" `ul` element, you wind up applying the list padding and content length restrictions in places where it wasn't necessarily supposed to be applied.

The encoded use cases for these formatting changes now include:
 - the standard `.maroon`, `.smokemode` and `.darkmode` classes that modify standard `ul` and `ol` elements.
- specifically, any `ul` element that is missing a class or in which the class is set as empty (`<ul class="">`)

It will also exclude any other `<ul>` in which a utility class is applied. For example `<ul class="nav">` still works out of the box. 