### PR TITLE
feat(app-degree-pages): add new attribute `appPathFolder`

### DIFF
--- a/packages/app-degree-pages/src/components/ListingPage/index.js
+++ b/packages/app-degree-pages/src/components/ListingPage/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { Hero } from "@asu-design-system/components-core";
 import PropTypes from "prop-types";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import styled, { createGlobalStyle } from "styled-components";
 
 import {
@@ -15,7 +15,7 @@ import { useListingPageLogger } from "../../core/hooks";
 import { useFetch } from "../../core/hooks/use-fetch";
 import {
   acceleratedConcurrentValues,
-  listingPageDefault,
+  resolveDefaultProps,
   resolveListingHeroTitle,
   LIST_VIEW_ID,
 } from "../../core/models";
@@ -120,6 +120,7 @@ function filterData({
  * @returns {JSX.Element}
  */
 const ListingPage = ({
+  appPathFolder,
   actionUrls,
   hasSearchBar = true,
   hasFilters = true,
@@ -136,6 +137,10 @@ const ListingPage = ({
   /* TODO: we need this to swtich between LIST_VIEW and GRID_VIEW
   const [dataViewComponent, setDataViewComponent] = useState(LIST_VIEW_ID); */
   const url = urlResolver(programList.dataSource, listingPageDefaultDataSource);
+  const { listingPageDefault } = useMemo(
+    () => resolveDefaultProps(appPathFolder),
+    []
+  );
   // These filter are input props which never change.
   const { collegeAcadOrg, departmentCode } = programList.dataSource;
 
@@ -375,6 +380,7 @@ const ListingPage = ({
 };
 
 ListingPage.propTypes = {
+  appPathFolder: PropTypes.string,
   actionUrls: PropTypes.shape({
     applyNowUrl: PropTypes.string,
   }),
@@ -383,7 +389,7 @@ ListingPage.propTypes = {
   hero: PropTypes.shape(Hero.propTypes),
   introContent: PropTypes.shape(IntroContent.propTypes),
   programList: PropTypes.shape({
-    dataSource: PropTypes.oneOfType([dataSourcePropShape, PropTypes.string]),
+    dataSource: dataSourcePropShape,
     settings: columSettingsPropShape,
   }),
 };

--- a/packages/app-degree-pages/src/components/ListingPage/index.stories.js
+++ b/packages/app-degree-pages/src/components/ListingPage/index.stories.js
@@ -18,6 +18,7 @@ export default {
  * @returns {JSX.Element}
  */
 const Template = ({
+  appPathFolder,
   actionUrls,
   hero,
   introContent,
@@ -26,6 +27,7 @@ const Template = ({
   hasSearchBar,
 }) => (
   <ListingPage
+    appPathFolder={appPathFolder}
     actionUrls={actionUrls}
     hero={hero}
     introContent={introContent}
@@ -63,6 +65,7 @@ const dataSource = {
 export const Default = Template.bind({});
 
 Default.args = {
+  // appPathFolder: "/", // OPTIONAL
   actionUrls,
   hero: null,
   introContent: {
@@ -98,8 +101,10 @@ Default.args = {
  * @type {{ args: AppProps}}
  */
 export const DefaultWithCollegeAcadOrgAndDepartmentCode = Template.bind({});
-
-DefaultWithCollegeAcadOrgAndDepartmentCode.args = { ...Default.args };
+DefaultWithCollegeAcadOrgAndDepartmentCode.args = {
+  ...Default.args,
+  appPathFolder: "/", // OPTIONAL
+};
 DefaultWithCollegeAcadOrgAndDepartmentCode.args.programList = {
   ...Default.args.programList,
   dataSource: {

--- a/packages/app-degree-pages/src/components/ProgramDetailPage/index.js
+++ b/packages/app-degree-pages/src/components/ProgramDetailPage/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { Hero, Video } from "@asu-design-system/components-core";
 import PropTypes, { arrayOf } from "prop-types";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 
 import {
@@ -17,7 +17,7 @@ import {
   anchorMenuPropType,
   cardPropShape,
   dataSourcePropShape,
-  detailPageDefault,
+  resolveDefaultProps,
   linkPropShape,
   imagePropShape,
   videoPropShape,
@@ -63,6 +63,7 @@ const VideoWrapper = styled.div`
  * @returns
  */
 const ProgramDetailPage = ({
+  appPathFolder,
   dataSource,
   anchorMenu,
   hero,
@@ -84,6 +85,10 @@ const ProgramDetailPage = ({
   const [resolver, setResolver] = useState(degreeDataPropResolverService({}));
 
   const url = urlResolver(dataSource, detailPageDefaultDataSource);
+  const { detailPageDefault } = useMemo(
+    () => resolveDefaultProps(appPathFolder),
+    []
+  );
 
   useEffect(() => {
     doFetchPrograms(url);
@@ -323,7 +328,8 @@ const ProgramDetailPage = ({
 };
 
 ProgramDetailPage.propTypes = {
-  dataSource: PropTypes.oneOfType([dataSourcePropShape, PropTypes.string]),
+  appPathFolder: PropTypes.string,
+  dataSource: dataSourcePropShape,
   anchorMenu: PropTypes.shape(anchorMenuPropType),
   hero: PropTypes.shape(Hero.propTypes),
   introContent: PropTypes.shape({

--- a/packages/app-degree-pages/src/components/ProgramDetailPage/index.stories.js
+++ b/packages/app-degree-pages/src/components/ProgramDetailPage/index.stories.js
@@ -14,6 +14,63 @@ export default {
   title: "Program Detail Page",
 };
 
+/**
+ * @param {AppProps} props
+ * @returns {JSX.Element}
+ */
+const Template = ({
+  appPathFolder,
+  dataSource,
+  anchorMenu,
+  introContent,
+  hero,
+  atAGlance,
+  applicationRequirements,
+  changeMajorRequirements,
+  affordingCollege,
+  flexibleDegreeOptions,
+  careerOutlook,
+  exampleCareers,
+  globalOpportunity,
+  programContactInfo,
+  attendOnline,
+  nextSteps,
+}) => (
+  <>
+    <ProgramDetailPage
+      appPathFolder={appPathFolder}
+      dataSource={dataSource}
+      anchorMenu={anchorMenu}
+      introContent={introContent}
+      hero={hero}
+      atAGlance={atAGlance}
+      applicationRequirements={applicationRequirements}
+      changeMajorRequirements={changeMajorRequirements}
+      affordingCollege={affordingCollege}
+      flexibleDegreeOptions={flexibleDegreeOptions}
+      careerOutlook={careerOutlook}
+      exampleCareers={exampleCareers}
+      globalOpportunity={globalOpportunity}
+      programContactInfo={programContactInfo}
+      attendOnline={attendOnline}
+      nextSteps={nextSteps}
+    />
+    <section id="my-request-form-info-id" className="container mb-4">
+      <div className="row">
+        <h4>This is a just a Place holder</h4>
+        <img
+          src="/examples/assets/img/request-form-information.png"
+          alt=""
+          style={{
+            opacity: "0.7",
+            mixBlendMode: "luminosity",
+          }}
+        />
+      </div>
+    </section>
+  </>
+);
+
 // ====================================================================================
 // TEST:  this is just an example which shows how to parse the page URL querystring
 // to get the acadPlan
@@ -25,10 +82,11 @@ const queryAcadPllan = new URL(window.location.href).searchParams.get(
 
 /** @type {AppProps} */
 const defaultArgs = {
+  // appPathFolder: "/", // OPTIONAL
   dataSource: {
-    // OPTIONAL - endpoint: "https://degreesearch-proxy.apps.asu.edu/degreesearch/",
-    // OPTIONAL - method: "findDegreeByAcadPlan",
-    // OPTIONAL - init: "false",
+    // endpoint: "https://degreesearch-proxy.apps.asu.edu/degreesearch/", // OPTIONAL
+    // method: "findDegreeByAcadPlan", // OPTIONAL
+    // init: "false", // OPTIONAL
     acadPlan: queryAcadPllan || "BABUSGLBA",
     // acadPlan: "LSBISBIS", // this has marketText
     // acadPlan: "ESBMEMDBSE", // this does not have required courses
@@ -215,61 +273,6 @@ const defaultArgs = {
  * @param {AppProps} props
  * @returns {JSX.Element}
  */
-const Template = ({
-  dataSource,
-  anchorMenu,
-  introContent,
-  hero,
-  atAGlance,
-  applicationRequirements,
-  changeMajorRequirements,
-  affordingCollege,
-  flexibleDegreeOptions,
-  careerOutlook,
-  exampleCareers,
-  globalOpportunity,
-  programContactInfo,
-  attendOnline,
-  nextSteps,
-}) => (
-  <>
-    <ProgramDetailPage
-      dataSource={dataSource}
-      anchorMenu={anchorMenu}
-      introContent={introContent}
-      hero={hero}
-      atAGlance={atAGlance}
-      applicationRequirements={applicationRequirements}
-      changeMajorRequirements={changeMajorRequirements}
-      affordingCollege={affordingCollege}
-      flexibleDegreeOptions={flexibleDegreeOptions}
-      careerOutlook={careerOutlook}
-      exampleCareers={exampleCareers}
-      globalOpportunity={globalOpportunity}
-      programContactInfo={programContactInfo}
-      attendOnline={attendOnline}
-      nextSteps={nextSteps}
-    />
-    <section id="my-request-form-info-id" className="container mb-4">
-      <div className="row">
-        <h4>This is a just a Place holder</h4>
-        <img
-          src="/examples/assets/img/request-form-information.png"
-          alt=""
-          style={{
-            opacity: "0.7",
-            mixBlendMode: "luminosity",
-          }}
-        />
-      </div>
-    </section>
-  </>
-);
-
-/**
- * @param {AppProps} props
- * @returns {JSX.Element}
- */
 export const Default = Template.bind({});
 Default.args = {
   ...defaultArgs,
@@ -285,7 +288,10 @@ Default.args = {
  * @returns {JSX.Element}
  */
 export const PageWithContent = Template.bind({});
-PageWithContent.args = defaultArgs;
+PageWithContent.args = {
+  ...defaultArgs,
+  appPathFolder: "/", // OPTIONAL
+};
 
 /**
  * @param {AppProps} props

--- a/packages/app-degree-pages/src/core/models/listing-page-types.js
+++ b/packages/app-degree-pages/src/core/models/listing-page-types.js
@@ -91,6 +91,7 @@
 
 /**
  * @typedef {{
+ *  appPathFolder?: string,
  *  actionUrls?: ActionUrlProps
  *  hero?: HeroProps
  *  introContent?: IntroContentProps

--- a/packages/app-degree-pages/src/core/models/page-default-props.js
+++ b/packages/app-degree-pages/src/core/models/page-default-props.js
@@ -1,105 +1,120 @@
 // @ts-check
 
-import { getCurrnetScriptPath } from "../utils/script-utils";
+import { getCurrentScriptPath } from "../utils/script-utils";
 
-const scriptPath = getCurrnetScriptPath();
-const detailImageFolder = `${scriptPath}assets/img/detail-page`;
-const listingImageFolder = `${scriptPath}assets/img/listing-page`;
+const currentScriptPath = getCurrentScriptPath();
 
 /**
- * @type {import("./program-detail-types").ProgramDetailPageProps}
+ *
+ * @param {string} appPathFolder
+ * @returns {Object}
  */
-const detailPageDefault = {
-  dataSource: undefined,
-  introContent: {
-    image: {
-      url: `${detailImageFolder}/intro.jpg`,
-      altText: "Detail Page Degree",
-    },
-  },
-  hero: {
-    image: {
-      url: `${detailImageFolder}/hero.jpg`,
-      altText: "Detail Page Degree",
-      size: "medium",
-    },
-    title: {
-      text: "Detail Page Degree",
-      highlightColor: "gold",
-    },
-  },
-  nextSteps: {
-    cards: [
-      {
-        icon: ["fas", "info-circle"],
-        title: "Lear more about our programs",
-        content:
-          "Tell us what type of student you are and we'll get you the information you need.",
-        buttonLink: {
-          label: "Request information",
-          ariaLabel: "Request information",
-          color: "maroon",
-          href: "https://admission.asu.edu/contact/request-info",
-        },
-      },
-      {
-        icon: ["fas", "file-alt"],
-        title: "Apply to program",
-        content:
-          "Arizona State University invites freshman, transfer, international, graduate and online students to apply for admission using our online application.",
-        buttonLink: {
-          label: "Apply now",
-          ariaLabel: "Apply now",
-          color: "maroon",
-          href: "https://admission.asu.edu/apply",
-        },
-      },
-      {
-        icon: ["fas", "map-marker-alt"],
-        title: "Visit our campus",
-        content:
-          "An Experience ASU visit includes a presentation on admissions, scholarships and financial aid, student housing, getting involved on campus and much more.You will also go on a student-led walking tour of campus.",
-        buttonLink: {
-          label: "Schedule a visit",
-          ariaLabel: "Schedule a visit",
-          color: "maroon",
-          href: "https://visit.asu.edu/",
-        },
-      },
-    ],
-  },
-  globalOpportunity: {
-    image: {
-      url: `${detailImageFolder}/global-opportunity.jpg`,
-      altText: "Global opportunity",
-    },
-  },
-  careerOutlook: {
-    image: {
-      url: `${detailImageFolder}/career-outlook.jpg`,
-      altText: "Career Outlook",
-    },
-  },
-  attendOnline: {
-    image: {
-      url: `${detailImageFolder}/attend-online.jpg`,
-      altText: "Attend online",
-    },
-  },
-};
+const resolveDefaultProps = appPathFolder => {
+  const scriptPath = appPathFolder || currentScriptPath;
 
-/**
- * @type {import("./listing-page-types").ListingPageProps}
- */
-const listingPageDefault = {
-  hero: {
-    image: {
-      url: `${listingImageFolder}/hero.jpg`,
-      altText: "Listing Page Degree",
-      size: "medium",
+  const detailImageFolder = `${scriptPath}assets/img/detail-page`;
+  const listingImageFolder = `${scriptPath}assets/img/listing-page`;
+
+  /**
+   * @type {import("./program-detail-types").ProgramDetailPageProps}
+   */
+  const detailPageDefault = {
+    dataSource: undefined,
+    introContent: {
+      image: {
+        url: `${detailImageFolder}/intro.jpg`,
+        altText: "Detail Page Degree",
+      },
     },
-  },
-  programList: undefined,
+    hero: {
+      image: {
+        url: `${detailImageFolder}/hero.jpg`,
+        altText: "Detail Page Degree",
+        size: "medium",
+      },
+      title: {
+        text: "Detail Page Degree",
+        highlightColor: "gold",
+      },
+    },
+    nextSteps: {
+      cards: [
+        {
+          icon: ["fas", "info-circle"],
+          title: "Lear more about our programs",
+          content:
+            "Tell us what type of student you are and we'll get you the information you need.",
+          buttonLink: {
+            label: "Request information",
+            ariaLabel: "Request information",
+            color: "maroon",
+            href: "https://admission.asu.edu/contact/request-info",
+          },
+        },
+        {
+          icon: ["fas", "file-alt"],
+          title: "Apply to program",
+          content:
+            "Arizona State University invites freshman, transfer, international, graduate and online students to apply for admission using our online application.",
+          buttonLink: {
+            label: "Apply now",
+            ariaLabel: "Apply now",
+            color: "maroon",
+            href: "https://admission.asu.edu/apply",
+          },
+        },
+        {
+          icon: ["fas", "map-marker-alt"],
+          title: "Visit our campus",
+          content:
+            "An Experience ASU visit includes a presentation on admissions, scholarships and financial aid, student housing, getting involved on campus and much more.You will also go on a student-led walking tour of campus.",
+          buttonLink: {
+            label: "Schedule a visit",
+            ariaLabel: "Schedule a visit",
+            color: "maroon",
+            href: "https://visit.asu.edu/",
+          },
+        },
+      ],
+    },
+    globalOpportunity: {
+      image: {
+        url: `${detailImageFolder}/global-opportunity.jpg`,
+        altText: "Global opportunity",
+      },
+    },
+    careerOutlook: {
+      image: {
+        url: `${detailImageFolder}/career-outlook.jpg`,
+        altText: "Career Outlook",
+      },
+    },
+    attendOnline: {
+      image: {
+        url: `${detailImageFolder}/attend-online.jpg`,
+        altText: "Attend online",
+      },
+    },
+  };
+
+  /**
+   * @type {import("./listing-page-types").ListingPageProps}
+   */
+  const listingPageDefault = {
+    hero: {
+      image: {
+        url: `${listingImageFolder}/hero.jpg`,
+        altText: "Listing Page Degree",
+        size: "medium",
+      },
+    },
+    programList: undefined,
+  };
+
+  return {
+    detailPageDefault,
+    listingPageDefault,
+  };
 };
 
 /**
@@ -125,4 +140,4 @@ const resolveListingHeroTitle = dataSource => {
   return "Degrees";
 };
 
-export { detailPageDefault, listingPageDefault, resolveListingHeroTitle };
+export { resolveDefaultProps, resolveListingHeroTitle };

--- a/packages/app-degree-pages/src/core/models/program-detail-types.js
+++ b/packages/app-degree-pages/src/core/models/program-detail-types.js
@@ -146,7 +146,8 @@
  *  }} HideProp
  *
  *  @typedef {{
- *  dataSource: import("./listing-page-types").ProgramDetailDataSource | string
+ *  appPathFolder?: string,
+ *  dataSource: import("./listing-page-types").ProgramDetailDataSource
  *  anchorMenu?: AnchorMenuProps
  *  hero?: HideProp & import("@asu-design-system/components-core/src/components").HeroProps
  *  introContent?: IntroContentProps

--- a/packages/app-degree-pages/src/core/utils/http-url-resolver.js
+++ b/packages/app-degree-pages/src/core/utils/http-url-resolver.js
@@ -2,27 +2,21 @@
 
 /**
  *
- * @param {import("../models/listing-page-types").AppDataSource | string} dataSource
+ * @param {import("../models/listing-page-types").AppDataSource} dataSource
  * @param {import("../models/listing-page-types").AppDataSource} defaultDataSource
  * @returns {string}
  */
 function urlResolver(dataSource, defaultDataSource) {
-  if (typeof dataSource === "object") {
-    const httpParamters = { ...defaultDataSource, ...dataSource };
-    const { endpoint, fields, ...keyValues } = httpParamters;
+  const httpParamters = { ...defaultDataSource, ...dataSource };
+  const { endpoint, fields, ...keyValues } = httpParamters;
 
-    const params = Object.keys(keyValues).reduce(
-      (accumulator, paramName) =>
-        `${accumulator}&${paramName}=${httpParamters[paramName]}`,
-      ""
-    );
+  const params = Object.keys(keyValues).reduce(
+    (accumulator, paramName) =>
+      `${accumulator}&${paramName}=${httpParamters[paramName]}`,
+    ""
+  );
 
-    return `${endpoint}?fields=${fields}${params}`;
-  }
-  if (typeof dataSource === "string") {
-    return dataSource;
-  }
-  return "";
+  return `${endpoint}?fields=${fields}${params}`;
 }
 
 export { urlResolver };

--- a/packages/app-degree-pages/src/core/utils/script-utils.js
+++ b/packages/app-degree-pages/src/core/utils/script-utils.js
@@ -1,9 +1,9 @@
 // @ts-check
 
-function getCurrnetScriptPath() {
+function getCurrentScriptPath() {
   // @ts-ignore
   const match = (document.currentScript.src || "").match(/(.*\/)/);
   return match.length > 0 ? match[0] : "/";
 }
 
-export { getCurrnetScriptPath };
+export { getCurrentScriptPath };


### PR DESCRIPTION
In this PR

- new attribute `appPathFolder` to set the path folder up,
this is the where the `build `or `dist` folder is placed in the server
- update all stories to test the new attribute `appPathFolder`
- update types definitions
- create the function `resolveDefaultProps(appPathFolder)`
to wrap the default props and set the appPathFolder at runtime
- I clean up the function `urlResolver(...)` to handle the dataSource only as an  Object.
No more string are accepted as valid datasource