### PR TITLE
fix(app-rfi): avoid toISOString() date conversion failures

### DIFF
--- a/packages/app-rfi/src/components/utils/submission-helpers.js
+++ b/packages/app-rfi/src/components/utils/submission-helpers.js
@@ -33,11 +33,20 @@ export function submissionFormFieldPrep(payload) {
   // artifact. Remove.
   delete output.Email;
 
-  // Can't transform the date to iso value during validation as it breaks type
-  // checking in Yup, so doing it here.
-  output.BirthDate = output.BirthDate
-    ? new Date(output.BirthDate).toISOString()
-    : undefined;
+  // Can't transform the BirthDate to iso value during validation as it breaks
+  // type checking in Yup, so doing it here. Also... Yup.date() lets dates
+  // without divider characters through but toISOString() then chokes,
+  // so in those cases, since it is an optional field, we drop the date from
+  // the payload, considering it bad data. The regex test ensures there's 2
+  // of / or - or . characters in the string. They can be mixed.
+  if (new RegExp(/[.|/|-].{2}/).test(output.BirthDate)) {
+    output.BirthDate = output.BirthDate
+      ? new Date(output.BirthDate).toISOString()
+      : undefined;
+  } else {
+    // Is invalid date in the eyes of toISOString(), so drop.
+    output.BirthDate = undefined;
+  }
 
   return output;
 }


### PR DESCRIPTION
ERFI-80

yup .date() validation gives us a lot in the way of validation logic on dates, however it allows through numeric strings that look like dates but don't have any separator characters (/ or - or .). That, unfortunately leads to issues with the toISOString() conversion we do on the date string when preparing the payload for submit. That handles everything we get that passes through the date validation gracefully except these "seperator-less" dates.

I went in circles for a bit attempting to check the input in the yup validation, but didn't have any luck with the methods available to the date() type in yup.  I couldn't do string type validation on date(), and didnt 'have any luck with doing transformations in the validation chain.

I attempted for a while to switch over to treating BirthDate as a .string() type, which opened up all sorts of regex opportunities, but then also put the burden on us to implement all the date check logic, and the regex date validation rabbit hole is a deep one, and in the end I couldn't find an approach I liked for this, including additional date validation libraries.

So pulled back from that, and am implementing a check on the date value in the payload preparation step, checking to see if we have two separators in the date string with a regex (it's only coerced from a string in the Yup validation). If we lack those, we treat the value as bad data and discard it. The date field is optional, so we do a best effort which will catch 95% of cases on the frontend validation, and for those values that get through that just won't work, we drop it.  All other options looked to add more complexity than I wanted to throw at this edge case, for optional data.