### PR TITLE
chore(*): switch to fixed versioning strategy

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent",
+  "version": "1.4.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }


### PR DESCRIPTION
Lerna config change to switch us to fixed/lockstep versioning. After reviewing all releases on registry.web.asu.edu I see that our latest release is 1.3.1 for components-library package. I've bumped the number up one minor release to account for review time and to avoid potential for collisions.