### PR TITLE
Fix design token numbering for colors

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_cards.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_cards.scss
@@ -179,7 +179,7 @@ Cards - Table of Contents
 --------------------------------------------------------------------*/
 
 .card-foldable {
-  border-color: $uds-color-base-gray-5;
+  border-color: $uds-color-base-gray-3;
   border-left: $uds-size-spacing-1 solid $uds-color-base-gold;
   height: auto;
 
@@ -194,14 +194,14 @@ Cards - Table of Contents
         display: block;
         padding: $uds-size-spacing-2 $uds-size-spacing-4;
         text-decoration: none;
-        color: $uds-color-base-gray-1;
+        color: $uds-color-base-gray-7;
         display: flex;
         flex-wrap: nowrap;
         justify-content: space-between;
         align-items: center;
 
         &:hover {
-          background-color: $uds-color-base-gray-7;
+          background-color: $uds-color-base-gray-1;
         }
 
         svg.fa-chevron-up {
@@ -215,12 +215,12 @@ Cards - Table of Contents
       }
     }
     + .card-body {
-      border-top: 1px solid $uds-color-base-gray-5;
+      border-top: 1px solid $uds-color-base-gray-3;
     }
   }
 
   .card-body {
-    background-color: $uds-color-base-gray-7;
+    background-color: $uds-color-base-gray-1;
 
     > p:first-child {
       margin-top: $uds-size-spacing-2;
@@ -238,7 +238,7 @@ Cards - Table of Contents
 
 @include media-breakpoint-up(lg) {
   .card-foldable.desktop-disable {
-    border-left: 1px solid $uds-color-base-gray-5;
+    border-left: 1px solid $uds-color-base-gray-3;
     .card-header {
       h4 a {
         padding-top: $uds-size-spacing-4;

--- a/packages/bootstrap4-theme/src/scss/extends/_globalfooter.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_globalfooter.scss
@@ -14,7 +14,7 @@ Footer - Table of Contents
 --------------------------------------------------------------------*/
 
 @mixin footer-links {
-  color: $uds-color-base-gray-6;
+  color: $uds-color-base-gray-2;
   line-height: $uds-size-spacing-3;
   text-decoration: none;
 
@@ -60,7 +60,7 @@ Footer - Table of Contents
 
 #wrapper-endorsed-footer {
   a {
-    color: $uds-color-base-gray-6;
+    color: $uds-color-base-gray-2;
   }
 }
 
@@ -78,7 +78,7 @@ Footer - Table of Contents
 }
 
 #wrapper-footer-colophon {
-  background-color: $uds-color-base-gray-6-alt;
+  background-color: $uds-color-base-gray-2-alt;
   a {
     margin-right: $uds-size-spacing-3;
     text-decoration: none;
@@ -168,7 +168,7 @@ Footer - Table of Contents
       border-top: 1px solid $uds-color-divider-lighter;
 
       a {
-        color: $uds-color-base-gray-6;
+        color: $uds-color-base-gray-2;
         padding: $uds-size-spacing-3 0;
         text-decoration: none;
 

--- a/packages/bootstrap4-theme/src/scss/extends/_sidebar.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_sidebar.scss
@@ -39,10 +39,10 @@ Sidebar Navigation
   }
 
   > .nav-link {
-    border: 1px solid $uds-color-base-gray-6;
+    border: 1px solid $uds-color-base-gray-2;
     padding: $uds-size-spacing-2 $uds-size-spacing-4;
     overflow: hidden;
-    color: $uds-color-base-gray-1;
+    color: $uds-color-base-gray-7;
 
     @include like-an-h4;
 
@@ -52,7 +52,7 @@ Sidebar Navigation
   }
 
   .card-foldable {
-    border: 1px solid $uds-color-base-gray-6;
+    border: 1px solid $uds-color-base-gray-2;
 
     .card-header,
     .card-body {

--- a/packages/bootstrap4-theme/src/scss/variables/_colors.scss
+++ b/packages/bootstrap4-theme/src/scss/variables/_colors.scss
@@ -1,17 +1,17 @@
 // ASU Brand Standard Colors
 // Reference: https://hub.asu.edu/brand-hq/brand-standards/color-palette
 
-$black: $uds-color-base-black;
-$gray-1: $uds-color-base-gray-1;
-$gray-2: $uds-color-base-gray-2;
-$gray-3: $uds-color-base-gray-3;
-$gray-4: $uds-color-base-gray-4;
-$gray-5: $uds-color-base-gray-5;
-$gray-6: $uds-color-base-gray-6;
-$gray-7: $uds-color-base-gray-7;
 $white: $uds-color-base-white;
+$gray-1: $uds-color-base-gray-7;
+$gray-2: $uds-color-base-gray-6;
+$gray-3: $uds-color-base-gray-5;
+$gray-4: $uds-color-base-gray-4;
+$gray-5: $uds-color-base-gray-3;
+$gray-6: $uds-color-base-gray-2;
+$gray-7: $uds-color-base-gray-1;
+$black: $uds-color-base-black;
 
-$body-color: $uds-color-base-gray-1;
+$body-color: $uds-color-base-gray-7;
 
 $grays: ();
 // stylelint-disable-next-line scss/dollar-variable-default
@@ -31,8 +31,8 @@ $grays: map-merge(
 $gold: $uds-color-base-gold;
 $maroon: $uds-color-base-maroon;
 $maroon-alt-darker: $uds-color-base-darkmaroon;
-$dark: $uds-color-base-gray-1;
-$light: $uds-color-base-gray-6;
+$dark: $uds-color-base-gray-7;
+$light: $uds-color-base-gray-2;
 $blue: $uds-color-base-blue;
 $green: $uds-color-base-green;
 $orange: $uds-color-base-orange;
@@ -41,8 +41,8 @@ $bluefocus: $uds-color-base-bluefocus;
 $darkgold: $uds-color-base-darkgold;
 $darkmaroon: $uds-color-base-darkmaroon;
 
-$gray-3-alt-alpha: $uds-color-base-gray-3-alt-alpha;
-$gray-3-alt: $uds-color-base-gray-3-alt;
+$gray-3-alt-alpha: $uds-color-base-gray-5-alt-alpha;
+$gray-3-alt: $uds-color-base-gray-5-alt;
 
 $colors: () !default;
 
@@ -80,7 +80,7 @@ $theme-colors: map-merge(
     'warning': $warning,
     'danger': $danger,
     'light': $light,
-    'gray' : $gray-4,
+    'gray': $gray-4,
     'dark': $dark,
     'gray-1': $gray-1,
     'gray-2': $gray-2,
@@ -106,8 +106,8 @@ $link-hover-color: $maroon;
 $link-hover-decoration: none;
 
 :focus {
-   outline: 0;
-   box-shadow: 0 0 8px #00BAFF !important;
+  outline: 0;
+  box-shadow: 0 0 8px #00baff !important;
 }
 
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
@@ -116,11 +116,11 @@ $link-hover-decoration: none;
 // $stretched-link-pseudo-element: after;
 // $stretched-link-z-index: 1;
 
-$card-cap-bg:                       rgba($white, .03);
+$card-cap-bg: rgba($white, 0.03);
 
-$nav-tabs-link-color:               $dark;
-$nav-tabs-border-width:             1px;
-$nav-tabs-border-color:             $gray-3;
-$nav-tabs-border-radius:            0;
-$nav-tabs-link-active-color:        $maroon;
+$nav-tabs-link-color: $dark;
+$nav-tabs-border-width: 1px;
+$nav-tabs-border-color: $gray-3;
+$nav-tabs-border-radius: 0;
+$nav-tabs-link-active-color: $maroon;
 $nav-tabs-link-active-border-color: $maroon;

--- a/packages/design-tokens/components/breadcrumb.json
+++ b/packages/design-tokens/components/breadcrumb.json
@@ -30,7 +30,7 @@
         "value": "{color.base.gray.4.value}"
       },
       "active-color": {
-        "value": "{color.base.gray.1.value}"
+        "value": "{color.base.gray.7.value}"
       },
       "divider": {
         "value": "quote('/')"

--- a/packages/design-tokens/components/card.json
+++ b/packages/design-tokens/components/card.json
@@ -35,16 +35,16 @@
             "value": "100%"
           },
           "height": {
-            "value" : "12.5rem"
+            "value": "12.5rem"
           },
           "height-sm": {
-            "value" : "10rem"
+            "value": "10rem"
           },
           "height-lg": {
-            "value" : "15rem"
+            "value": "15rem"
           },
           "object-fit": {
-            "value" : "cover"
+            "value": "cover"
           }
         },
         "icon-top": {
@@ -117,10 +117,10 @@
           }
         },
         "footer-link": {
-          "padding" : {
+          "padding": {
             "value": "{size.spacing.2.value} {size.spacing.4.value} {size.spacing.2.value} {size.spacing.4.value}"
           },
-          "padding-sm" : {
+          "padding-sm": {
             "value": "{size.spacing.2.value} {size.spacing.2.value} {size.spacing.2.value} {size.spacing.2.value}"
           },
           "border-top": {
@@ -169,7 +169,7 @@
       },
       "event": {
         "base": {
-          "color": "{color.base.gray.6.value}"
+          "color": "{color.base.gray.2.value}"
         },
         "active": {
           "color": "{color.base.gold.value}"
@@ -178,7 +178,7 @@
           "color": "{color.base.gold.value}"
         },
         "visited": {
-          "color": "{color.base.gray.6.value}"
+          "color": "{color.base.gray.2.value}"
         }
       }
     }

--- a/packages/design-tokens/components/link.json
+++ b/packages/design-tokens/components/link.json
@@ -33,7 +33,7 @@
       },
       "light": {
         "base": {
-          "color": "{color.base.gray.6.value}"
+          "color": "{color.base.gray.2.value}"
         },
         "active": {
           "color": "{color.brand.gold.value}"
@@ -42,7 +42,7 @@
           "color": "{color.brand.gold.value}"
         },
         "visited": {
-          "color": "{color.base.gray.6.value}"
+          "color": "{color.base.gray.2.value}"
         }
       }
     }

--- a/packages/design-tokens/components/list.json
+++ b/packages/design-tokens/components/list.json
@@ -66,16 +66,16 @@
           "value": "{color.background.dark.value}"
         },
         "color": {
-          "value": "{color.base.gray.6.value}"
+          "value": "{color.base.gray.2.value}"
         },
         "li-before-color": {
-          "value": "{color.base.gray.6.value}"
+          "value": "{color.base.gray.2.value}"
         },
         "gold-color": {
           "value": "{color.brand.gold.value}"
         },
         "steplist-background-color": {
-          "value": "{color.base.gray.6.value}"
+          "value": "{color.base.gray.2.value}"
         },
         "steplist-color": {
           "value": "{color.background.dark.value}"

--- a/packages/design-tokens/properties/color/background.json
+++ b/packages/design-tokens/properties/color/background.json
@@ -6,11 +6,11 @@
         "comment": "Background - White"
       },
       "gray": {
-        "value": "{color.base.gray.6.value}",
+        "value": "{color.base.gray.2.value}",
         "comment": "Background - Gray"
       },
       "dark": {
-        "value": "{color.base.gray.1.value}",
+        "value": "{color.base.gray.7.value}",
         "comment": "Background - Dark"
       },
       "success": {

--- a/packages/design-tokens/properties/color/base.json
+++ b/packages/design-tokens/properties/color/base.json
@@ -43,38 +43,38 @@
       },
       "gray": {
         "1": {
-          "value": "#191919",
-          "comment": "Base font color and default black level"
+          "value": "#FAFAFA"
         },
         "2": {
-          "value": "#484848"
+          "value": "#E8E8E8"
         },
-        "3_alt_alpha": {
-          "value": "#70707080",
-          "comment": "Alt border for RFI form card"
-        },
-        "3_alt": {
-          "value": "#707070",
-          "comment": "Alt border for header search input border"
+        "2_alt": {
+          "value": "#E5E5E5",
+          "comment": "Used in footer and as a lighter card border"
         },
         "3": {
-          "value": "#747474"
+          "value": "#D0D0D0"
         },
         "4": {
           "value": "#BFBFBF"
         },
         "5": {
-          "value": "#D0D0D0"
+          "value": "#747474"
         },
-        "6_alt": {
-          "value": "#E5E5E5",
-          "comment": "Used in footer and as a lighter card border"
+        "5_alt": {
+          "value": "#707070",
+          "comment": "Alt border for header search input border"
+        },
+        "5_alt_alpha": {
+          "value": "#70707080",
+          "comment": "Alt border for RFI form card"
         },
         "6": {
-          "value": "#E8E8E8"
+          "value": "#484848"
         },
         "7": {
-          "value": "#FAFAFA"
+          "value": "#191919",
+          "comment": "Base font color and default black level"
         }
       }
     }

--- a/packages/design-tokens/properties/color/border.json
+++ b/packages/design-tokens/properties/color/border.json
@@ -2,15 +2,15 @@
   "color": {
     "border": {
       "lighter": {
-        "value": "{color.base.gray.6_alt.value}",
+        "value": "{color.base.gray.2_alt.value}",
         "comment": "Border - Used for one card border variant"
       },
       "light": {
-        "value": "{color.base.gray.6.value}",
+        "value": "{color.base.gray.2.value}",
         "comment": "Border - Light"
       },
       "base": {
-        "value": "{color.base.gray.5.value}",
+        "value": "{color.base.gray.3.value}",
         "comment": "Border - Base"
       },
       "dark": {

--- a/packages/design-tokens/properties/color/brand.json
+++ b/packages/design-tokens/properties/color/brand.json
@@ -10,7 +10,7 @@
         "comment": "ASU Maroon brand color"
       },
       "dark": {
-        "value": "{color.base.gray.1.value}",
+        "value": "{color.base.gray.7.value}",
         "comment": "ASU Dark brand color - Near Black"
       },
       "light": {

--- a/packages/design-tokens/properties/color/font.json
+++ b/packages/design-tokens/properties/color/font.json
@@ -3,7 +3,7 @@
     "font": {
       "dark": {
         "base": {
-          "value": "{color.base.gray.1.value}",
+          "value": "{color.base.gray.7.value}",
           "comment": "Default text color on light background"
         },
         "alternate": {
@@ -45,7 +45,7 @@
       },
       "light": {
         "base": {
-          "value": "{color.base.gray.7.value}",
+          "value": "{color.base.gray.1.value}",
           "comment": "Default text on dark background"
         },
         "link": {


### PR DESCRIPTION
This PR addresses an error that we made when first setting up the color variables in the design token library.

The error accidentally inverted the order in which we numbered each variant of gray. So, in our design token library, gray-1 was the closest color to black, even though the design documents numbered these colors the opposite way. 

The PR includes a remap of the gray values in the design token library as well as the results of some search-replace actions to reassign colors based on the new color scale. 