### PR TITLE
UDS-148 (follow up) Top center the background image as per HUB, so scaling doesn't cut off heads.

### DIFF
--- a/packages/design-tokens/components/heroes.json
+++ b/packages/design-tokens/components/heroes.json
@@ -16,7 +16,7 @@
           "value": "cover"
         },
         "background-position": {
-          "value": "center"
+          "value": "top"
         },
         "width-percent": {
           "value": "100%"


### PR DESCRIPTION
In recent discussions with the HUB it became clear they desire background images to scale to top-center in order to avoid heads being cut off. Previously we were scaling from center-center for Heroes. This fixes that.