### PR TITLE
fix(bootstrap4-theme): 🐛 add wrapping container to center container f…

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_banners.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_banners.scss
@@ -95,15 +95,6 @@
 }
 
 // Media Queries
-
-@media screen and (min-width: $uds-breakpoint-sm) {
-  .banner {
-    max-width: 1200px;
-    margin: auto;
-  }
-
-}
-
 .banner {
   // Mobile tweaks. 576px
   @media screen and (max-width: $uds-breakpoint-sm) {

--- a/packages/bootstrap4-theme/stories/components/banners/banners.stories.js
+++ b/packages/bootstrap4-theme/stories/components/banners/banners.stories.js
@@ -10,7 +10,7 @@ storiesOf('Components/Banners', module)
 
 .add('Banners, green', () => `
 <div class="banner-green">
-  <div class="banner" role="banner">
+  <div class="banner container" role="banner">
     <div class="banner-icon">
       <span title="Banner" class="fa fa-icon fa-bell"></span>
     </div>
@@ -34,7 +34,7 @@ storiesOf('Components/Banners', module)
 
   .add('Banners, orange', () => `
 <div class="banner-orange">
-  <div class="banner" role="banner">
+  <div class="banner container" role="banner">
     <div class="banner-icon">
       <span title="Banner" class="fa fa-icon fa-bell"></span>
     </div>
@@ -58,7 +58,7 @@ storiesOf('Components/Banners', module)
 
   .add('Banners, blue', () => `
 <div class="banner-blue">
-  <div class="banner" role="banner">
+  <div class="banner container" role="banner">
     <div class="banner-icon">
       <span title="Banner" class="fa fa-icon fa-bell"></span>
     </div>
@@ -82,7 +82,7 @@ storiesOf('Components/Banners', module)
 
   .add('Banners, gray', () => `
 <div class="banner-gray">
-  <div class="banner" role="banner">
+  <div class="banner container" role="banner">
     <div class="banner-icon">
       <span title="Banner" class="fa fa-icon fa-bell"></span>
     </div>
@@ -106,7 +106,7 @@ storiesOf('Components/Banners', module)
 
   .add('Banners, black', () => `
 <div class="banner-black">
-  <div class="banner" role="banner">
+  <div class="banner container" role="banner">
     <div class="banner-icon">
       <span title="Banner" class="fa fa-icon fa-bell"></span>
     </div>


### PR DESCRIPTION
…or banners

changed the notification banners for desktop display so that content is
contained in a div that remains centered. Mobile display remains the
same as before.

https://asudev.jira.com/browse/UDS-532

✅ Closes: 532