### PR TITLE
fix(component-carousel): 🐛 UDS-671: border bottom not displaying on large screens

### DIFF
--- a/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
+++ b/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
@@ -81,8 +81,6 @@ $uds-color-brand-gold: #ffc627; // ASU Gold brand color
   $sm: $glide-modifier-separator;
 
   &#{$se}slides {
-    margin-bottom: 0; // Avoid gap, for gradient,
-
    [data-image-auto-size="true"] & .glide__slide {
       height: auto;
       position: relative;


### PR DESCRIPTION
This causes the `border-bottom` of the card to not display on large screens within the image carousel with content, as can be seen in the image below or in the, currently available, CMS page [here](https://rc2-dept-webspark-2.ws.asu.edu/image-carousel). 

![Screenshot 2021-06-21 at 16 13 12](https://user-images.githubusercontent.com/8904644/122786045-cd44a280-d2ab-11eb-97cb-3d3a180a7818.png)

The comment suggests that it was originally a problem with the gradient, but I couldn't reproduce this, maybe @mlsamuelson has more information.


✅ Closes: UDS-671