### PR TITLE
fix(bootstrap4-theme): CSS fix for gold slivers in Bootstrap Header. …

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_global-header.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_global-header.scss
@@ -23,7 +23,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
   display: block;
   height: $uds-size-spacing-1;
   /* Use linear gradient so we can offset and avoid little gold slivers */
-  background-image: linear-gradient(to right, transparent 0.5%, #ffc627 0.5%);
+  background-image: linear-gradient(to right, transparent 0.5%, $uds-color-base-gold 0.5%);
 }
 
 @mixin gold-underline-mobile {
@@ -97,8 +97,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
     font-size: 0.75rem;
     font-family: $uds-font-family-base;
     line-height: 0.75rem;
-    padding: $uds-size-spacing-half $uds-size-spacing-1 $uds-size-spacing-half
-      $uds-size-spacing-1;
+    padding: $uds-size-spacing-half $uds-size-spacing-1 $uds-size-spacing-half $uds-size-spacing-1;
     margin-right: $uds-size-spacing-1;
 
     &.sr-only {
@@ -111,23 +110,23 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
     align-items: center;
     margin-right: $uds-size-spacing-1;
 
-    > a {
+    >a {
       padding: 0;
       margin: 0;
       color: $uds-color-base-gray-6;
       text-decoration: none;
     }
 
-    > a.name {
+    >a.name {
       font-weight: 700;
     }
 
-    > a.signout:before {
+    >a.signout:before {
       content: '(';
       margin-left: 4px;
     }
 
-    > a.signout:after {
+    >a.signout:after {
       content: ') ';
     }
   }
@@ -141,8 +140,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
   }
 
   input[type='search'] {
-    background: url($image-assets-path + '/font-awesome-svg/search-gray-6.svg')
-      no-repeat 10px 50%;
+    background: url($image-assets-path + '/font-awesome-svg/search-gray-6.svg') no-repeat 10px 50%;
     background-size: 12px;
     width: 32px;
     cursor: pointer;
@@ -155,7 +153,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
     height: $uds-size-spacing-3;
     margin: 0;
 
-    + label {
+    +label {
       display: none;
     }
   }
@@ -169,11 +167,11 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
     margin: 0.75rem 0;
     padding-left: $uds-size-spacing-4;
 
-    + label {
+    +label {
       display: block;
     }
 
-    &:valid + label {
+    &:valid+label {
       display: none;
     }
   }
@@ -240,6 +238,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
     }
 
     .navbar-nav {
+
       .nav-link,
       .dropdown .nav-link {
         padding-top: 0;
@@ -358,16 +357,16 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
     font-weight: 700;
     padding: 0 $uds-size-spacing-4 $uds-size-spacing-3 $uds-size-spacing-4;
 
-    > a {
+    >a {
       color: $uds-color-base-gray-7;
       text-decoration: none;
     }
 
-    > a:visited {
+    >a:visited {
       color: $uds-color-base-gray-7;
     }
 
-    > a:hover {
+    >a:hover {
       text-decoration: underline;
     }
 
@@ -378,8 +377,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
 
   .navbar-nav {
     .nav-link {
-      padding: $uds-size-spacing-2 $uds-size-spacing-4 $uds-size-spacing-1
-        $uds-size-spacing-4;
+      padding: $uds-size-spacing-2 $uds-size-spacing-4 $uds-size-spacing-1 $uds-size-spacing-4;
       border-top: 1px solid $uds-color-base-gray-3;
       color: $uds-color-base-gray-7;
 
@@ -443,8 +441,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
 
       input {
         width: 100%;
-        background: url($image-assets-path + '/font-awesome-svg/search-gray-6.svg')
-          no-repeat 10px 50%;
+        background: url($image-assets-path + '/font-awesome-svg/search-gray-6.svg') no-repeat 10px 50%;
         background-size: 16px;
         background-color: $uds-color-base-white;
         border: 0;
@@ -478,7 +475,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
         display: block;
         width: 100%;
 
-        > a {
+        >a {
           border: 0;
           padding: 0;
           margin: 0;
@@ -486,16 +483,16 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
           text-decoration: none;
         }
 
-        > a.name {
+        >a.name {
           font-weight: 700;
         }
 
-        > a.signout:before {
+        >a.signout:before {
           content: '(';
           margin-left: 4px;
         }
 
-        > a.signout:after {
+        >a.signout:after {
           content: ') ';
         }
       }
@@ -506,9 +503,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
       content: '';
       height: $uds-size-spacing-7;
       width: 100%;
-      background: transparent
-        linear-gradient(0deg, #19191914 0%, #19191900 100%) 0% 0% no-repeat
-        padding-box;
+      background: transparent linear-gradient(0deg, #19191914 0%, #19191900 100%) 0% 0% no-repeat padding-box;
       position: absolute;
       top: -3.5rem;
     }
@@ -589,7 +584,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
       color: $uds-color-base-gray-7;
     }
 
-    & + .dropdown-item {
+    &+.dropdown-item {
       border-top: 1px solid $uds-color-base-gray-4;
     }
   }
@@ -681,7 +676,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
         margin-bottom: 0;
       }
 
-      .btn + .btn {
+      .btn+.btn {
         margin-left: $uds-size-spacing-2;
       }
     }
@@ -693,7 +688,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
     .navbar-nav {
       line-height: $uds-size-spacing-2;
 
-      > .nav-link {
+      >.nav-link {
         border: 0;
         font-size: $uds-size-font-medium;
         color: $uds-color-base-gray-7;
@@ -708,7 +703,8 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
         }
 
         &.nav-link-home:after {
-          bottom: -7px; /* Home needs to be tweaked to not overlap border */
+          bottom: -7px;
+          /* Home needs to be tweaked to not overlap border */
         }
 
         &:hover:after {
@@ -722,7 +718,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
         }
       }
 
-      > .nav-link-home {
+      >.nav-link-home {
         padding-bottom: 7px;
         /* Magic number */
 
@@ -817,7 +813,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
         text-decoration: underline;
       }
 
-      & + .dropdown-item {
+      &+.dropdown-item {
         border-top: 0;
       }
     }
@@ -874,18 +870,18 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
         .dropdown-item {
           white-space: normal;
 
-          & + .dropdown-item {
+          &+.dropdown-item {
             border-top: 0;
           }
         }
 
-        .dropdown-item + .btn {
+        .dropdown-item+.btn {
           position: absolute;
           bottom: 0;
           margin: 0;
         }
 
-        .btn + .btn {
+        .btn+.btn {
           margin-left: $uds-size-spacing-3;
         }
       }
@@ -903,28 +899,29 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
 // Margins are needed to prevent content from flowing under global header.
 
 // Mobile
-#asu-header + div,
-#asu-header + main {
+#asu-header+div,
+#asu-header+main {
   @include transition;
   margin-top: 113px;
 }
 
-#asu-header.scrolled + div,
-#asu-header.scrolled + main {
+#asu-header.scrolled+div,
+#asu-header.scrolled+main {
   @include transition;
   margin-top: 97px;
 }
 
 // Desktop
 @include media-breakpoint-up(lg) {
-  #asu-header + div,
-  #asu-header + main {
+
+  #asu-header+div,
+  #asu-header+main {
     @include transition;
     margin-top: 137px;
   }
 
-  #asu-header.scrolled + div,
-  #asu-header.scrolled + main {
+  #asu-header.scrolled+div,
+  #asu-header.scrolled+main {
     @include transition;
     margin-top: 81x;
   }


### PR DESCRIPTION
…Includes code formatting from Prettier. UDS-393

Lines with actual, non-autoformatter changes, are 25 + 26 and 710-713.

In essence, we've moved from using a background color for the gold bar on the menu items to using a background linear-gradient() with offsets at the end so if there's a sliver there, it's transparent.  That's lines 25 and 26.

Lines 710-713 adjust the bottom on the home nav item, as it was overlapping the bottom border of the header, unlike the rest of the menu items. This tweak brings everything back in line with one another.