### PR TITLE
feat(component-carousel): create initTestimonialCarousel launcher

### DIFF
--- a/packages/component-carousel/src/components/index.js
+++ b/packages/component-carousel/src/components/index.js
@@ -2,3 +2,4 @@
 export * from "./AsuCarousel";
 export * from "./ImageCarousel";
 export * from "./ImageGalleryCarousel";
+export * from "./TestimonialCarousel";

--- a/packages/component-carousel/src/core/helpers/component-helper.js
+++ b/packages/component-carousel/src/core/helpers/component-helper.js
@@ -2,6 +2,7 @@
 import { h, hydrate, render } from "preact";
 
 import { AsuCarousel } from "../../components/AsuCarousel";
+import { TestimonialCarousel } from "../../components/TestimonialCarousel";
 
 const HydratePreact = (component, props, target) => {
   return hydrate(h(component, props), target);
@@ -29,4 +30,26 @@ const initCarousel = (props, target = "carouselContainer", hydrate = false) => {
   }
 };
 
-export { HydratePreact, RenderPreact, initCarousel };
+/**
+ * Initialize the TestimonialCarousel.
+ *
+ * @param {object} props - Properties to initialize the carousel with. See the
+ * component definiton src/components/AsuCarousel/index.js for more details.
+ * @param {boolean} hydrate - If true, will run Preact's hydrate function instead of render.
+ * Should only be set to true if the header has been completely rendered server-side.
+ * @param {string} target - The ID of the containing <div> where the header should
+ * be either hydrated or rendered.
+ */
+const initTestimonialCarousel = (
+  props,
+  target = "testimonialCarouselContainer",
+  hydrate = false
+) => {
+  if (hydrate) {
+    HydratePreact(TestimonialCarousel, props, document.getElementById(target));
+  } else {
+    RenderPreact(TestimonialCarousel, props, document.getElementById(target));
+  }
+};
+
+export { HydratePreact, RenderPreact, initCarousel, initTestimonialCarousel };

--- a/packages/component-carousel/src/index.html
+++ b/packages/component-carousel/src/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr"
+  prefix="content: http://purl.org/rss/1.0/modules/content/ dc: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ og: http://ogp.me/ns# rdfs: http://www.w3.org/2000/01/rdf-schema# sioc: http://rdfs.org/sioc/ns# sioct: http://rdfs.org/sioc/types# skos: http://www.w3.org/2004/02/skos/core# xsd: http://www.w3.org/2001/XMLSchema#">
+
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>Test page</title>
+
+
+  <!-- include bundled scripts from Preact packages -->
+  <script src="../dist/vendor.production.js"></script>
+  <script src="../dist/carousel.production.js"></script>
+
+</head>
+
+<body>
+
+  <!-- Provide target divs for two carousels. Must have unique ids. -->
+  <div id="testimonialCarouselContainer"></div>
+
+  <script>
+    var testimonialNoCitation = [
+      {
+        id: 1,
+        quote: {
+          title: "Walt Disney",
+          content:
+            "Laughter is timeless, imagination has no age, dreams are forever.",
+        },
+        imageSource: `https://placeimg.com/300/300/nature`,
+        altText: `Image of Walt Disney`,
+      },
+      {
+        id: 2,
+        quote: {
+          title: "Walt Disney",
+          content: `We keep opening new doors and doing new things,
+      because we’recurious and curiosity keeps leading us down new paths.`,
+        },
+        imageSource: `https://placeimg.com/300/300/nature`,
+        altText: `Image of Walt Disney`,
+      },
+    ];
+
+    //var props = ("Testimonials", testimonialNoCitation);
+    var testimonialItems = { "testimonialItems": testimonialNoCitation };
+
+    // Setup and initialize the testimonial carousel.
+    // No need to provide target ID as carouselContainer is the default.
+    AsuWebcarousel.initTestimonialCarousel(testimonialItems);
+  </script>
+
+
+
+
+
+</body>
+
+</html>

--- a/packages/component-carousel/src/index.js
+++ b/packages/component-carousel/src/index.js
@@ -1,5 +1,10 @@
 // @ts-check
-import { HydratePreact, RenderPreact, initCarousel } from "./core/helpers/component-helper";
+import {
+  HydratePreact,
+  RenderPreact,
+  initCarousel,
+  initTestimonialCarousel,
+} from "./core/helpers/component-helper";
 
 export * from "./components";
-export { HydratePreact, RenderPreact, initCarousel };
+export { HydratePreact, RenderPreact, initCarousel, initTestimonialCarousel };


### PR DESCRIPTION
provide a means for non-component html to launch the testimonial carousel

@mdibenedetto, I was helping Archie from the Webspark 2 team with creating a testimonials carousel (which needed to be in the release  and it didn't look like there was a means to launch it from a plain HTML page, so this adds that ability. I'm not sure if it matches the approach you would take, and would love your feedback. This is just what worked to get the component ready in time.

Going forward, because we need most of our components to be launched from CMSes, let's decide on a consistent best practice for doing that. (We'll need that, too, for the Degrees component. :) )  Your thoughts would be much appreciated.

^ FYI @imorale2 @artem-vasiatkin 