### PR TITLE
feat(bootstrap4-theme): 🎸 limit the max-width of p tags as per uds-699

### DIFF
--- a/packages/bootstrap4-theme/src/scss/variables/_typography.scss
+++ b/packages/bootstrap4-theme/src/scss/variables/_typography.scss
@@ -58,3 +58,6 @@ strong {
   font-weight: $uds-font-weight-bold !important;
 }
 
+p {
+  max-width: 700px;
+}


### PR DESCRIPTION
This change is obviously incredibly broad in scope, but that's what's needed [for the issue](https://asudev.jira.com/browse/UDS-699). I spent a bit of time testing various components and it doesn't seem to break anything, but it's tough to anticipate the full ramifications of integrating it into the CMS. 

If we want to instead scope this to various different components just let me know. 