### PR TITLE
fix(bootstrap4-theme): card arrangements

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_card-arrangements.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_card-arrangements.scss
@@ -1,7 +1,3 @@
-.container {
-  padding: 2.5rem;
-}
-
 .uds-card-arrangement {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
remove global container style that was giving padding to all containers