### PR TITLE
Content section max width (UDS-335)

### DIFF
--- a/packages/bootstrap4-theme/.storybook/preview.js
+++ b/packages/bootstrap4-theme/.storybook/preview.js
@@ -21,7 +21,7 @@ addDecorator(withA11y)
 export const parameters = {
   options: {
     storySort: {
-      order: ['Design', ['Colors', 'Typography', 'Layout', 'Icons', 'Backgrounds', 'Focus States'], 'Components', 'Content Sections', 'Docs', ['Global Header', ['Header top', 'Header main', 'Navbar options', 'No navigation']]],
+      order: ['Design', ['Colors', 'Typography', 'Layout', 'Icons', 'Backgrounds', 'Focus States'], 'Components', 'Content Sections', 'Docs', ['Page Layout', 'Global Header', ['Header top', 'Header main', 'Navbar options', 'No navigation']]],
     },
   },
 };

--- a/packages/bootstrap4-theme/src/scss/bootstrap-asu-extends.scss
+++ b/packages/bootstrap4-theme/src/scss/bootstrap-asu-extends.scss
@@ -1,4 +1,5 @@
 // css Bootstrap doesn't have variables for
+@import 'extends/layout';
 @import 'extends/misc';
 @import 'extends/alerts';
 @import 'extends/banners';

--- a/packages/bootstrap4-theme/src/scss/extends/_global-header.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_global-header.scss
@@ -8,7 +8,6 @@
 5. Main Menu, Mobile
 6. Main Menu, Mobile Only
 7. Main Menu, Desktop
-8. Page Content
 --------------------------------------------------------------*/
 
 $fa-search: url($image-assets-path+'/font-awesome-svg/search.svg');
@@ -884,39 +883,5 @@ $fa-search: url($image-assets-path+'/font-awesome-svg/search.svg');
     .navbar-mobile-footer {
       display: none;
     }
-  }
-}
-
-/*--------------------------------------------------------------
-8. Page Wrapper
---------------------------------------------------------------*/
-// Margins are needed to prevent content from flowing under global header.
-
-// Mobile
-#asu-header+div,
-#asu-header+main {
-  @include transition;
-  margin-top: 113px;
-}
-
-#asu-header.scrolled+div,
-#asu-header.scrolled+main {
-  @include transition;
-  margin-top: 97px;
-}
-
-// Desktop
-@include media-breakpoint-up(lg) {
-
-  #asu-header+div,
-  #asu-header+main {
-    @include transition;
-    margin-top: 137px;
-  }
-
-  #asu-header.scrolled+div,
-  #asu-header.scrolled+main {
-    @include transition;
-    margin-top: 81x;
   }
 }

--- a/packages/bootstrap4-theme/src/scss/extends/_layout.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_layout.scss
@@ -1,0 +1,61 @@
+/*--------------------------------------------------------------
+# Basic Page Layout
+
+1. Baseline grid
+2. Page wrapper margins
+--------------------------------------------------------------*/
+
+body {
+  display: grid;
+  grid-template-columns: 1fr fit-content(1920px) 1fr;
+  grid-template-rows: auto auto auto;
+  gap: 0px 0px;
+  grid-template-areas:
+    "ASU-Header ASU-Header ASU-Header"
+    ". content ."
+    "ASU-Footer ASU-Footer ASU-Footer";
+}
+
+#asu-header { grid-area: ASU-Header; }
+
+#asu-header + main { grid-area: content; }
+#asu-header + div { grid-area: content; }
+
+#asu-footer { grid-area: ASU-Footer; };
+body > footer { grid-area: ASU-Footer; }
+
+
+/*--------------------------------------------------------------
+2. Page wrapper margins
+--------------------------------------------------------------*/
+// Margins are needed to prevent content from flowing under the pinned global header.
+
+// Mobile
+#asu-header+div,
+#asu-header+main {
+  @include transition;
+  margin-top: 113px;
+}
+
+#asu-header.scrolled+div,
+#asu-header.scrolled+main {
+  @include transition;
+  margin-top: 97px;
+}
+
+// Desktop
+@include media-breakpoint-up(lg) {
+
+  #asu-header+div,
+  #asu-header+main {
+    @include transition;
+    margin-top: 137px;
+  }
+
+  #asu-header.scrolled+div,
+  #asu-header.scrolled+main {
+    @include transition;
+    margin-top: 81x;
+  }
+}
+

--- a/packages/bootstrap4-theme/stories/components/global-footer/globalfooter.stories.js
+++ b/packages/bootstrap4-theme/stories/components/global-footer/globalfooter.stories.js
@@ -9,7 +9,7 @@ storiesOf('Components/Global Footer', module)
   })
 
   .add('Global elements only', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
 
     <div class="wrapper" id="wrapper-footer-innovation">
       <div class="container" id="footer-innovation">
@@ -51,7 +51,7 @@ storiesOf('Components/Global Footer', module)
   `)
 
   .add('Zero columns', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
     <div class="wrapper" id="wrapper-endorsed-footer">
       <div class="container" id="endorsed-footer">
         <div class="row">
@@ -113,7 +113,7 @@ storiesOf('Components/Global Footer', module)
   `)
 
   .add('One column', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
     <div class="wrapper" id="wrapper-endorsed-footer">
       <div class="container" id="endorsed-footer">
         <div class="row">
@@ -189,7 +189,7 @@ storiesOf('Components/Global Footer', module)
   `)
 
   .add('One column, no logo or social', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
 
     <div class="wrapper" id="wrapper-footer-columns">
       <div class="container" id="footer-columns">
@@ -244,7 +244,7 @@ storiesOf('Components/Global Footer', module)
   `)
 
   .add('Two columns', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
     <div class="wrapper" id="wrapper-endorsed-footer">
       <div class="container" id="endorsed-footer">
         <div class="row">
@@ -340,7 +340,7 @@ storiesOf('Components/Global Footer', module)
   `)
 
   .add('Three columns', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
     <div class="wrapper" id="wrapper-endorsed-footer">
       <div class="container" id="endorsed-footer">
         <div class="row">
@@ -457,7 +457,7 @@ storiesOf('Components/Global Footer', module)
   `)
 
   .add('Four columns', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
     <div class="wrapper" id="wrapper-endorsed-footer">
       <div class="container" id="endorsed-footer">
         <div class="row">
@@ -595,7 +595,7 @@ storiesOf('Components/Global Footer', module)
   `)
 
   .add('Five columns', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
     <div class="wrapper" id="wrapper-endorsed-footer">
       <div class="container" id="endorsed-footer">
         <div class="row">
@@ -754,7 +754,7 @@ storiesOf('Components/Global Footer', module)
   `)
 
   .add('Six columns', () => `
-  <footer role="contentinfo">
+  <footer id="asu-footer" role="contentinfo">
     <div class="wrapper" id="wrapper-endorsed-footer">
       <div class="container" id="endorsed-footer">
         <div class="row">

--- a/packages/bootstrap4-theme/stories/docs/layout/baseline-grid.stories.mdx
+++ b/packages/bootstrap4-theme/stories/docs/layout/baseline-grid.stories.mdx
@@ -1,0 +1,68 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Page Layout/Baseline Grid" />
+
+# Baseline Grid
+
+The UDS Boostrap 4 project ships with a recommended solution for limiting all content to a maximum width of 1920px. This max width restriction will help to prevent background textures and background images from bleeding out to the edge of large-format display monitors.
+
+Our basline grid is applied to the `body` element on the page and establishes a flexible 3 x 3 cell layout.
+
+```
+body {
+  display: grid;
+  grid-template-columns: 1fr fit-content(1920px) 1fr;
+  grid-template-rows: auto auto auto;
+  gap: 0px 0px;
+  grid-template-areas:
+    "ASU-Header ASU-Header ASU-Header"
+    ". content ."
+    "ASU-Footer ASU-Footer ASU-Footer";
+}
+```
+
+- The entire top row is taken up by the global header element.
+- The middle cell of the middle row is the `content` grid area. It will behave like a `margin:auto` statement until the max width is reached.
+- The entire bottom row is taken up by the global footer element.
+- All rows are set to `height:auto` allowing them to expand and contract normally.
+
+Landmarks within the UDS-Boostrap codebase are assigned to specific areas within this grid.
+
+```
+#asu-header { grid-area: ASU-Header; }
+
+#asu-header + main { grid-area: content; }
+#asu-header + div { grid-area: content; }
+
+#asu-footer { grid-area: ASU-Footer; };
+body > footer { grid-area: ASU-Footer; }
+```
+
+## Recommended markup
+
+The global header markup requires the use of a wrapper element as a container for the remainder of the content on the page. This wrapper prevents the content from flowing under the global header. (The header is `position:fixed` to the top and is otherwise removed from the content flow.) This wrapper element is also the target for the middle row of our CSS grid and is constrained to a maximum width of 1920px.
+
+The recommended bare bones page markup should look like this:
+
+```
+<body>
+  <header id="asu-header" class="fixed-top">...</header>
+  <main>...</main>
+  <footer id="asu-footer">...</footer>
+</body>
+```
+
+We have added a few additional rules for legacy projects using this codebase.
+
+- Instead of using the `<main>` HTML tag, the given CSS will also target any generic `<div>` that is ajacent to `#asu-header.`
+- Early versions of the global footer failed to include the `#asu-footer` landmark. As a fall back, the given CSS will target any `<footer>` element that is an immediate child of the main `<body>` tag.
+
+## Project specific overrides
+
+Utilization of a baseline CSS grid is one of many solutions for this type of problem. Should you choose to impliment a different solution within your project, you may override the CSS grid declarations here by including a statement like the following after the initial CSS from this package has been loaded.
+
+```
+body { display:initial; }
+```
+
+If you are compiling the SASS directly into your project, you may also comment out or omit the first section of `/scss/extends/_layout.scss`.


### PR DESCRIPTION
Utilizing a basic CSS grid at the body tag level, we can target elements that are likely (required?) to be on the page and force them to a maximum width of 1920px. 

This story includes one "docs" style story that outlines the included SASS and provides a basic example of how the markup of a whole page should look to fully take advantage of what's there.

One small correction was made to the global footer markup that also ties into this requirement. 

- The global footer never established a recognizable CSS ID for easy targeting by the CSS grid declaration.
- I altered the existing global footer stories to include the recommendation: `#asu-footer`. 
- The SASS has a fallback rule that should catch most things in production. That rule looks for any `<footer>` element that is an immediate child of the `<body>` tag and applies the same layout. 