### PR TITLE
fix: asuthemes docs had bad footer path.

### DIFF
--- a/server/views/asuthemes/index.njk
+++ b/server/views/asuthemes/index.njk
@@ -71,7 +71,7 @@
                     &lt;?php echo file_get_contents('https://www.asu.edu/asuthemes/5.0/headers/component.html'); ?>
 
                     // include in the &lt;footer>
-                    &lt;?php echo file_get_contents('https://www.asu.edu/asuthemes/5.0/footers/component-footer.html'); ?>
+                    &lt;?php echo file_get_contents('https://www.asu.edu/asuthemes/5.0/includes/component-footer.html'); ?>
                 </code>
               </pre>
               </p>


### PR DESCRIPTION
https://unity.web.asu.edu/asuthemes
has https://www.asu.edu/asuthemes/5.0/footers/component-footer.html
should be
https://www.asu.edu/asuthemes/5.0/includes/component-footer.html