### PR TITLE
fix(components-library): display underline on active menu item in mobile view

### DIFF
--- a/packages/components-library/src/components/Nav/styles.js
+++ b/packages/components-library/src/components/Nav/styles.js
@@ -46,8 +46,6 @@ const navListStyles = breakpoint => css`
         }
       }
 
-
-
       > a {
         :after {
           transition: 0.5s cubic-bezier(0.19, 1, 0.19, 1);
@@ -388,6 +386,13 @@ const dropControlsStyles = breakpoint => css`
 
     > a {
       color: #191919;
+    }
+
+    :hover,
+    &.nav-item-selected {
+      :after {
+        width: 100%;
+      }
     }
 
     > svg {


### PR DESCRIPTION
Gold underline on active menu item wasn't being displayed on mobile view. Added selector to display
underline.