### PR TITLE
refactor(bootstrap4-theme): 💡 change interface to grid links

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_grid-links.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_grid-links.scss
@@ -54,56 +54,23 @@
 2. Desktop modifiers
 --------------------------------------------------------------*/
 
-@mixin two-col {
-  grid-template-columns: repeat(2, 1fr);
-}
-
-@mixin three-col {
-  grid-template-columns: repeat(3, 1fr);
-}
-
-@mixin four-col {
-  grid-template-columns: repeat(4, 1fr);
-}
-
 @include media-breakpoint-up(md) {
-  .uds-grid-links.mobile-at-md.two-columns {
-    @include two-col;
-  }
-
-  .uds-grid-links.mobile-at-md.three-columns {
-    @include three-col;
-  }
-
-  .uds-grid-links.mobile-at-md.four-columns {
-    @include four-col;
+  .uds-grid-links.two-columns,
+  .uds-grid-links.three-columns,
+  .uds-grid-links.four-columns {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @include media-breakpoint-up(lg) {
-  .uds-grid-links.mobile-at-lg.two-columns {
-    @include two-col;
-  }
-
-  .uds-grid-links.mobile-at-lg.three-columns {
-    @include three-col;
-  }
-
-  .uds-grid-links.mobile-at-lg.four-columns {
-    @include four-col;
+  .uds-grid-links.three-columns,
+  .uds-grid-links.four-columns {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 
 @include media-breakpoint-up(xl) {
-  .uds-grid-links.mobile-at-xl.two-columns {
-    @include two-col;
-  }
-
-  .uds-grid-links.mobile-at-xl.three-columns {
-    @include three-col;
-  }
-
-  .uds-grid-links.mobile-at-xl.four-columns {
-    @include four-col;
+  .uds-grid-links.four-columns {
+    grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/packages/bootstrap4-theme/stories/components/grid-links/grid-links.stories.js
+++ b/packages/bootstrap4-theme/stories/components/grid-links/grid-links.stories.js
@@ -4,11 +4,11 @@ export const BackgroundWhite = () => `
 <div class="container">
   <div class="row">
     <div class="col-md-12 mb-4">
-      <h3><span class="highlight-gold">Two columns.</span> Mobile at lg breakpoint.</h3>
+      <h3><span class="highlight-gold">Two columns.</span></h3>
     </div>
     <div class="col-md-12">
 
-      <div class="uds-grid-links two-columns mobile-at-md">
+      <div class="uds-grid-links two-columns">
         <a href="#"><span class="fa fa-fw fa-university"></span>First-year student</a>
         <a href="#"><span class="fa fa-fw fa-desktop"></span>Online student</a>
         <a href="#"><span class="fa fa-fw fa-lightbulb"></span>Transfer student</a>
@@ -25,16 +25,16 @@ export const BackgroundWhite = () => `
 `;
 
 export const BackgroundGray1 = () => `
-<section class="bg-gray-1 p-8">
+<section class="bg-gray-1">
   <div class="container">
     <div class="row">
       <div class="col-md-12 mb-4">
-        <h3><span class="highlight-gold">Three columns.</span> Mobile at md breakpoint.</h3>
+        <h3><span class="highlight-gold">Three columns.</span></h3>
       </div>
 
       <div class="col-md-12">
 
-        <div class="uds-grid-links three-columns mobile-at-md">
+        <div class="uds-grid-links three-columns">
           <a href="#"><span class="fa fa-fw fa-university"></span>First-year student</a>
           <a href="#"><span class="fa fa-fw fa-desktop"></span>Online student</a>
           <a href="#"><span class="fa fa-fw fa-lightbulb"></span>Transfer student</a>
@@ -52,16 +52,16 @@ export const BackgroundGray1 = () => `
 `;
 
 export const GoldText = () => `
-<section class="bg-gray-7 p-8">
+<section class="bg-gray-7">
   <div class="container">
     <div class="row">
       <div class="col-md-12 mb-4">
-        <h3 class="text-white">Three columns. Mobile at lg breakpoint.</h3>
+        <h3 class="text-white">Three columns.</h3>
       </div>
 
       <div class="col-md-12">
 
-        <div class="uds-grid-links three-columns mobile-at-lg text-gold">
+        <div class="uds-grid-links three-columns text-gold">
           <a href="#">First-year student</a>
           <a href="#">Online student</a>
           <a href="#">Transfer student</a>
@@ -79,16 +79,16 @@ export const GoldText = () => `
 `;
 
 export const WhiteText = () => `
-<section class="bg-gray-7 p-8">
+<section class="bg-gray-7">
   <div class="container">
     <div class="row">
       <div class="col-md-12 mb-4">
-        <h3 class="text-white">Four columns. Mobile at xl breakpoint.</h3>
+        <h3 class="text-white">Four columns.</h3>
       </div>
 
       <div class="col-md-12">
 
-        <div class="uds-grid-links four-columns mobile-at-xl text-white">
+        <div class="uds-grid-links four-columns text-white">
           <a href="#"><span class="fa fa-fw fa-university"></span>First-year student</a>
           <a href="#"><span class="fa fa-fw fa-desktop"></span>Online student</a>
           <a href="#"><span class="fa fa-fw fa-lightbulb"></span>Transfer student</a>


### PR DESCRIPTION
The use of mobile-overwrite classes was making the implementation in the
CMS more difficult. This change requires content-editors to only specify
the number of columns they would ideally like, which is then overwritten
sensibly as the screen gets smaller.