### PR TITLE
fix(bootstrap4-theme): Add explicit rgba declaration to variable.

### DIFF
--- a/packages/bootstrap4-theme/src/scss/variables/_modals.scss
+++ b/packages/bootstrap4-theme/src/scss/variables/_modals.scss
@@ -1,1 +1,1 @@
-$uds-modal-overlay-background-color: rgb(25, 25, 25, .75);
+$uds-modal-overlay-background-color: rgba(25, 25, 25, .75);


### PR DESCRIPTION
Declaring `rgb()` with four fields in the parentheses doesn't break the Storybook build process, but is incorrect. Adding the explicit `rgba` declaration solves a build process problem when using the code outside of Storybook.