### PR TITLE
fix(bootstrap4-theme): 🐛 changing breakcrumbs to not need specific cl…

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_breadcrumb.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_breadcrumb.scss
@@ -1,20 +1,5 @@
-ol.breadcrumb {
-  .breadcrumb-item {
-    a {
-      text-decoration: none;
-    }
-    // Get spacing around the / dividers right.
-    //padding-left: $uds-component-breadcrumb-ol-breadcrumb-breadcrumb-item-padding-left-px;
-    &:first-of-type {
-      //padding-left: $uds-component-breadcrumb-ol-breadcrumb-breadcrumb-item-first-of-type-padding-left;
-      // Reset first item number from list component styles.
-      &:before {
-        content: '';
-      }
-    }
-  }
-  .breadcrumb-item + .breadcrumb-item:before {
-    //padding-left: $uds-component-breadcrumb-ol-breadcrumb-breadcrumb-item-plus-breadcrumb-item-before-padding-left;
-    //padding-right: $uds-component-breadcrumb-ol-breadcrumb-breadcrumb-item-plus-breadcrumb-item-before-padding-right;
+.breadcrumb.bg-gray-7 {
+  li.active {
+    color: $uds-color-base-gray-1;
   }
 }

--- a/packages/bootstrap4-theme/stories/components/breadcrumb/breadcrumb.stories.js
+++ b/packages/bootstrap4-theme/stories/components/breadcrumb/breadcrumb.stories.js
@@ -1,49 +1,41 @@
 export default { title: 'Components/Breadcrumbs' };
 
 export const breadcrumbsAgainstWhiteBackground = () => `
-  <div class="bg-white">
-    <nav aria-label="breadcrumbs">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Home</a></li>
-        <li class="breadcrumb-item"><a href="#">Second Nav Item</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Current Page</li>
-      </ol>
-    </nav>
-  </div>
+  <nav aria-label="breadcrumbs">
+    <ol class="breadcrumb bg-white">
+      <li class="breadcrumb-item"><a href="#">Home</a></li>
+      <li class="breadcrumb-item"><a href="#">Second Nav Item</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Current Page</li>
+    </ol>
+  </nav>
 `;
 
 export const breadcrumbsAgainstGray1Background = () => `
-  <div class="bg-gray-1">
-    <nav aria-label="breadcrumbs">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Home</a></li>
-        <li class="breadcrumb-item"><a href="#">Second Nav Item</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Current Page</li>
-      </ol>
-    </nav>
-  </div>
+  <nav aria-label="breadcrumbs">
+    <ol class="breadcrumb bg-gray-1">
+      <li class="breadcrumb-item"><a href="#">Home</a></li>
+      <li class="breadcrumb-item"><a href="#">Second Nav Item</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Current Page</li>
+    </ol>
+  </nav>
 `;
 
 export const breadcrumbsAgainstGray2Background = () => `
-  <div class="bg-gray-2">
-    <nav aria-label="breadcrumbs">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Home</a></li>
-        <li class="breadcrumb-item"><a href="#">Second Nav Item</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Current Page</li>
-      </ol>
-    </nav>
-  </div>
+  <nav aria-label="breadcrumbs">
+    <ol class="breadcrumb bg-gray-2">
+      <li class="breadcrumb-item"><a href="#">Home</a></li>
+      <li class="breadcrumb-item"><a href="#">Second Nav Item</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Current Page</li>
+    </ol>
+  </nav>
 `;
 
 export const breadcrumbsAgainstGray7Background = () => `
-  <div class="bg-gray-7">
-    <nav aria-label="breadcrumbs">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Home</a></li>
-        <li class="breadcrumb-item"><a href="#">Second Nav Item</a></li>
-        <li class="breadcrumb-item active text-gray-1" aria-current="page">Current Page</li>
-      </ol>
-    </nav>
-  </div>
+  <nav aria-label="breadcrumbs">
+    <ol class="breadcrumb bg-gray-7">
+      <li class="breadcrumb-item"><a href="#">Home</a></li>
+      <li class="breadcrumb-item"><a href="#">Second Nav Item</a></li>
+      <li class="breadcrumb-item active" aria-current="page">Current Page</li>
+    </ol>
+  </nav>
 `;


### PR DESCRIPTION
The current structure of the breadcrumbs was causing trouble during integration because the bg-gray-7 example needed an extra class on the active elements. I've re-factored this in conversation with @deptant to make it easier.