### PR TITLE
fix(component-carousel): 🐛 fix testimonial carousels with new peek config

### DIFF
--- a/packages/component-carousel/src/components/TestimonialCarousel/index.js
+++ b/packages/component-carousel/src/components/TestimonialCarousel/index.js
@@ -87,6 +87,7 @@ const TestimonialCarousel = ({
       hasNavButtons={hasNavButtons}
       hasPositionIndicators={hasPositionIndicators}
       imageAutoSize={imageAutoSize}
+      hasPeek={false}
     />
   );
 };


### PR DESCRIPTION
A [recent change](https://github.com/ASU/asu-unity-stack/pull/331) to carousels made `hasPeek` a config option that should be passed to `BaseCarousel` and defaults to true. I never updated `TestimonialCarousel` to overwrite this as false. 