### PR TITLE
fix(components-core): remove postinstall build script

### DIFF
--- a/packages/components-core/package.json
+++ b/packages/components-core/package.json
@@ -16,8 +16,7 @@
     "build": "webpack -c webpack/webpack.prod.js",
     "build:stats": "webpack -c webpack/webpack.prod.js --profile --json=compilation-stats.json",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "postinstall": "yarn build"
+    "build-storybook": "build-storybook"
   },
   "bugs": {
     "url": "https://github.com/ASU/asu-unity-stack/issues"


### PR DESCRIPTION
Resolves issue where installing components-core in a bare package would fail due to missing build environ packages.

