### PR TITLE
fix(bootstrap4-theme): 🐛 fix style issues for tabbed panels

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_tabbed-panels.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_tabbed-panels.scss
@@ -81,11 +81,6 @@
     top: 0;
     background: rgba(0, 0, 0, 0);
     left: 0;
-    background: linear-gradient(
-      270deg,
-      rgba(25, 25, 25, 0) 0%,
-      rgba(25, 25, 25, 0.25) 100%
-    );
 
     span.carousel-control-prev-icon {
       margin: 0 42px 0 12px;
@@ -126,11 +121,7 @@
 }
 
 .tab-content {
-  padding: 96px 48px;
-
-  @media screen and (max-width: $uds-breakpoint-md) {
-    padding: 48px 32px;
-  }
+  padding: 32px 0px;
 }
 
 .carousel-control-next-icon {


### PR DESCRIPTION
removed shadow from left side of tabbed panels. Changed padding to match
ux specs, text is now aligned to the left. Spacing below tabs and before
text set to 32px

This commit changes some of the styling @connercms explicitly added so adding as reviewer to make sure I am not breaking anything.

https://asudev.jira.com/browse/UDS-535

✅ Closes: 535