### PR TITLE
fix(bootstrap4-theme): remove underline on hover for pagination

### DIFF
--- a/packages/bootstrap4-theme/src/scss/design-tokens/_variables.scss
+++ b/packages/bootstrap4-theme/src/scss/design-tokens/_variables.scss
@@ -401,7 +401,7 @@ $uds-component-pager-max-width: 17.5rem;
 $uds-component-pager-hover-state-transform: scale(1.1);
 $uds-component-pager-active-state-transform: scale(1);
 $uds-component-pager-padding: 1rem 2rem;
-$uds-component-pager-hover-text-decoration: none;
+$uds-component-pager-hover-text-decoration: underline;
 $uds-component-pager-hover-color: #ffffff;
 $uds-component-pager-active-background-color: #8c1d40;
 $uds-component-pager-active-color: #ffffff;

--- a/packages/design-tokens/components/pager.json
+++ b/packages/design-tokens/components/pager.json
@@ -48,7 +48,7 @@
       },
       "hover": {
         "text-decoration": {
-          "value": "underline"
+          "value": "none"
         },
         "color": {
           "value": "{color.base.white.value}"


### PR DESCRIPTION
I just changed the text decoration being used by the anchor tags in pagination to use none instead of underlining. This is the desired behaviour outlined in the [XD File](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/1af28db0-6c0f-4f44-b288-996e15054412/). 

[Task in Jira](https://asudev.jira.com/browse/UDS-459)