### PR TITLE
fix(bootstrap4-theme): 🐛 fix the line height height issue for h1s on …

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_headings.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_headings.scss
@@ -35,6 +35,7 @@ p:last-of-type + h6 {
 h1 {
   font-size: $heading-one-font-size;
   letter-spacing: $heading-one-letter-spacing;
+  line-height: normal;
 
   &.article {
     font-size: $heading-one-article-font-size;


### PR DESCRIPTION
Safari h1 tags don't have the same line-height as in other browsers, so we can set it to achieve consistency. 