### PR TITLE
feat(app-degree-pages): add page level filters:collegeAcadOrg and departmentCode

### DIFF
--- a/packages/app-degree-pages/examples/listing-page.html
+++ b/packages/app-degree-pages/examples/listing-page.html
@@ -49,8 +49,8 @@
         init: "false", // "true" | "false"Î
         program: "undergrad", // graduate | undergrad
         cert: "false", // "true" | "false"
-        // CollegeAcadOrg: null, //  OPTIONAL: example values: CLW, CTB, CTE
-        // DepartmentCode: null, //  OPTIONAL: example values: CMANAGE, CHUMARTCLT, CHL
+        // collegeAcadOrg: "CGF", // OPTIONAL example values: CLW, CTB, CTE
+        // departmentCode: "CSFIS", // OPTIONAL example values: CMANAGE, CHUMARTCLT, CHL
       };
 
       // those links are just examples

--- a/packages/app-degree-pages/src/components/ListingPage/components/Filters/index.js
+++ b/packages/app-degree-pages/src/components/ListingPage/components/Filters/index.js
@@ -13,9 +13,11 @@ import { Section, ButtonLink } from "./index.style";
 
 /**
  *  @typedef  {{
- *    locations?: string [],
- *    asuLocals?: string [],
- *    acceleratedConcurrent: "acceleratedConcurrent" | "concurrentDegrees" | "all"
+ *    collegeAcadOrg?: string
+ *    departmentCode?: string
+ *    locations?: string []
+ *    asuLocals?: string []
+ *    acceleratedConcurrent?: "acceleratedConcurrent" | "concurrentDegrees" | "all"
  * }} FiltersState
  */
 

--- a/packages/app-degree-pages/src/components/ListingPage/index.stories.js
+++ b/packages/app-degree-pages/src/components/ListingPage/index.stories.js
@@ -53,8 +53,8 @@ const dataSource = {
   // init: "false",  // OPTIONAL "true" | "false"
   program: "graduate", // graduate | undergrad
   cert: "true", // "true" | "false"
-  // CollegeAcadOrg: null, // OPTIONAL example values: CLW, CTB, CTE
-  // DepartmentCode: null, // OPTIONAL example values: CMANAGE, CHUMARTCLT, CHL
+  // collegeAcadOrg: "CGF", // OPTIONAL example values: CLW, CTB, CTE
+  // departmentCode: "CSFIS", // OPTIONAL example values: CMANAGE, CHUMARTCLT, CHL
 };
 
 /**
@@ -105,8 +105,8 @@ DefaultWithCollegeAcadOrgAndDepartmentCode.args.programList = {
   dataSource: {
     // @ts-ignore
     ...Default.args.programList.dataSource,
-    CollegeAcadOrg: "CTB",
-    DepartmentCode: "CMANAGE",
+    collegeAcadOrg: "CGF",
+    departmentCode: "CSFIS",
   },
 };
 

--- a/packages/app-degree-pages/src/core/constants/web-api-constants.js
+++ b/packages/app-degree-pages/src/core/constants/web-api-constants.js
@@ -8,6 +8,7 @@ const listingPageDefaultDataSource = {
   method: "findAllDegrees",
   init: "false",
   fields:
+    "CollegeAcadOrg,DepartmentCode," +
     "Descr100,Institution,AcadPlan," +
     "Degree,DegreeDescr,DegreeDescrlong," +
     "concurrentDegreeMajorMaps,managedOnlineCampus,onlineMajorMapURL," +

--- a/packages/app-degree-pages/src/core/hooks/index.js
+++ b/packages/app-degree-pages/src/core/hooks/index.js
@@ -1,0 +1,2 @@
+export * from "./use-fetch";
+export * from "./use-logger";

--- a/packages/app-degree-pages/src/core/hooks/use-logger.js
+++ b/packages/app-degree-pages/src/core/hooks/use-logger.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-console */
+// @ts-check
+
+import { useEffect } from "react";
+
+import { isDebugActive } from "../utils/dev-tools-utils";
+
+/**
+ *
+ * @param {{
+ * dataSource: import("../models/listing-page-types").ProgramListDataSource
+ * tableView: Object []
+ * programs: Object []
+ * stateFilters: import("src").FiltersState
+ * }} props
+ */
+const useListingPageLogger = ({
+  dataSource,
+  tableView = [],
+  programs,
+  stateFilters,
+}) => {
+  const { collegeAcadOrg, departmentCode } = dataSource;
+
+  useEffect(() => {
+    if (!programs || !isDebugActive()) return;
+
+    const sharedStyle =
+      "background:#eee; -webkit-text-stroke: 1px black; color: tomato; padding-left: 0.5rem;";
+    const titleStyle = "font-size:30px;";
+    const titleStyle2 = "font-size:24px;";
+    const bodyStyle = "font-size: 18px; margin-left: 0.5rem;";
+    console.group("<< ASU Degree Page >>");
+    console.log("%c🏫 Listing Page Programs 📚", sharedStyle + titleStyle);
+    console.log(
+      `%cTotal programs found: ${programs.length}`,
+      sharedStyle + bodyStyle
+    );
+    console.log(`%cPrograms found`, sharedStyle + bodyStyle);
+    console.log(programs);
+    console.log(
+      `%cTotal programs loaded: ${tableView.length}`,
+      sharedStyle + bodyStyle
+    );
+    console.log(`%cPrograms loaded`, sharedStyle + bodyStyle);
+    console.log(tableView);
+
+    console.log(`%cPage Filters`, sharedStyle + titleStyle2);
+    console.log(
+      `%c- collegeAcadOrg:${collegeAcadOrg}`,
+      sharedStyle + bodyStyle
+    );
+    console.log(
+      `%c- departmentCode:${departmentCode}`,
+      sharedStyle + bodyStyle
+    );
+
+    console.log(`%cSearch Filters`, sharedStyle + titleStyle2);
+    console.log(stateFilters);
+
+    console.groupEnd();
+  });
+};
+
+export { useListingPageLogger };

--- a/packages/app-degree-pages/src/core/models/listing-page-types.js
+++ b/packages/app-degree-pages/src/core/models/listing-page-types.js
@@ -35,8 +35,8 @@
  *
  * @typedef {{
  *    program?: string
- *    CollegeAcadOrg?: string
- *    DepartmentCode?: string
+ *    collegeAcadOrg?: string
+ *    departmentCode?: string
  * } & AppDataSource } ProgramListDataSource
  *
  * @typedef {{
@@ -77,7 +77,7 @@
  * }} ColumSettings
  *
  * @typedef {{
- *    dataSource: ProgramListDataSource | string
+ *    dataSource: ProgramListDataSource
  *    columns?: GridColumn[]
  *    settings?: ColumSettings
  * }} GridListProps

--- a/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
@@ -68,6 +68,10 @@ function degreeDataPropResolverService(row = {}) {
     getChangeMajor: () => row["ChangeMajor"],
     getAsuCareerOpportunity: () => row["AsuCareerOpp"],
     getGlobalExp: () => row["globalExp"],
+    /** @return {string} */
+    getCollegeAcadOrg: () => row["CollegeAcadOrg"],
+    /** @return {string} */
+    getDepartmentCode: () => row["DepartmentCode"],
   };
 }
 

--- a/packages/app-degree-pages/src/core/utils/dev-tools-utils.js
+++ b/packages/app-degree-pages/src/core/utils/dev-tools-utils.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-underscore-dangle */
+// @ts-check
+const KEY = "AsuDevTools";
+const devTools = {
+  isDebug: false,
+};
+
+function isDebugActive() {
+  const settings = JSON.parse(localStorage.getItem(KEY));
+  return settings?.isDebug;
+}
+
+// @ts-ignore
+window.__AsuDevTools = {
+  enableDebug(isDebug) {
+    const settings = JSON.stringify({
+      ...devTools,
+      isDebug,
+    });
+    localStorage.setItem(KEY, settings);
+  },
+};
+
+export { isDebugActive };

--- a/packages/app-degree-pages/src/core/utils/index.js
+++ b/packages/app-degree-pages/src/core/utils/index.js
@@ -8,3 +8,4 @@ export * from "./jsx-utils";
 export * from "./id-generator";
 export * from "./string-utils";
 export * from "./script-utils";
+export * from "./dev-tools-utils";


### PR DESCRIPTION
In this PR:

- I fix the page level filters **collegeAcadOrg** and **departmentCode** which are provided by the configurations props
- I adjust the spelling of **collegeAcadOrg** and **departmentCode** to be camel case @duarte-daniela you may need to update the CMS about the above mentioned spelling

![Screenshot 2021-07-23 at 16 40 19](https://user-images.githubusercontent.com/7423476/126806891-7fc8ff2e-15c0-4d67-bddd-5790f94911ee.png)

- I add a level of debug logging which can be enabled by executing the line `window.__AsuDevTools.enableDebug(true)` 
inside the devtools. 
<img width="934" alt="Screenshot 2021-07-23 at 15 45 26" src="https://user-images.githubusercontent.com/7423476/126799230-55a7872f-412c-4cfb-9c38-6af41fabf8d0.png">

NB. to this inside the storybook page you need select the right context
<img width="487" alt="Screenshot 2021-07-23 at 15 43 36" src="https://user-images.githubusercontent.com/7423476/126799054-f2e0f8dd-5cf5-4075-9544-8ffae7119a7f.png">
