### PR TITLE
fix(bootstrap4-theme): fix spacing between pagination items

### DIFF
--- a/packages/bootstrap4-theme/src/scss/bootstrap-asu-extends.scss
+++ b/packages/bootstrap4-theme/src/scss/bootstrap-asu-extends.scss
@@ -33,3 +33,4 @@
 @import 'extends/display-list';
 @import 'extends/anchor-menu';
 @import 'extends/card-arrangements';
+@import 'extends/pagination';

--- a/packages/bootstrap4-theme/src/scss/extends/_pagination.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_pagination.scss
@@ -1,0 +1,3 @@
+.page-item {
+  margin: 0 $uds-size-spacing-1; // .5rem = 8px margin on each side, or 16px between each page-item
+}

--- a/packages/bootstrap4-theme/stories/components/pagination/pagination.stories.js
+++ b/packages/bootstrap4-theme/stories/components/pagination/pagination.stories.js
@@ -1,4 +1,3 @@
-import { document, console } from 'global';
 import { storiesOf } from '@storybook/html';
 
 storiesOf('Components/Pagination', module)


### PR DESCRIPTION
Added .5rem (8px) horizontal margin to page-items, which equates to 16px spacing between them as
required by the XD docs