### PR TITLE
fix(component-carousel): fix errors and allow for br statements

### DIFF
--- a/packages/component-carousel/src/components/ImageGalleryCarousel/index.js
+++ b/packages/component-carousel/src/components/ImageGalleryCarousel/index.js
@@ -10,6 +10,20 @@ import {
   BaseNavButtonContainer,
 } from "../../core/components/BaseCarousel/components";
 
+const calculateHeightNeeded = (content, width) => {
+  // Make height consistent across all slides.
+  // Assumes about 6 horizontal and 20 vertical px per character.
+  if (!content) {
+    return 0;
+  }
+  const brCount = (content.match(/<br/g) || []).length;
+  const charactersPerLine = width / 6;
+
+  const linesNeeded =
+    parseInt(content.length / charactersPerLine, 10) + brCount;
+
+  return linesNeeded * 20;
+};
 /**
  * @typedef {import('../../core/components/BaseCarousel').CarouselItem} CarouselItem
  */
@@ -80,24 +94,23 @@ const CustomNavComponent = ({ instanceName, imageItems, hasContent }) => {
   };
 
   useEffect(() => {
-    // Make height consistent across all slides.
-    // Assumes about 6 horizontal and 20 vertical px per character.
     const textArea = document.querySelector(
       `.image-gallery figcaption .uds-caption-text div`
     );
-    const longestContent = imageItems.reduce((acc, val) => {
-      return val.content.length > acc ? val.content.length : acc;
-    }, 0);
-    const contentWidth = parseInt(
-      window
-        .getComputedStyle(textArea, null)
-        .getPropertyValue("width")
-        .split("px")[0],
-      10
-    );
-    const charactersPerLine = contentWidth / 6;
-    const linesNeeded = parseInt(longestContent / charactersPerLine, 10);
-    textArea.style.height = `${linesNeeded * 20}px`;
+    if (textArea) {
+      const contentWidth = parseInt(
+        window
+          .getComputedStyle(textArea, null)
+          .getPropertyValue("width")
+          .split("px")[0],
+        10
+      );
+      const tallestContent = imageItems.reduce((acc, val) => {
+        const heightNeeded = calculateHeightNeeded(val.content, contentWidth);
+        return heightNeeded > acc ? heightNeeded : acc;
+      }, 0);
+      textArea.style.height = `${tallestContent}px`;
+    }
 
     const currentSlider = document.querySelector(`#${instanceName}`);
 

--- a/packages/component-carousel/src/components/ImageGalleryCarousel/index.stories.js
+++ b/packages/component-carousel/src/components/ImageGalleryCarousel/index.stories.js
@@ -67,14 +67,23 @@ const mockItemWithContent = () => {
 const mockItemWithMoreContent = () => {
   const shortContent = `Body copy goes <span style="font-weight: bold; display: inline;">here in bold!</span>. Then there's a <a href="https://google.com">link!!!!</a>
   Limit to 5 lines max`;
-  const longContent = `Body copy goes <span style="font-weight: bold; display: inline;">here in bold!</span>. Then there's a <a href="https://google.com">link!!!!</a>
-  Limit to 5 lines max. Lorem ipsum dolor sit amet,
-  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-  labore et dolore magna aliqua eiusmod tempo, , sed do eiusmod tempor incididunt ut
-  labore et dolore magna aliqua eiusmod tempo, , sed do eiusmod tempor incididunt ut
-  labore et dolore magna aliqua eiusmod tempo, , sed do eiusmod tempor incididunt ut
-  labore et dolore magna aliqua eiusmod tempo, , sed do eiusmod tempor incididunt ut
-  labore et dolore magna aliqua eiusmod tempo.`;
+  const longContent = `
+  <div>
+    <p>
+      <strong>Lorem ipsum is </strong>
+    </p>
+    <br />
+    <p>
+      <strong>p</strong>laceholder text commonly used in the graphic,
+      print, and publishing industries for previewing layouts and visual
+      mockups. Lorem ipsum is placeholder text commonly used in the graphic,
+      print, and publishing industries for previewing layouts and visual
+      mockups. Lorem ipsum is placeholder text commonly used in the graphic,
+      print, and publishing industries for previewing layouts and visual
+      mockups.&nbsp;<a href="https://packagist.org/packages/asuwebplatforms/webspark-module-webspark_blocks">
+      https://packagist.org/packages/asuwebplatforms/webspark-module-webspark_blocks</a></p>
+  </div>
+  `;
   return myCarouselItems.map((item, index) => ({
     ...item,
     title: `Content ${index + 1}`,


### PR DESCRIPTION
Daniela found a few issues here that needed to be resolved.

- Content editors can now use `<br />`s which will add lines appropriately.
- An error when body content was empty has been fixed. 