### PR TITLE
fix(bootstrap4-theme): 🐛 fix donut chart z-index issue

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_charts-and-graphs.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_charts-and-graphs.scss
@@ -37,5 +37,4 @@ canvas {
   width: 100%;
   height: auto;
   position: relative;
-  z-index: 0;
 }


### PR DESCRIPTION
Donut charts have a z-index of -1, causing them to disappear behind the new section backgrounds being added in Drupal. @connercms if there's a reason this needs to stay just let me know and I can rework it. 