### PR TITLE
fix(bootstrap4-theme): rule removed from misc

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_misc.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_misc.scss
@@ -38,7 +38,6 @@ label {
   height: auto;
 }
 .card-header {
-  padding-bottom: 0;
   border-bottom: 0;
 }
 .card-header .card-title {


### PR DESCRIPTION
This is actually [causing a bug](https://asudev.jira.com/browse/UDS-805) in the degree page, as it's coming in from the components-core card. The bug is not reproducible in storybook locally, but when the CSS is minified this rule seems to take precedence in a different way, and can be [seen here](https://dev-stable-release.ws.asu.edu/bachelors-degrees/majorinfo/TSGITBS/undergrad/false/20). If it's necessary though we can try to overwrite it locally in the app-degree-pages package or in components-core.