### PR TITLE
BUG: global-header.js + a missing #asu-header element produces an error.

### DIFF
--- a/packages/bootstrap4-theme/src/js/global-header.js
+++ b/packages/bootstrap4-theme/src/js/global-header.js
@@ -1,12 +1,6 @@
 jQuery(document).ready(function ($) {
   'use strict';
 
-  // Is the global header component indeed on this page?
-  // If not, stop executing.
-  if ($('#asu-header').length == 0) {
-    return;
-  }
-
   $(window).scroll(function () {
     if ($(this).scrollTop() > 0) {
       $('#asu-header').addClass('scrolled');
@@ -85,11 +79,11 @@ jQuery(document).ready(function ($) {
 
   function recordTopValue () {
     topValue = $(document).scrollTop();
-    $('body').addClass('dropdown-pinned');
+    $('#asu-header').closest('body').addClass('dropdown-pinned');
   }
 
   function restoreTopValue () {
-    $('body').removeClass('dropdown-pinned');
+    $('#asu-header').closest('body').removeClass('dropdown-pinned');
     topValue = $(document).scrollTop(topValue);
   }
 


### PR DESCRIPTION
This quick PR helps to resolve a display problem within the UDS-Boostrap-4 version of Storybook within this repo. 

Right now, `global-header.stories.js` loads the necessary Javascript for that component as an include statement from elsewhere within the project. 

```
import '../../../src/js/global-header.js';
```
That import statement is responsible for loading the script across the entire project as Storybook compiles everything inside of the `/stories` folder. That means that the `global-header.js` file has the potential to be executed even if the global header is not present on the screen. The `global-header.js` contains a couple of event listeners that watch for elements on the screen to be resized and then applying a class of `dropdown-pinned` to the `<body>` on the page. It was this class that was triggering the very odd resizing issue when Storybook users were to resize the individual frames within the application.

Luckily... the fix was easier than the explanation. I added a quick check at the top of the JS file that looks for the presence of `#asu-header` in order to continue. If that element is not found, the rest of the script never loads.

I have no reason to believe that the addition of this simple check will affect anything in production. If you are using the UDS-Boostrap version of the header, both the JS and the markup will be present on the page.

If you are using other elements of UDS-Boostrap and the Boostrap header isn't present, the recommended course of action is to not load the JS file to begin with. This might be the case if someone wanted to load the Preact header AND the Bootstrap library. 

If the Preact header & the `global-header.js` are loaded on the page at the same time, you will probably encounter an error.
