### PR TITLE
fix(bootstrap4-theme): 🐛 rework image overlap for greater content allowance

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_image-overlap.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_image-overlap.scss
@@ -22,7 +22,8 @@
 
   .content-wrapper {
     background-color: $uds-color-base-white;
-    padding: $uds-size-spacing-4;
+    padding: 40px;
+    overflow: hidden;
   }
 }
 
@@ -33,26 +34,27 @@
 @include media-breakpoint-up(lg) {
 
   .uds-image-overlap {
-
+    max-height: 100%;
     &:before {
       display:none;
     }
 
     display: grid;
-    grid-template-columns: 1.5rem 1fr 10rem 1fr 10rem 1fr 1.5rem;
-    grid-template-rows: minmax(0, auto) minmax(0, 2rem) 1fr minmax(0, 2rem) minmax(0, auto);
+    grid-template-columns: 1.5rem 1fr 20rem 10rem 1.5rem;
+    grid-template-rows: $uds-size-spacing-9 1fr $uds-size-spacing-9;
     gap: 0px 0px;
 
     img {
-      width:100%;
-      height:auto;
-      grid-column: 2 / span 4;
-      grid-row: 2 / 5;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      grid-column: 2 / span 2;
+      grid-row: 1 / span 3;
     }
 
     .content-wrapper {
-      grid-column: 5 / span 3;
-      grid-row: 3 / 4;
+      grid-column: 3 / span 2;
+      grid-row: 2 / span 1;
     }
 
     &:after {
@@ -60,40 +62,29 @@
       width:1.5rem;
       background-color: $uds-color-base-gold;
       grid-column: 1 / 2;
-      grid-row: 3 / span 1;
+      grid-row: 2 / span 1;
     }
 
   }
 
   .uds-image-overlap.content-left {
+    grid-template-columns: 1.5rem 10rem 20rem 1fr 1.5rem;
+
     img {
-      grid-column: 3 / span 4;
-      grid-row: 2 / 5;
+      grid-column: 3 / span 2;
+      grid-row: 1 / span 3;
     }
 
     .content-wrapper {
-      grid-column: 1 / span 3;
-      grid-row: 3 / 4;
+      grid-column: 2 / span 2;
+      grid-row: 2 / span 1;
     }
 
     &:after {
-      grid-column: 7 / 8;
-      grid-row: 3 / span 1;
+      grid-column: 5 / 6;
+      grid-row: 2 / span 1;
     }
   }
 }
 
 
-/*------------------------------------------------------------------
-2. Desktop, XL
---------------------------------------------------------------------*/
-@include media-breakpoint-up(xl) {
-
-  .uds-image-overlap {
-    grid-template-rows: minmax(0, auto) minmax(0, $uds-size-spacing-9) 1fr minmax(0, $uds-size-spacing-9) minmax(0, auto);
-
-    .content-wrapper {
-      padding:$uds-size-spacing-6;
-    }
-  }
-}

--- a/packages/bootstrap4-theme/stories/components/image-overlap/image-overlap.stories.js
+++ b/packages/bootstrap4-theme/stories/components/image-overlap/image-overlap.stories.js
@@ -10,7 +10,7 @@ export const contentImageOverlapRight = () => `
           <div class="content-wrapper">
             <h3>This is the content that goes in the box.</h3>
             <p>Instagram tour operator travel sailing flying package. Territory New York City group discount active lifestyle creditcard insurance wellness kayak guide overnight rural lonely planet.</p>
-            <p>Train luxury Paris recommendations nature France sight seeing. Flexibility Amsterdam maps. Pacific lonely planet private jet national insurance taxi tourist attractions. Budget Pacific guide caravan Barcelona place to stay maps gateway diary tour operator money</p>
+
           </div>
         </div>
         <!-- Component End -->


### PR DESCRIPTION
The current implementation works fine up to a certain amount of content, but we [require more than this](https://asudev.jira.com/browse/UDS-787). 

I'm not 100% sold on this implementation, but it does achieve what was caught in QA. 