### PR TITLE
fix(bootstrap4-theme): card and image: card header padding

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_card-and-image.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_card-and-image.scss
@@ -23,6 +23,9 @@
 
   &-container {
     max-width: 384px;
+    .card .card-header {
+      padding-bottom: $uds-size-spacing-2 !important;
+    }
     @media screen and (max-width: $uds-breakpoint-sm) {
       width: 100%;
     }


### PR DESCRIPTION
This pr adds styles to the card and image card header component to override `misc.scss` styles applied on the cms. Taks: https://asudev.jira.com/browse/WS2-738