### PR TITLE
fix(components-library) UDS-371 Add aria-label to main menu toggle btn

### DIFF
--- a/packages/components-library/src/components/Navbar/styles.js
+++ b/packages/components-library/src/components/Navbar/styles.js
@@ -31,6 +31,7 @@ const NavbarToggler = ({ mobileOpen, ...props }) => {
   return (
     <button
       {...props}
+      aria-label="main menu"
       class={cx(
         css`
           .fa-circle {
@@ -54,7 +55,6 @@ const NavbarToggler = ({ mobileOpen, ...props }) => {
         `,
         "navbar-toggler"
       )}
-      aria-label="main menu"
     >
       {mobileOpen ? (
         <Icon type="circle-close" />


### PR DESCRIPTION
For assistive technology users, and proper form, we need a label on the mobile menu's toggler button - we're talking about the hamburger menu button in the Preact Header when we're at a mobile width. 

I've gone with the aria-label="main menu" fix as it required the least alteration to the code to implement.