### PR TITLE
feat(app-degree-pages): table collapse accessibility

### DIFF
--- a/packages/app-degree-pages/src/components/ListingPage/components/ProgramList/ListView/index.js
+++ b/packages/app-degree-pages/src/components/ListingPage/components/ProgramList/ListView/index.js
@@ -43,7 +43,7 @@ const renderInfo = ({ resolver, id }) => {
       />
       <label
         ref={labelRef}
-        className="label-more-less"
+        className="label-more-less element-focus"
         htmlFor={`#${id}`}
         role="button"
         tabIndex={0}

--- a/packages/app-degree-pages/src/components/ListingPage/components/ProgramList/ListView/index.style.js
+++ b/packages/app-degree-pages/src/components/ListingPage/components/ProgramList/ListView/index.style.js
@@ -156,7 +156,6 @@ const Table = styled.table`
       td .cell-container {
         display: flex;
         flex-direction: row;
-        // align-items: center;
         justify-content: space-between;
         gap: 0.5rem;
       }
@@ -177,6 +176,16 @@ const Table = styled.table`
           overflow: auto;
         }
 
+        &:not(:checked) + .desc-long::after {
+          content: " ";
+          height: 1rem;
+          background: #ffffff;
+          box-shadow: -1px -2px 20px 15px #f3f3f3;
+          width: 100%;
+          position: absolute;
+          bottom: 0;
+        }
+
         &:checked + .desc-long + .label-more-less {
           .label-more {
             display: none;
@@ -187,8 +196,6 @@ const Table = styled.table`
         }
 
         &:not(:checked) + .desc-long + .label-more-less {
-          width: 100%;
-
           .label-more {
             display: inline;
           }
@@ -208,8 +215,6 @@ const Table = styled.table`
         cursor: pointer;
         line-height: normal;
         color: #8c1d40;
-        background: white;
-        box-shadow: -1px -2px 20px 15px #f3f3f3;
         text-align: right;
         border: 0;
         margin: 0;

--- a/packages/app-degree-pages/src/core/components/Styles/index.js
+++ b/packages/app-degree-pages/src/core/components/Styles/index.js
@@ -13,6 +13,11 @@ const ThemeStyle = createGlobalStyle`
     }
   }
 
+  .element-focus:focus {
+    outline: none;
+    box-shadow: 0px 0px 0px 2px #fff, 0px 0px 0px 4px #191919 !important;
+  }
+
 `;
 
 const Main = styled.main`

--- a/packages/app-degree-pages/src/core/components/icons/BaseStateIconButton/index.js
+++ b/packages/app-degree-pages/src/core/components/icons/BaseStateIconButton/index.js
@@ -51,8 +51,9 @@ function BaseStateIconButton({
   const res = (
     <span
       role="button"
+      className="element-focus"
       tabIndex={0}
-      onKeyDown={onClickButton}
+      onKeyDown={e => e.key === "Enter" && onClickButton()}
       onClick={onClickButton}
       aria-label={ariaLabel}
       aria-expanded={selected}


### PR DESCRIPTION
Based on the way the collapse and the table is implemented, this way is the only way I found to make It work, even though is not the best approach. Maybe there is another way and I don't seeing it.

PD: The way tab navigation works if from top of the page to bottom and from the left to the right. As the collapse is in another row, the `[...more]` label will be focused after all the links in the previous row are focused.