### PR TITLE
feat(bootstrap4-theme): Add card checkboxes

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_cards.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_cards.scss
@@ -66,6 +66,10 @@ Cards - Table of Contents
   margin: $uds-component-card-basic-icon-top-margin;
 }
 
+.card-image-content {
+  position: relative;
+}
+
 .card-img-top img,
 .card-img-top {
   max-width: $uds-component-card-basic-image-top-width-percent;
@@ -737,4 +741,56 @@ Cards - Table of Contents
   .uds-quicklinks.uds-quicklinks-expanded-xl {
     @include uds-quicklinks-expanded;
   }
+}
+
+/*------------------------------------------------------------------
+11. Checkbox Stacked Cards
+--------------------------------------------------------------------*/
+
+.card-story-checkbox-stacked .card-header .card-title:after {
+  content: $uds-component-card-degree-title-underline-content;
+  width: $uds-component-card-degree-title-underline-width;
+  height: $uds-component-card-degree-title-underline-height;
+  display: $uds-component-card-degree-title-underline-display;
+  margin-top: $uds-component-card-degree-title-underline-margin-top;
+}
+
+.card-story-checkbox-stacked .card-header {
+  position: relative;
+}
+
+.card-story-checkbox-stacked .card-form {
+  position: absolute;
+  bottom: $uds-component-card-checkbox-stacked-bottom;
+  color: $white;
+}
+
+.card-story-checkbox-stacked .card-footer {
+  background-color: $white;
+}
+
+/*------------------------------------------------------------------
+12. Checkbox Inline Cards
+--------------------------------------------------------------------*/
+
+.card-story-checkbox-stacked .card-header .card-title:after {
+  content: $uds-component-card-degree-title-underline-content;
+  width: $uds-component-card-degree-title-underline-width;
+  height: $uds-component-card-degree-title-underline-height;
+  display: $uds-component-card-degree-title-underline-display;
+  margin-top: $uds-component-card-degree-title-underline-margin-top;
+}
+
+.card-story-checkbox-inline .card-header {
+  position: relative;
+}
+
+.card-story-checkbox-inline .card-form {
+  position: absolute;
+  bottom: $uds-component-card-checkbox-inline-bottom;
+  color: $white;
+}
+
+.card-story-checkbox-inline .card-footer {
+  background-color: $white;
 }

--- a/packages/bootstrap4-theme/src/scss/extends/_form-fields.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_form-fields.scss
@@ -77,6 +77,19 @@ form.uds-form {
       margin: $uds-size-spacing-2 0;
     }
   }
+
+  .card-image-fieldset {
+    margin-bottom: $uds-size-spacing-2;
+
+    &.inline {
+      display: flex;
+
+      .form-check:not(:first-child) {
+        margin-left: $uds-size-spacing-4;
+      }
+    }
+  }
+
   .form-check {
     margin: 0 0 $uds-size-spacing-4 0;
 

--- a/packages/bootstrap4-theme/src/scss/variables/_cards.scss
+++ b/packages/bootstrap4-theme/src/scss/variables/_cards.scss
@@ -1,1 +1,3 @@
 $card-border-radius: 0;
+$uds-component-card-checkbox-stacked-bottom: 0;
+$uds-component-card-checkbox-inline-bottom: 0;

--- a/packages/bootstrap4-theme/stories/components/cards/cards.stories.js
+++ b/packages/bootstrap4-theme/stories/components/cards/cards.stories.js
@@ -1057,3 +1057,90 @@ export const sizingUsingUtilities = () => `
     </div>
   </div>
 `;
+
+export const checkboxStackedCard = () => `
+  <div class="container">
+    <div class="row row-spaced pt-2 pb-2">
+      <div class="col col-12 col-md-6 col-lg-4">
+
+        <div class="card card-story-checkbox-stacked">
+          <div class="card-image-content">
+            <img class="card-img-top" src="${exampleImage}" alt="Card image cap">
+            <form class="uds-form card-form ml-4">
+              <fieldset class="card-image-fieldset">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="checkbox2" value="option2">
+                  <label class="form-check-label" for="checkbox2">Option 2</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="checkbox1" value="option1" checked>
+                  <label class="form-check-label" for="checkbox1">Option 1</label>
+                </div>
+              </fieldset>
+            </form>
+          </div>
+          <div class="card-header">
+            <h3 class="card-title">Card default title</h3>
+          </div>
+          <div class="card-body">
+            <p class="card-text">Basic card with mixed content and a fixed width.  Cards have no margin and no fixed width by default (they’ll naturally fill the full width of its parent), so use 'spacing utilities'.</p>
+          </div>
+          <div class="card-button">
+            <a href="#" class="btn btn-maroon">Default button</a>
+          </div>
+          <div class="card-link">
+            <a href="#" class="">Regular text link here</a>
+          </div>
+          <div class="card-tags">
+            <a class="btn btn-tag btn-tag-alt-white" href="#" >test tag</a> <a class="btn btn-tag btn-tag-alt-white" href="#" >test tag 2</a> <a class="btn btn-tag btn-tag-alt-white" href="#" >test tag 3</a>
+          </div>
+        </div> <!-- .card -->
+
+      </div> <!-- .col -->
+    </div>
+  </div>
+`;
+
+export const checkboxInlineCard = () => `
+<div class="container">
+  <div class="row row-spaced pt-2 pb-2">
+    <div class="col col-12 col-md-6 col-lg-4">
+
+      <div class="card card-story-checkbox-inline">
+        <div class="card-image-content">
+          <img class="card-img-top" src="${exampleImage}" alt="Card image cap">
+          <form class="uds-form card-form ml-4">
+            <fieldset class="card-image-fieldset inline">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="checkbox2" value="option2">
+                <label class="form-check-label" for="checkbox2">Option 2</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="checkbox1" value="option1" checked>
+                <label class="form-check-label" for="checkbox1">Option 1</label>
+              </div>
+            </fieldset>
+          </form>
+        </div>
+        <div class="card-header">
+          <h3 class="card-title">Card default title</h3>
+        </div>
+        <div class="card-body">
+          <p class="card-text">Basic card with mixed content and a fixed width.  Cards have no margin and no fixed width by default (they’ll naturally fill the full width of its parent), so use 'spacing utilities'.</p>
+        </div>
+        <div class="card-button">
+          <a href="#" class="btn btn-maroon">Default button</a>
+        </div>
+        <div class="card-link">
+          <a href="#" class="">Regular text link here</a>
+        </div>
+        <div class="card-tags">
+          <a class="btn btn-tag btn-tag-alt-white" href="#" >test tag</a> <a class="btn btn-tag btn-tag-alt-white" href="#" >test tag 2</a> <a class="btn btn-tag btn-tag-alt-white" href="#" >test tag 3</a>
+        </div>
+      </div> <!-- .card -->
+
+    </div> <!-- .col -->
+  </div>
+</div>
+`;
+


### PR DESCRIPTION
Added Stories for Card Checkboxes (Stacked and Inline).
I added a `card-image-content` which differentiates these cards, but as the content is to be positioned within the image I thought that made the most sense. It could probably be done without it by absolutely positioning it within the card but I feel that it would be messier and also less semantically correct, as the position of the checkboxes is intended to be relative to the image.

Also, this PR replaces [130](https://github.com/ASU/asu-unity-stack/pull/130), as that had been long running and this seemed cleaner.