### PR TITLE
fix(bootstrap4-theme): apply margin x to foldable cards

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_cards.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_cards.scss
@@ -498,6 +498,10 @@ Cards - Table of Contents
   border-left: $uds-size-spacing-1 solid $uds-color-base-gold;
   height: auto;
 
+  @include media-breakpoint-down(sm) {
+    margin: 0 $uds-size-spacing-4;
+  }
+
   &.card-maroon {
     border-left-color: $uds-color-base-maroon;
   }

--- a/packages/bootstrap4-theme/stories/components/accordion/accordion.stories.js
+++ b/packages/bootstrap4-theme/stories/components/accordion/accordion.stories.js
@@ -7,7 +7,7 @@ export const FoldableCardComponent = createStory(
   <div class="container my-5">
 
     <div class="row">
-      <div class="col-md-12">
+      <div class="col-md-12 px-4">
         <h4>Foldable Card</h4>
         <p>The <code>.card-foldable</code> class is a wrapper for a generic card which creates a single section that expands and contracts independently of other surrounding foldable cards.</p>
         <ul>
@@ -18,7 +18,7 @@ export const FoldableCardComponent = createStory(
     </div>
 
     <div class="row mt-4">
-      <div class="col-md-4">
+      <div class="col-md-4 px-0">
 
         <div class="card card-foldable mt-3">
           <div class="card-header">
@@ -41,7 +41,7 @@ export const FoldableCardComponent = createStory(
     </div>
 
     <div class="row mt-4">
-      <div class="col-md-6">
+      <div class="col-md-6  px-0">
 
         <div class="card card-foldable mt-3">
           <div class="card-header">
@@ -64,7 +64,7 @@ export const FoldableCardComponent = createStory(
     </div>
 
     <div class="row mt-4">
-      <div class="col-md-9">
+      <div class="col-md-9 px-0">
 
         <div class="card card-foldable mt-3">
           <div class="card-header">
@@ -95,15 +95,15 @@ export const AccordionComponent = createStory(
   <div class="container my-5">
 
     <div class="row mt-4">
-      <div class="col-md-10">
-
-        <h4>Accordion</h4>
-        <p>With some small modifications of the <strong>foldable card</strong> code, a series of foldable cards can be connected together to form an accordion.</p>
-        <ul style={{padding:'1rem 3rem'}}>
-          <li>Wrap the collection of foldable cards with an element containing the class of <code>.accordion</code> and a unique ID.</li>
-          <li>Include the <code>data-parent</code> attribute within the card body element to properly toggle the folded/expanded state.</li>
-        </ul>
-
+      <div class="col-md-10 px-0">
+        <div class="px-4">
+          <h4>Accordion</h4>
+          <p>With some small modifications of the <strong>foldable card</strong> code, a series of foldable cards can be connected together to form an accordion.</p>
+          <ul style={{padding:'1rem 3rem'}}>
+            <li>Wrap the collection of foldable cards with an element containing the class of <code>.accordion</code> and a unique ID.</li>
+            <li>Include the <code>data-parent</code> attribute within the card body element to properly toggle the folded/expanded state.</li>
+          </ul>
+        </div>
         <div class="accordion" id="accordionExample">
 
           <div class="card card-foldable mt-3">
@@ -165,20 +165,21 @@ export const AccordionComponent = createStory(
 export const AccordionWithColorCombinationsComponent = createStory(
   <div class="container my-5">
     <div class="row mt-4">
-      <div class="col-md-10">
-        <h4>Accordion with color combinations</h4>
-        <p>With some small modifications of the <strong>foldable card</strong> code, different color styles can be applied.</p>
+      <div class="col-md-10 px-0">
+        <div class="px-4">
+          <h4>Accordion with color combinations</h4>
+          <p>With some small modifications of the <strong>foldable card</strong> code, different color styles can be applied.</p>
 
-        <p>
-          Identify the element wich has the class <code>.card-foldable</code>
-        </p>
-        <ul style={{padding:'0 3rem'}}>
-          <li>Gold is the default style no change needed</li>
-          <li>To set the marron color add the class <code>.card-maroon</code></li>
-          <li>To set the gray color add the class <code>.card-gray</code></li>
-          <li>To set the dark color add the class <code>.card-dark</code></li>
-        </ul>
-
+          <p>
+            Identify the element wich has the class <code>.card-foldable</code>
+          </p>
+          <ul style={{padding:'0 3rem'}}>
+            <li>Gold is the default style no change needed</li>
+            <li>To set the marron color add the class <code>.card-maroon</code></li>
+            <li>To set the gray color add the class <code>.card-gray</code></li>
+            <li>To set the dark color add the class <code>.card-dark</code></li>
+          </ul>
+        </div>
         <div class="accordion" id="accordionExample">
 
           <div class="card card-foldable mt-3">
@@ -258,53 +259,54 @@ export const AccordionWithColorCombinationsComponent = createStory(
 export const AccordionWithIconsComponent = createStory(
   <div class="container my-5">
     <div class="row mt-4">
-      <div class="col-md-10">
-        <h4>Accordion with icons</h4>
-        <p>With some small modifications of the <strong>foldable card</strong> code, different icons can be inserted.</p>
+      <div class="col-md-10 px-0">
+        <div class="px-4">
+          <h4>Accordion with icons</h4>
+          <p>With some small modifications of the <strong>foldable card</strong> code, different icons can be inserted.</p>
 
-        <ul style={{padding:'0 3rem'}}>
-          <li>Identify the card which you want to add the icon</li>
-          <li>Identify element header with class <code>.card-header</code>
-            and add the class <code>.card-header-icon</code>
-          </li>
-          <li>
-            Wrap the cart title content into a new
-            <code>
-              &lt;span class=&quot;card-icon&quot;&gt; ...content  &lt;/span&gt;
-            </code> tag
-            <br/> Example:
-            <br/>
+          <ul style={{padding:'0 3rem'}}>
+            <li>Identify the card which you want to add the icon</li>
+            <li>Identify element header with class <code>.card-header</code>
+              and add the class <code>.card-header-icon</code>
+            </li>
+            <li>
+              Wrap the cart title content into a new
+              <code>
+                &lt;span class=&quot;card-icon&quot;&gt; ...content  &lt;/span&gt;
+              </code> tag
+              <br/> Example:
+              <br/>
 
-            <code style={{background: '#e3e1e1', display: 'block', padding: '5px', border: '1px solid gray'}}>
-            <pre>
-              &lt;div class=&quot;card card-foldable mt-3&quot;&gt;
-                &lt;div class=&quot;card-header card-header-icon&quot;&gt;
-                  &lt;h4&gt;
-                    &lt;a
-                      id=&quot;cardOne&quot;
-                      class=&quot;collapsed&quot;
-                      href=&quot;#cardBodyOne&quot;
-                      data-toggle=&quot;collapse&quot;
-                      data-target=&quot;#cardBodyOne&quot;
-                      role=&quot;button&quot;
-                      aria-expanded=&quot;false&quot;
-                      aria-controls=&quot;cardBodyOne&quot;&gt;
+              <code style={{background: '#e3e1e1', display: 'block', padding: '5px', border: '1px solid gray'}}>
+              <pre>
+                &lt;div class=&quot;card card-foldable mt-3&quot;&gt;
+                  &lt;div class=&quot;card-header card-header-icon&quot;&gt;
+                    &lt;h4&gt;
+                      &lt;a
+                        id=&quot;cardOne&quot;
+                        class=&quot;collapsed&quot;
+                        href=&quot;#cardBodyOne&quot;
+                        data-toggle=&quot;collapse&quot;
+                        data-target=&quot;#cardBodyOne&quot;
+                        role=&quot;button&quot;
+                        aria-expanded=&quot;false&quot;
+                        aria-controls=&quot;cardBodyOne&quot;&gt;
 
-                      &lt;span class=&quot;card-icon&quot;&gt;
-                          &lt;i class=&quot;fas fa-dog mr-2&quot; role=&quot;img&quot; aria-label=&quot;...&quot;&gt;&lt;/i&gt;
-                          Accordion with icon and gold color.
-                      &lt;/span&gt;
+                        &lt;span class=&quot;card-icon&quot;&gt;
+                            &lt;i class=&quot;fas fa-dog mr-2&quot; role=&quot;img&quot; aria-label=&quot;...&quot;&gt;&lt;/i&gt;
+                            Accordion with icon and gold color.
+                        &lt;/span&gt;
 
-                      &lt;span class=&quot;fas fa-chevron-up&quot;&gt;&lt;/span&gt;
+                        &lt;span class=&quot;fas fa-chevron-up&quot;&gt;&lt;/span&gt;
 
-                    &lt;/a&gt;
-                  &lt;/h4&gt;
-                &lt;/div&gt;
-                </pre>
-                </code>
-          </li>
-        </ul>
-
+                      &lt;/a&gt;
+                    &lt;/h4&gt;
+                  &lt;/div&gt;
+                  </pre>
+                  </code>
+            </li>
+          </ul>
+        </div>
         <div class="accordion" id="accordionExample">
 
           <div class="card card-foldable mt-3">
@@ -358,7 +360,7 @@ export const DisableFoldAtBreakpointComponent = createStory(
   <div class="container my-5">
 
     <div class="row">
-      <div class="col">
+      <div class="col px-4">
 
         <h4>Foldable cards, disabled at breakpoints</h4>
         <p>Several utility class were created to allow an foldable card to display as a fully expanded normal card upon reaching a screen size of a specific breakpoint.</p>
@@ -368,7 +370,7 @@ export const DisableFoldAtBreakpointComponent = createStory(
     </div>
 
     <div class="row mt-4">
-      <div class="col-md-7 mb-4">
+      <div class="col-md-7 px-0 mb-4">
         <div class="card card-foldable desktop-disable-md">
           <div class="card-header">
             <h4>
@@ -388,7 +390,7 @@ export const DisableFoldAtBreakpointComponent = createStory(
         </div>
       </div>{/* end .col */}
 
-      <div class="col-md-7 mb-4">
+      <div class="col-md-7 px-0 mb-4">
         <div class="card card-foldable desktop-disable-lg">
           <div class="card-header">
             <h4>
@@ -408,7 +410,7 @@ export const DisableFoldAtBreakpointComponent = createStory(
         </div>
       </div>{/* end .col */}
 
-      <div class="col-md-7 mb-4">
+      <div class="col-md-7 px-0 mb-4">
         <div class="card card-foldable desktop-disable-xl">
           <div class="card-header">
             <h4>


### PR DESCRIPTION
Much like the [other PR open](https://github.com/ASU/asu-unity-stack/pull/419), the padding here was done in the storybook only code that the CMS hasn't taken, so there's misalignment with the header on mobile. [It's been decided](https://asudev.jira.com/browse/UDS-806) to have the margin part of the foldable card on mobile. Note this applies to all foldable cards, but I believe that's the intention of the ticket.