### PR TITLE
fix(bootstrap4-theme): ol li type, add decimals

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_list.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_list.scss
@@ -155,15 +155,21 @@ ol.uds-list {
   }
 
   li:before,
-  ol ol li:before,
-  ol ol ol ol li:before {
-    content: counter(listcounter) ' ';
+  ol ol ol li:before,
+  ol ol ol ol ol li:before {
+    content: counter(listcounter) '. ';
     counter-increment: listcounter;
   }
 
   ol li:before,
-  ol ol ol li:before {
-    content: counter(listcounter, lower-alpha) ' ';
+  ol ol ol ol li:before {
+    content: counter(listcounter, lower-alpha) '. ';
+    counter-increment: listcounter;
+  }
+
+  ol ol li:before,
+  ol ol ol ol ol ol li:before {
+    content: counter(listcounter, lower-roman) '. ';
     counter-increment: listcounter;
   }
 


### PR DESCRIPTION
This pull request adds decimals after list items in an ordered list. It also makes every 3rd indention use lower Roman numerals instead of numbers.

Fixes UDS-474