### PR TITLE
fix(components-core): fix testimonial eslint error

### DIFF
--- a/packages/components-core/src/components/Testimonial/index.stories.js
+++ b/packages/components-core/src/components/Testimonial/index.stories.js
@@ -8,19 +8,20 @@ export default {
   component: Testimonial,
   decorators: [
     (Story, context) => {
-      const { backgroundColor, ...props } = context.args;
+      // Extract wrapper background color from args, it doesn't need passed down to component
+      const { wrapperBackgroundColor, ...args } = context.args;
       return (
         <div
-          className={`p-6 ${backgroundColor}`}
+          className={`p-6 ${wrapperBackgroundColor}`}
           style={{ width: "fit-content" }}
         >
-          <Story {...props} />
+          {Story({ args })}
         </div>
       );
     },
   ],
   argTypes: {
-    backgroundColor: {
+    wrapperBackgroundColor: {
       defaultValue: "",
       options: ["", "bg-gray-2", "bg-gray-7"],
       control: {


### PR DESCRIPTION
Fixed no spread props eslint error on testimonial. Changed prop name from backgroundColor to wrapperBackground color to avoid possible naming conflict, if component were to ever use backgroundColor as an internal prop. 