### PR TITLE
fix(components-library) UDS-401 Fix breakpoints deadzone for Header.

### DIFF
--- a/packages/components-library/src/components/Login/styles.js
+++ b/packages/components-library/src/components/Login/styles.js
@@ -1,6 +1,7 @@
 
 
 import { cx, css } from "@emotion/css";
+import { breakpointForMin } from "../../theme";
 
 const loginStyles = breakpoint => css`
   .login-status {
@@ -31,7 +32,7 @@ const loginStyles = breakpoint => css`
     }
 
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       margin-left: .5rem;
     }
   }

--- a/packages/components-library/src/components/Nav/styles.js
+++ b/packages/components-library/src/components/Nav/styles.js
@@ -9,6 +9,7 @@ import {
   BreakpointLg,
   BreakpointXl,
   containerSize,
+  breakpointForMin
 } from "../../theme";
 import { IconChevronDown } from "../Icons/styles";
 
@@ -61,7 +62,7 @@ const navListStyles = breakpoint => css`
         }
       }
 
-      @media (min-width: ${breakpoint}) {
+      @media (min-width: ${breakpointForMin(breakpoint)}) {
         position: static;
 
         &.dropdown-open,
@@ -127,7 +128,7 @@ const navListStyles = breakpoint => css`
       ${hiddenStyle}
     }
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       svg.fa-chevron-down {
         float: none;
         display: inline-block;
@@ -306,7 +307,7 @@ const dropdownContainerStyles = breakpoint => css`
       }
     }
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       position: fixed;
 
       &:not(.mega) .menu-column {
@@ -386,7 +387,7 @@ const dropControlsStyles = breakpoint => css`
       }
     }
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       line-height: 1rem;
       box-sizing: content-box;
       :hover,
@@ -454,7 +455,7 @@ const menuColumnStyles = breakpoint => css`
       border-right: none;
     }
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       width: 16rem;
       padding: 0 1.5rem 0 0;
       border-right: 1px solid #bfbfbf;
@@ -479,7 +480,7 @@ const menuColumnStyles = breakpoint => css`
       }
     }
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       padding: 0 1.5rem 0 0;
       border-right: 1px solid #bfbfbf;
       margin-right: 1.5rem;
@@ -513,7 +514,7 @@ const componentStyles = breakpoint => css`
     ${hiddenStyle}
   }
 
-  @media (min-width: ${breakpoint}) {
+  @media (min-width: ${breakpointForMin(breakpoint)}) {
     width: 100%;
     display: flex;
     flex-direction: row;

--- a/packages/components-library/src/components/NavItem/styles.js
+++ b/packages/components-library/src/components/NavItem/styles.js
@@ -3,7 +3,7 @@ import { forwardRef } from "preact/compat";
 import { Icon } from "../Icons";
 import { css, cx } from "@emotion/css";
 import { Button } from "../";
-import { hiddenStyle } from "../../theme";
+import { hiddenStyle, breakpointForMin } from "../../theme";
 
 const navItemStyles = breakpoint => css`
   .navlink,
@@ -40,7 +40,7 @@ const navItemStyles = breakpoint => css`
       color: #191919;
     }
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       > a {
         padding: 0.5rem 0;
         white-space: normal;
@@ -60,7 +60,7 @@ const navItemStyles = breakpoint => css`
   .navbutton {
     margin-top: auto;
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       order: 1;
     }
 

--- a/packages/components-library/src/components/Navbar/styles.js
+++ b/packages/components-library/src/components/Navbar/styles.js
@@ -1,7 +1,7 @@
 
 
 import { css, cx } from "@emotion/css";
-import { containerSize, primaryNavTopPadding } from "../../theme";
+import { containerSize, primaryNavTopPadding, breakpointForMin } from "../../theme";
 import { Icon } from "../Icons";
 
 /**
@@ -21,7 +21,7 @@ const navbarTogglerStyles = breakpoint => css`
     cursor: pointer;
     align-self: flex-start;
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       display: none;
     }
   }

--- a/packages/components-library/src/components/Search/styles.js
+++ b/packages/components-library/src/components/Search/styles.js
@@ -2,6 +2,7 @@
 /* eslint-disable react/prop-types */
 
 import { cx, css } from "@emotion/css";
+import { breakpointForMin } from "../../theme";
 
 /** Search */
 const searchStyles = breakpoint => css`
@@ -81,7 +82,7 @@ const searchStyles = breakpoint => css`
       padding: 0;
     }
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       > form {
         justify-content: flex-end;
       }

--- a/packages/components-library/src/components/Title/styles.js
+++ b/packages/components-library/src/components/Title/styles.js
@@ -6,6 +6,7 @@ import { cx, css } from "@emotion/css";
 import {
   containerSize,
   BreakpointLg,
+  breakpointForMin
 } from "../../theme";
 
 /**
@@ -42,7 +43,7 @@ const titleStyles = breakpoint => css`
       color: #191919;
     }
 
-    @media (min-width: ${breakpoint}) {
+    @media (min-width: ${breakpointForMin(breakpoint)}) {
       line-height: 1;
       font-weight: 700;
       padding: 0;

--- a/packages/components-library/src/theme.js
+++ b/packages/components-library/src/theme.js
@@ -54,6 +54,17 @@ const showReset = position => {
   `;
 };
 
+/* When using max-width and min-width in media queries use <= and >= logic
+ * and that means when they are both used in media queries with the same
+ * breakpoint, there's a deadspace. For min-width we provide this function to
+ * bump the value by +1. We are working with a string, so it's regex time.
+ */
+const breakpointForMin = breakpoint => {
+  var breakpointMatch = breakpoint.match(/[a-z]+|[^a-z]+/gi);
+  // Add 1 and string it back together.
+  return (parseInt(breakpointMatch[0]) + 1).toString() + breakpointMatch[1];
+};
+
 const srOnly = css`
   :not(:focus):not(:active) {
     clip: rect(0 0 0 0);
@@ -76,6 +87,7 @@ const primaryNavTopPadding = "24px";
 export {
   hiddenStyle,
   showReset,
+  breakpointForMin,
   mobileBreak,
   containerSize,
   srOnly,


### PR DESCRIPTION
As outlined in UDS-401, there were issues with the breakpoint transitional point. 

I’ve added a helper function to the component library’s theme.js file for the Preact Header:

breakpointForMin(). The purpose of this function is to take the breakpoint string value which is piped in via design token as something like “992px” and regex it and increment the numeric bit by 1 and return the value all stitched back together. This is necessary because the media query max-width operator means  <= and the min-width means >=. The = on each ensures there will be a conflict space on the exact breakpoint value. By incrementing just the min-width breakpoint target by 1px we ensure that the breakpoint transition point is between the two values - no conflict.

Doing this with a simple helper function made sense over creating a separate design token for min breakpoints or as a variable to pass around and manage. min-wdith is set in about 13 different places in the various components' styles.js, and I’ve deployed this function on all of them. Impacted beyond what was visibly broken before, when right at 992px, is the menu columns in the mobile menu - had you been able to see them, you’d have found them broken. They are fixed with this solve as well as all the readily visible transition bits.