### PR TITLE
perf(components-library): uds-436 - Underline nav bar links on hover

### DIFF
--- a/packages/components-library/src/components/Header/styles.js
+++ b/packages/components-library/src/components/Header/styles.js
@@ -202,6 +202,10 @@ const UniversalNavLinks = ({ children, ...props }) => {
             padding: 0.25rem 0.5rem;
             color: #484848;
             margin: 0;
+
+            &:hover{
+              text-decoration: underline;
+            }
           }
         `
       )}


### PR DESCRIPTION
In this PR
- Underline links when the user mouseover them

![image](https://user-images.githubusercontent.com/7423476/114722625-dc4e2800-9d31-11eb-8b47-3579a119ca75.png)
