### PR TITLE
fix(app-degree-pages): image overlap component style fixes

### DIFF
--- a/packages/app-degree-pages/src/components/ProgramDetailPage/components/ExampleCareers/index.style.js
+++ b/packages/app-degree-pages/src/components/ProgramDetailPage/components/ExampleCareers/index.style.js
@@ -2,9 +2,8 @@
 import styled from "styled-components";
 
 const widthSetUp = `
-  min-width: max-content !important;
-  max-width: max-content !important;
-  width: max-content !important;
+  width: unset !important;
+  min-width: unset !important;
 `;
 
 const SunIcon = styled.i`

--- a/packages/app-degree-pages/src/core/components/OverlapContentImage/index.js
+++ b/packages/app-degree-pages/src/core/components/OverlapContentImage/index.js
@@ -8,9 +8,12 @@ import { imagePropShape } from "../../models";
 import { ParagrapList } from "../ParagrapList";
 
 const GlobalStyle = createGlobalStyle`
-.uds-image-overlap {
-  padding-top: 0 ;
-}
+  .uds-image-overlap {
+    padding-top: 0 ;
+    @media (max-width: 768px) {
+      padding-top: 1.5rem !important;
+    }
+  }
 `;
 
 const ContentWrapper = styled.div`
@@ -23,8 +26,6 @@ const ContentWrapper = styled.div`
   @media (min-width: 992px) {
     .uds-image-overlap.content-left &.content-wrapper {
       padding-left: 0;
-      grid-column: 1 / span 4;
-      grid-row: 3/4;
     }
 
     .uds-image-overlap.content-right &.content-wrapper {


### PR DESCRIPTION
This fix the styles issues on the app degree pages image overlap component that appeared after this [pr](https://github.com/ASU/asu-unity-stack/pull/397/files) on the bootstrap 4 theme.
Also make some changes on the icons of the examples careers table, they have a strange behavior on safari and firefox