### PR TITLE
fix(components-library): uds-431 - Preact Global Header CSS class name typo

### DIFF
--- a/packages/components-library/src/components/Header/__snapshots__/index.test.js.snap
+++ b/packages/components-library/src/components/Header/__snapshots__/index.test.js.snap
@@ -1517,7 +1517,7 @@ exports[`Header Snapshot test 1`] = `
               type="search"
             />
             <label
-              class="univeral-search"
+              class="universal-search"
               id="asu-search-label"
             >
               Search ASU

--- a/packages/components-library/src/components/Search/index.js
+++ b/packages/components-library/src/components/Search/index.js
@@ -30,7 +30,7 @@ const Search = ({ type, open, inputRef, mobile, ...props }) => {
             required
           />
 
-          <label class="univeral-search" id="asu-search-label" onmousedown={() => event.preventDefault() /** prevent label click from removing input focus */ }>
+          <label class="universal-search" id="asu-search-label" onmousedown={() => event.preventDefault() /** prevent label click from removing input focus */ }>
             Search ASU
           </label>
 


### PR DESCRIPTION
In this PR
- fix a typo of a CSS class name
Hi @mlsamuelson I think is safe to merge, the class `univeral-search` or the fixed name `universal-search` does not exist in any css/scss file. I do not foreseen any braking change 