### PR TITLE
fix(bootstrap4-theme): 🐛 fix width when component is within a bootstrap row

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_card-and-image.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_card-and-image.scss
@@ -1,10 +1,12 @@
 .uds-card-and-image {
   background-position: top;
+  background-size: cover;
   display: flex;
   flex-direction: row;
   height: 466px;
   max-width: 1920px;
   padding: 48px 96px;
+  width: 100%;
 
   &-right {
     flex-direction: row-reverse;


### PR DESCRIPTION
@duarte-daniela is blocked by a small bug here whereby this component doesn't display properly when contained within a bootstrap row. It needs to take full width and the background should react appropriately.