### PR TITLE
fix(component-carousel): fUDS-399 - fix  arrow key down

### DIFF
--- a/packages/component-carousel/src/components/AsuCarousel/index.stories.js
+++ b/packages/component-carousel/src/components/AsuCarousel/index.stories.js
@@ -13,7 +13,7 @@ const myCarouselItems = [
           className="card-img-top"
           src="https://source.unsplash.com/random/800x400?a=1"
           alt="Card image cap"
-         />
+        />
         <div className="card-header">
           <h3 className="card-title">Card One</h3>
         </div>
@@ -40,7 +40,7 @@ const myCarouselItems = [
           className="card-img-top"
           src="https://source.unsplash.com/random/800x400?a=2"
           alt="Card image cap"
-         />
+        />
         <div className="card-header">
           <h3 className="card-title">Card Two</h3>
         </div>
@@ -67,7 +67,7 @@ const myCarouselItems = [
           className="card-img-top"
           src="https://source.unsplash.com/random/800x400?a=3"
           alt="Card image cap"
-         />
+        />
         <div className="card-header">
           <h3 className="card-title">Card Three</h3>
         </div>
@@ -94,7 +94,7 @@ const myCarouselItems = [
           className="card-img-top"
           src="https://source.unsplash.com/random/800x400?a=4"
           alt="Card image cap"
-         />
+        />
         <div className="card-header">
           <h3 className="card-title">Card Four</h3>
         </div>
@@ -121,7 +121,7 @@ const myCarouselItems = [
           className="card-img-top"
           src="https://source.unsplash.com/random/800x400?a=5"
           alt="Card image cap"
-         />
+        />
         <div className="card-header">
           <h3 className="card-title">Card Five</h3>
         </div>

--- a/packages/component-carousel/src/core/components/BaseCarousel/index.js
+++ b/packages/component-carousel/src/core/components/BaseCarousel/index.js
@@ -27,7 +27,7 @@ import { calcualteViewItems } from "./helper/width-calculator";
  * @param {{
  *            perView?: number | string
  *            width?: string
- *            maxWidth: string
+ *            maxWidth?: string
  *            carouselItems: CarouselItem[]
  *            cssClass?: string
  *            CustomNavComponent?: JSX.Element


### PR DESCRIPTION
In  this PR
- move the slider only when it has the focus.
- disable global key down which move any slider present into the page

Hi @imorale2 this require design review 

I was not able to reproduce this issue

> When tabbing through the carousel cards, the active card and the active card button were all successfully placed on screen when they each received the focus. But, when the focus jumped from the last card button to the dot-row, clicking on one of the buttons didn't always advance the carousel to the correct position.
> 
> Tabbing from the last card button to the dot-row, then attempting to click any dot except the last dot scrolls the carousel to the incorrect position.
> Clicking the last dot scrolls the carousel to the last position. At which point all content is aligned again and things work normally.
> 

Instead i was able to fix this issue
> observed that multiple carousels can be advanced simultaneously when clicking the left / right arrows on the keyboard. 
