### PR TITLE
fix(components-library,bootstrap4-theme) - uds-392 - Global header: Standarize skip navigation links on header

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_global-header.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_global-header.scss
@@ -112,6 +112,11 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
     &.sr-only {
       justify-self: flex-start;
     }
+
+    &:focus {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
   }
 
   .login-status {

--- a/packages/bootstrap4-theme/stories/components/global-header/global-header.stories.js
+++ b/packages/bootstrap4-theme/stories/components/global-header/global-header.stories.js
@@ -18,7 +18,7 @@ storiesOf('Components/Global Header', module)
         <div class="row">
           <div id="header-top" class="col-12">
             <nav class="nav" aria-label="Top">
-              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to content</a>
+              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to main content</a>
               <a class="nav-link sr-only sr-only-focusable" href="http://asu.edu/accessibility/feedback?a11yref=unity-design-system">Report an accessibility problem</a>
               <a class="nav-link" href="https://asu.edu">ASU Home</a>
               <a class="nav-link" href="https://my.asu.edu">My ASU</a>
@@ -144,7 +144,7 @@ storiesOf('Components/Global Header', module)
         <div class="row">
           <div id="header-top" class="col-12">
             <nav class="nav" aria-label="Top">
-              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to content</a>
+              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to main content</a>
               <a class="nav-link sr-only sr-only-focusable" href="http://asu.edu/accessibility/feedback?a11yref=unity-design-system">Report an accessibility problem</a>
               <a class="nav-link" href="https://asu.edu">ASU Home</a>
               <a class="nav-link" href="https://my.asu.edu">My ASU</a>
@@ -437,7 +437,7 @@ storiesOf('Components/Global Header', module)
         <div class="row">
           <div id="header-top" class="col-12">
             <nav class="nav" aria-label="Top">
-              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to content</a>
+              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to main content</a>
               <a class="nav-link sr-only sr-only-focusable" href="http://asu.edu/accessibility/feedback?a11yref=unity-design-system">Report an accessibility problem</a>
               <a class="nav-link" href="https://asu.edu">ASU Home</a>
               <a class="nav-link" href="https://my.asu.edu">My ASU</a>
@@ -533,7 +533,7 @@ storiesOf('Components/Global Header', module)
         <div class="row">
           <div id="header-top" class="col-12">
             <nav class="nav" aria-label="Top">
-              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to content</a>
+              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to main content</a>
               <a class="nav-link sr-only sr-only-focusable" href="http://asu.edu/accessibility/feedback?a11yref=unity-design-system">Report an accessibility problem</a>
               <a class="nav-link" href="https://asu.edu">ASU Home</a>
               <a class="nav-link" href="https://my.asu.edu">My ASU</a>
@@ -633,7 +633,7 @@ storiesOf('Components/Global Header', module)
         <div class="row">
           <div id="header-top" class="col-12">
             <nav class="nav" aria-label="Top">
-              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to content</a>
+              <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to main content</a>
               <a class="nav-link sr-only sr-only-focusable" href="http://asu.edu/accessibility/feedback?a11yref=unity-design-system">Report an accessibility problem</a>
               <a class="nav-link" href="https://asu.edu">ASU Home</a>
               <a class="nav-link" href="https://my.asu.edu">My ASU</a>

--- a/packages/components-library/src/components/Header/index.js
+++ b/packages/components-library/src/components/Header/index.js
@@ -156,6 +156,8 @@ const Header = ({
       <div onmousedown={killEvent} onclick={onClickCallbackOverride} data-onclick-identifier="no-action" />
       <S.UniversalNav open={mobileOpen} ref={universalRef} {...{ searchOpen }}>
         <S.UniversalNavLinks>
+          <a class="nav-link sr-only sr-only-focusable" href="#skip-to-content">Skip to main content</a>
+          <a class="nav-link sr-only sr-only-focusable" href="http://asu.edu/accessibility/feedback?a11yref=unity-design-system">Report an accessibility problem</a>
           <a href="https://www.asu.edu/">ASU Home</a>
           <a href="https://my.asu.edu/">My ASU</a>
           <a href="https://www.asu.edu/colleges/">Colleges and schools</a>

--- a/packages/components-library/src/components/Header/styles.js
+++ b/packages/components-library/src/components/Header/styles.js
@@ -217,6 +217,10 @@ const UniversalNavLinks = ({ children, ...props }) => {
               text-decoration: underline;
             }
           }
+
+          > a.sr-only-focusable {
+            position: relative;
+          }
         `
       )}
     >


### PR DESCRIPTION
In this PR:
- Standarize skip navigation links on header
- fix position for CSS class `.sr-only-focusable`
- fix header nav-link padding to get the right focus style

@imorale2  this require design review 
**Preview**
![image](https://user-images.githubusercontent.com/7423476/115867965-a563ca80-a433-11eb-93ee-2595f3f32554.png)

![image](https://user-images.githubusercontent.com/7423476/115868042-bca2b800-a433-11eb-81d8-ad8478c15300.png)
