### PR TITLE
fix: video overlay height

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_video.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_video.scss
@@ -55,8 +55,10 @@
 
   &-player {
     position: relative;
-    padding-bottom: 56.25%; /* 16:9 */
-    height: 0;
+    height: fit-content;
+    &.youtube-video {
+      padding-bottom: 56.25%; /* 16:9 */
+    }
   }
 
   &-overlay {
@@ -71,7 +73,7 @@
     top: 0;
     left: 0;
     right: 0;
-    bottom: 0;
+    bottom: $uds-size-spacing-1;
     z-index: 1;
 
     &:hover button.uds-video-btn-play {

--- a/packages/bootstrap4-theme/stories/components/video/video.stories.js
+++ b/packages/bootstrap4-theme/stories/components/video/video.stories.js
@@ -1,49 +1,60 @@
 import React from 'react';
-import { createComponent, createStory } from '../../../helpers/wrapper.js'
+import { createComponent, createStory } from '../../../helpers/wrapper.js';
 export default createComponent('Videos');
-import './video'
-import stockVideo from './stock-video-person-drawing.mp4'
-
+import './video';
+import stockVideo from './stock-video-person-drawing.mp4';
 
 export const Default = createStory(
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-12 col-md-10 col-lg-12">
-
         <div class="uds-video-container">
           <div class="uds-video-player">
             <video caption="Example video">
               <source src={stockVideo} />
-              <track src="path/to/caption.vtt" kind="captions" srclang="en" label="english_captions" />
+              <track
+                src="path/to/caption.vtt"
+                kind="captions"
+                srclang="en"
+                label="english_captions"
+              />
             </video>
             <div class="uds-video-overlay">
-              <button type="button" class="btn btn-circle btn-circle-large btn-circle-alt-white uds-video-btn-play">
+              <button
+                type="button"
+                class="btn btn-circle btn-circle-large btn-circle-alt-white uds-video-btn-play"
+              >
                 <i class="fa fa-play"></i>
                 <span class="sr-only">Play</span>
               </button>
             </div>
           </div>
         </div>
-
       </div>
     </div>
   </div>
 );
-
 
 export const DefaultWithCaption = createStory(
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-12 col-md-10 col-lg-12">
-
         <div class="uds-video-container uds-video-with-caption">
           <div class="uds-video-player">
             <video caption="Example video">
               <source src={stockVideo} />
-              <track src="path/to/caption.vtt" kind="captions" srclang="en" label="english_captions" />
+              <track
+                src="path/to/caption.vtt"
+                kind="captions"
+                srclang="en"
+                label="english_captions"
+              />
             </video>
             <div class="uds-video-overlay">
-              <button type="button" class="btn btn-circle btn-circle-large btn-circle-alt-white uds-video-btn-play">
+              <button
+                type="button"
+                class="btn btn-circle btn-circle-large btn-circle-alt-white uds-video-btn-play"
+              >
                 <i class="fa fa-play"></i>
                 <span class="sr-only">Play</span>
               </button>
@@ -53,44 +64,43 @@ export const DefaultWithCaption = createStory(
             <figcaption>Photo by Dent/ASU Now</figcaption>
           </figure>
         </div>
-
       </div>
     </div>
   </div>
 );
-
 
 export const YoutubeVideo = createStory(
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-12 col-md-10 col-lg-12">
-
         <div class="uds-video-container uds-video-with-caption">
-          <div class="uds-video-player">
-            <iframe title="Example video" src="https://www.youtube.com/embed/YW2p0ctzK9c"></iframe>
+          <div class="uds-video-player youtube-video">
+            <iframe
+              title="Example video"
+              src="https://www.youtube.com/embed/YW2p0ctzK9c"
+            ></iframe>
           </div>
         </div>
-
       </div>
     </div>
   </div>
 );
 
-
 export const YoutubeVideoWithCaption = createStory(
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-12 col-md-10 col-lg-12">
-
         <div class="uds-video-container uds-video-with-caption">
-          <div class="uds-video-player">
-            <iframe title="Example video" src="https://www.youtube.com/embed/YW2p0ctzK9c"></iframe>
+          <div class="uds-video-player youtube-video">
+            <iframe
+              title="Example video"
+              src="https://www.youtube.com/embed/YW2p0ctzK9c"
+            ></iframe>
           </div>
           <figure>
             <figcaption>Photo by Dent/ASU Now</figcaption>
           </figure>
         </div>
-
       </div>
     </div>
   </div>

--- a/packages/components-core/src/components/Video/index.js
+++ b/packages/components-core/src/components/Video/index.js
@@ -129,7 +129,7 @@ const youtubeTemplate = ({
       "uds-video-with-caption": caption,
     })}
   >
-    <div className="uds-video-player">
+    <div className="uds-video-player youtube-video">
       <iframe title={title} src={url} />
     </div>
     {caption && (


### PR DESCRIPTION
This pr is for [this](https://asudev.jira.com/secure/RapidBoard.jspa?rapidView=3345&projectKey=UDS&modal=detail&selectedIssue=UDS-830) ticket. Actually, the problem wasn't the gray line specifically, but the video has an auto height that makes the video adjust it heights to respect its ratio based on the width, so when the video height was smaller that the container, the gray overlay seems to generate that gray line.