### PR TITLE
style(components-library): uds-485 - fix style for sr-only link  on mobile view

### DIFF
--- a/packages/components-library/src/components/Header/styles.js
+++ b/packages/components-library/src/components/Header/styles.js
@@ -157,6 +157,11 @@ const universalStyles = breakpoint => css`
           :nth-child(even) {
             border-left: 1px solid #d0d0d0;
           }
+
+          &.sr-only {
+            display: none;
+          }
+
         }
       }
 
@@ -214,7 +219,7 @@ const UniversalNavLinks = ({ children, ...props }) => {
             padding-bottom: 0;
             ${focusStyle}
 
-            &:hover{
+            &:hover {
               text-decoration: underline;
             }
           }

--- a/packages/components-library/src/components/Nav/styles.js
+++ b/packages/components-library/src/components/Nav/styles.js
@@ -148,7 +148,7 @@ const navListStyles = breakpoint => css`
       > li {
         margin-right: 0;
 
-        > a {
+        > a, .drop-controls {
           padding: 1rem 2rem 0.5rem;
           justify-content: space-between;
           display: block;


### PR DESCRIPTION
In this PR
- I add the attribute `height: auto` to allow those link with class `.sr-only` to be accommodate properly into the box
Usually, those kind of link are displayed on focus, but on mobile view they are always displayed and in need of the adjustment I added.
- I fix nav menu padding on mobile view

@imorale2 this requires design review

**Preview**

**Bug**
![image](https://user-images.githubusercontent.com/7423476/116562160-d6903f00-a8fa-11eb-8bfc-d9f4b1a032e1.png)

**Fix**
![image](https://user-images.githubusercontent.com/7423476/116669204-338d0300-a996-11eb-9b4f-f1f4804a436a.png)
