### PR TITLE
fix(component-carousel): 🐛 UDS-670: mage gallery images change in size, incorrectly

### DIFF
--- a/packages/component-carousel/src/components/ImageGalleryCarousel/index.js
+++ b/packages/component-carousel/src/components/ImageGalleryCarousel/index.js
@@ -171,6 +171,7 @@ const ImageGalleryCarousel = ({
       ariaLabelledBy={hasContent ? "caption" : null}
       isFullWidth
       imageAutoSize={imageAutoSize}
+      hasPeek={false}
       // @ts-ignore
       CustomNavComponent={({ instanceName }) => (
         <CustomNavComponent

--- a/packages/component-carousel/src/components/ImageGalleryCarousel/index.stories.js
+++ b/packages/component-carousel/src/components/ImageGalleryCarousel/index.stories.js
@@ -8,7 +8,7 @@ import { ImageGalleryCarousel } from ".";
 const myCarouselItems = [];
 
 const imageFormats = [
-  "500x400",
+  "700x400",
   "300x400",
   "400x400",
   "200x200",

--- a/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.setup.js
+++ b/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.setup.js
@@ -46,20 +46,22 @@ function computeItemPerView(perView) {
  *
  * @returns {Glide.Options}
  */
-function buildConfig(perView = 1, isFullWidth) {
+function buildConfig(perView = 1, isFullWidth, hasPeek = true) {
   // Set a perView value for each breakpoint so we adapt down appropriately.
   const { perViewSm, perViewMd, perViewLg } = computeItemPerView(perView);
 
-  const smallPeeek = { before: 0, after: 62 };
-  const largePeek = { before: 124, after: 124 };
-
   // Set GlideJS config options, per https://glidejs.com/docs/options/
+
+  const gap = hasPeek ? 24 : 0;
+  const smallPeek = hasPeek ? { before: 0, after: 62 } : 0;
+  const largePeek = hasPeek ? { before: 124, after: 124 } : 0;
+
   return {
     type: "slider", // No wrap-around.
     focusAt: 0,
     bound: true, // Only if type slider with focusAt 0
     rewind: false, // Only if type slider
-    gap: 24, // Space between slides... may be impacted by viewport size.
+    gap, // Space between slides... may be impacted by viewport size.
     // `keyboard` Left/Right arrow key support for slides - true is default.
     // Is not fully Accessible, on keydown allcarousels move simultaneously
     // A custome keyboard handler is implemented
@@ -78,7 +80,7 @@ function buildConfig(perView = 1, isFullWidth) {
           576: {
             // BS4 sm
             perView: perViewSm,
-            peek: smallPeeek,
+            peek: smallPeek,
           },
           768: {
             // BS4 md
@@ -160,6 +162,7 @@ function setNavButtonGradient(gliderElement, currentIndex, buttonCount) {
  *  buttonCount: number
  *  isFullWidth?: boolean
  *  onItemClick?: (index: number) =>  void
+ *  hasPeek?: boolean
  * }} props
  *
  * @returns {Glide.Static}
@@ -170,9 +173,9 @@ function setupCaroarousel({
   buttonCount,
   isFullWidth = false,
   onItemClick,
+  hasPeek = true,
 }) {
-  const sliderConfig = buildConfig(perView, isFullWidth);
-
+  const sliderConfig = buildConfig(perView, isFullWidth, hasPeek);
   // Load up a new glideJS slider, but don't mount until we have event
   // listener (https://glidejs.com/docs/events/) handlers defined and configs
   // all mustered.

--- a/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
+++ b/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
@@ -211,12 +211,27 @@ $uds-color-brand-gold: #ffc627; // ASU Gold brand color
     gap: 0;
     overflow: hidden;
 
-    & li.glide__slide {
-      display: list-item;
-    }
-
     .glide__track {
       border: $border-element;
+
+      .#{$glide-class}#{$se}slides {
+        & li.glide__slide {
+          display: list-item;
+        }
+        margin-bottom: 0; // Avoid gap, for gradient,
+        height: 100%;
+        .glide__slide {
+          height: 100%;
+
+          & > div.uds-img {
+            height: 100%;
+            img {
+              object-fit: contain;
+              border: none;
+            }
+          }
+        }
+      }
     }
 
     .image-gallery-action-area {

--- a/packages/component-carousel/src/core/components/BaseCarousel/index.js
+++ b/packages/component-carousel/src/core/components/BaseCarousel/index.js
@@ -37,6 +37,7 @@ import { calcualteViewItems } from "./helper/width-calculator";
  *            hasPositionIndicators?: boolean
  *            removeSideBackground?: boolean
  *            imageAutoSize?: boolean
+ *            hasPeek?: boolean
  *          }} props
  * @returns
  */
@@ -55,6 +56,7 @@ const BaseCarousel = ({
   hasPositionIndicators = true,
   imageAutoSize = true,
   onItemClick = () => null,
+  hasPeek = true,
 }) => {
   // Only prop for the slider configs we expose is perView. Everything else is
   // considered locked down for Web Standards 2.
@@ -83,8 +85,9 @@ const BaseCarousel = ({
       buttonCount,
       isFullWidth,
       onItemClick,
+      hasPeek,
     });
-  }, [instanceName, perView, buttonCount, isFullWidth, onItemClick]);
+  }, [instanceName, perView, buttonCount, isFullWidth, onItemClick, hasPeek]);
 
   return (
     <div
@@ -128,6 +131,7 @@ BaseCarousel.propTypes = {
   hasNavButtons: PropTypes.bool,
   hasPositionIndicators: PropTypes.bool,
   imageAutoSize: PropTypes.bool,
+  hasPeek: PropTypes.bool,
 };
 
 export { BaseCarousel, calcualteViewItems };


### PR DESCRIPTION
In the PR:

- I've surfaced 'hasPeek' as an option that can be set when creating carousels. This defaults to true, which I think is most in-line with current behaviour. The image gallery overwrites this to be false, which is what we want.
- New CSS specific to the image gallery will control images correctly.

Definitely appreciate @mdibenedetto's thoughts here, happy to change if you think there's a better way :) 