### PR TITLE
feat(app-rfi): add actualCampus prop for additional prefiltering WS2-880

### DIFF
--- a/packages/app-rfi/examples/rfi.html
+++ b/packages/app-rfi/examples/rfi.html
@@ -83,7 +83,8 @@
      *   https://degreesearch-proxy.apps.asu.edu/degreesearch/?method=findAllDegrees&init=false&fields=Descr100,Degree,CollegeAcadOrg,CollegeDescr100,DepartmentCode,DepartmentName,AcadPlanType,AcadPlan,AcadProg,AcadProg,planCatDescr,CampusStringArray&cert=true&program=graduate
      *
      * RFI COMPONENT PROPS, FOR REFERENCE
-     * - campus: One of ONLNE, GROUND, NOPREF, or undefined
+     * - campus: One of a campus type: ONLNE, GROUND, NOPREF, or undefined
+     * - actualCampus: A specific campus like TEMPE, DTPHX, POLY, WEST, ONLNE...
      * - college: Use one acadOrgCode from reference
      *     https://api.myasuplat-dpl.asu.edu/api/codeset/colleges
      * - department: Use one department code. See DepartmentCode values in
@@ -118,6 +119,7 @@
       targetSelector: "#rfi-container",
       props: {
         campus: "NOPREF", // ONLNE, GROUND, NOPREF
+        actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
         college: undefined, // e.g. CES
         department: undefined, // e.g. CINFOTECH
         studentType: "undergrad",

--- a/packages/app-rfi/src/components/AsuRfi/AsuRfi.js
+++ b/packages/app-rfi/src/components/AsuRfi/AsuRfi.js
@@ -13,6 +13,7 @@ import "./AsuRfi.css";
 
 const AsuRfi = ({
   campus,
+  actualCampus,
   college,
   department,
   studentType,
@@ -33,6 +34,7 @@ const AsuRfi = ({
     <div>
       <RfiMainForm
         campus={campus}
+        actualCampus={actualCampus}
         college={college}
         department={department}
         studentType={studentType}
@@ -58,6 +60,7 @@ export { AsuRfi };
 // Props
 AsuRfi.defaultProps = {
   campus: undefined,
+  actualCampus: undefined,
   college: undefined,
   department: undefined,
   studentType: undefined,
@@ -79,6 +82,7 @@ AsuRfi.defaultProps = {
 
 AsuRfi.propTypes = {
   campus: PropTypes.string,
+  actualCampus: PropTypes.string,
   college: PropTypes.string,
   department: PropTypes.string,
   studentType: PropTypes.string,

--- a/packages/app-rfi/src/components/AsuRfi/AsuRfi.stories.js
+++ b/packages/app-rfi/src/components/AsuRfi/AsuRfi.stories.js
@@ -34,6 +34,7 @@ const testSubmissionUrl = "https://httpbin.org/post";
 export const RfiDefault = Template.bind({});
 RfiDefault.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: undefined,
   department: undefined,
   studentType: undefined, // graduate, undergrad
@@ -54,6 +55,7 @@ RfiDefault.args = {
 export const RfiOnCollegePage = Template.bind({});
 RfiOnCollegePage.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: "CGM", // CHI
   department: undefined,
   studentType: undefined, // graduate, undergrad
@@ -74,6 +76,7 @@ RfiOnCollegePage.args = {
 export const RfiOnCollegePageWithAreaOfInterest = Template.bind({});
 RfiOnCollegePageWithAreaOfInterest.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: "CES",
   department: undefined,
   studentType: undefined, // graduate, undergrad
@@ -97,6 +100,7 @@ RfiOnCollegePageWithAreaOfInterest.args = {
 export const RfiOnDegreePageUndergraduate = Template.bind({});
 RfiOnDegreePageUndergraduate.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: undefined,
   department: undefined,
   studentType: undefined, // graduate, undergrad
@@ -117,6 +121,7 @@ RfiOnDegreePageUndergraduate.args = {
 export const RfiOnDegreePageGraduate = Template.bind({});
 RfiOnDegreePageGraduate.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: undefined,
   department: undefined,
   studentType: undefined, // graduate, undergrad
@@ -137,6 +142,7 @@ RfiOnDegreePageGraduate.args = {
 export const RfiOnCollegeDepartmentPage = Template.bind({});
 RfiOnCollegeDepartmentPage.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: "CES",
   department: "CINFOTECH",
   studentType: undefined, // graduate, undergrad
@@ -157,6 +163,7 @@ RfiOnCollegeDepartmentPage.args = {
 export const RfiOnNonAcademicUnitPage = Template.bind({});
 RfiOnNonAcademicUnitPage.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: undefined,
   department: undefined,
   studentType: undefined, // graduate, undergrad
@@ -177,6 +184,7 @@ RfiOnNonAcademicUnitPage.args = {
 export const RfiOnCertOrMinorPage = Template.bind({});
 RfiOnCertOrMinorPage.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: undefined,
   department: undefined,
   studentType: undefined, // graduate, undergrad
@@ -197,6 +205,7 @@ RfiOnCertOrMinorPage.args = {
 export const RfiOnCampaignLandingPage = Template.bind({});
 RfiOnCampaignLandingPage.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: undefined,
   department: undefined,
   studentType: "graduate",
@@ -217,6 +226,7 @@ RfiOnCampaignLandingPage.args = {
 export const RfiTestMode = Template.bind({});
 RfiTestMode.args = {
   campus: "GROUND", // ONLNE, GROUND, NOPREF
+  actualCampus: undefined, // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: undefined,
   department: undefined,
   studentType: "graduate",
@@ -237,6 +247,7 @@ RfiTestMode.args = {
 export const RfiDevTester = Template.bind({});
 RfiDevTester.args = {
   campus: undefined, // ONLNE, GROUND, NOPREF
+  actualCampus: "POLY", // TEMPE, DTPHX, POLY, WEST, ONLNE...
   college: undefined,
   department: undefined,
   studentType: "undergrad",

--- a/packages/app-rfi/src/components/stepper/RfiMainForm.js
+++ b/packages/app-rfi/src/components/stepper/RfiMainForm.js
@@ -17,6 +17,7 @@ import { RfiStepper } from "./RfiStepper";
 
 const RfiMainForm = ({
   campus,
+  actualCampus,
   college,
   department,
   studentType,
@@ -44,6 +45,7 @@ const RfiMainForm = ({
             <div className="uds-image-text-block-text-container">
               <RfiStepper
                 campus={campus}
+                actualCampus={actualCampus}
                 college={college}
                 department={department}
                 studentType={studentType}
@@ -131,6 +133,7 @@ const RfiMainForm = ({
 // Props
 RfiMainForm.defaultProps = {
   campus: undefined,
+  actualCampus: undefined,
   college: undefined,
   department: undefined,
   studentType: undefined,
@@ -146,6 +149,7 @@ RfiMainForm.defaultProps = {
 
 RfiMainForm.propTypes = {
   campus: PropTypes.string,
+  actualCampus: PropTypes.string,
   college: PropTypes.string,
   department: PropTypes.string,
   studentType: PropTypes.string,

--- a/packages/app-rfi/src/components/stepper/RfiStepper.js
+++ b/packages/app-rfi/src/components/stepper/RfiStepper.js
@@ -107,6 +107,7 @@ class RfiStepper extends React.Component {
       handleSubmit,
       // props
       campus,
+      actualCampus,
       college,
       department,
       studentType,
@@ -291,6 +292,7 @@ const RfiStepperButtons = ({ stepNum, lastStep, handleBack, submitting }) => (
 // Props
 RfiStepper.defaultProps = {
   campus: undefined,
+  actualCampus: undefined,
   college: undefined,
   department: undefined,
   studentType: undefined,
@@ -310,6 +312,7 @@ RfiStepper.propTypes = {
   formComponents: PropTypes.arrayOf(PropTypes.func).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   campus: PropTypes.string,
+  actualCampus: PropTypes.string,
   college: PropTypes.string,
   department: PropTypes.string,
   studentType: PropTypes.string,

--- a/packages/app-rfi/src/components/steps/ProgramInterest.js
+++ b/packages/app-rfi/src/components/steps/ProgramInterest.js
@@ -40,8 +40,9 @@ function filterDegrees(
   return degreeData;
 }
 
-// Filter degree data by department or college props if they exist.
-function filterDegreesByDeptOrCollege(degreeData, props) {
+// Filter degree data by department or college or actualCampus props if they
+// exist.
+function filterDegreesByDeptOrCollegeOrCampus(degreeData, props) {
   // Progress return if most specific is found first.
   if (props.department) {
     // Filter with prop's props.department against data's DepartmentCode
@@ -50,6 +51,15 @@ function filterDegreesByDeptOrCollege(degreeData, props) {
   if (props.college) {
     // Filter with prop's props.college against data's CollegeAcadOrg
     return filterDegrees(degreeData, "CollegeAcadOrg", props, "college");
+  }
+  if (props.actualCampus) {
+    // Filter with prop's props.actualCampus against data's CampusStringArray
+    return filterDegrees(
+      degreeData,
+      "CampusStringArray",
+      props,
+      "actualCampus"
+    );
   }
   // Passthrough.
   return degreeData;
@@ -296,7 +306,7 @@ const ProgramInterest = props => {
       // DS REST Areas of Interest
 
       // Filter with props.department or props.college if they exist.
-      const degreeDataProcessed = filterDegreesByDeptOrCollege(
+      const degreeDataProcessed = filterDegreesByDeptOrCollegeOrCampus(
         degreeData,
         props
       );
@@ -357,7 +367,7 @@ const ProgramInterest = props => {
       );
 
       // Filter with props.department or props.college if they exist.
-      const degreeDataProcessed = filterDegreesByDeptOrCollege(
+      const degreeDataProcessed = filterDegreesByDeptOrCollegeOrCampus(
         degreeDataFiltered,
         props
       );


### PR DESCRIPTION
WS2-880 Add a prop to the app-rfi component to allow for pre-filtering based on campus code (rather than campus type). Because we already have a `campus` prop that maps to the campus type, I've named this new prop `actualCampus`. When implemented in the CMS, it will draw on the https://api.myasuplat-dpl.asu.edu/api/codeset/campuses service to pull in the campus options.