### PR TITLE
Spacing changes to the divider components. (UDS-252)

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_dividers.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_dividers.scss
@@ -1,10 +1,13 @@
 hr {
-  border-top: $horizonatal-rule-border;
+  border-top: 0;
+  height: 1px;
+  margin: $uds-size-spacing-6 0;
+  background-color: $uds-color-base-gray-3;
 
   &.copy-divider {
-    margin-left: $copy-divider-margin;
-    max-width: $copy-divider-width;
-    border-top: $copy-divider-border;
+    height: $uds-size-spacing-1;
+    background-color: $uds-color-base-gold;
+    max-width: $uds-size-spacing-32;
   }
 }
 

--- a/packages/bootstrap4-theme/src/scss/variables/_dividers.scss
+++ b/packages/bootstrap4-theme/src/scss/variables/_dividers.scss
@@ -1,8 +1,3 @@
-$horizonatal-rule-border: 1px solid #d0d0d0;
-$copy-divider-margin: 0;
-$copy-divider-width: 256px;
-$copy-divider-border: 8px solid #ffc627;
-
 $bg: transparent #fff 0% 0% repeat padding-box;
 $bg-opacity: 1;
 


### PR DESCRIPTION
Small CSS changes to the divider components to provide better default spacing between the elements that they will be separating. The default spacing is now 3rem (48px). 

Also refactored the CSS to also use no additional design tokens for this component. Uses just the default spacing and color tokens only.