### PR TITLE
fix(bootstrap4-theme): uds-470 - update caption text color

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_images.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_images.scss
@@ -26,6 +26,7 @@
     .uds-caption-text {
       display: block;
       max-width: 75ch;
+      color: $uds-color-base-gray-5;
     }
   }
 


### PR DESCRIPTION
In this PR:
- Fix current image caption to be “Gray 5” ( #747474.)![image](https://user-images.githubusercontent.com/7423476/114561396-71cfb600-9c65-11eb-8baa-84d4e08dbde1.png)
