### PR TITLE
fix(components-library): no-wrap menu items

### DIFF
--- a/packages/components-library/src/components/Nav/styles.js
+++ b/packages/components-library/src/components/Nav/styles.js
@@ -122,6 +122,7 @@ const navListStyles = breakpoint => css`
         display: block;
         padding: 0.5rem 0.75rem;
         color: #191919;
+        white-space: nowrap;
 
         svg.fa-chevron-down {
           transition: 0.5s cubic-bezier(0.19, 1, 0.19, 1);


### PR DESCRIPTION
Add `white-space: nowrap` to the components-library header's menu links. For https://asudev.jira.com/browse/WS2-428 "Global Header navigation menu link text wraps to multiple lines"

@imorale2 You can test this by using the controls under the header component in Storybook to edit the menu titles and make them really long to induce wrapping... instead, they should just grow and push off the side of the page, as described in the solution on the ticket involving overflow (which didn't work out, but this achieves the same concept).