### PR TITLE
fix(app-degree-pages): fix overlap section alignment issue

### DIFF
--- a/packages/app-degree-pages/src/core/components/OverlapContentImage/index.js
+++ b/packages/app-degree-pages/src/core/components/OverlapContentImage/index.js
@@ -12,6 +12,10 @@ const GlobalStyle = createGlobalStyle`
     padding-top: 0;
     width: auto;
     align-items: center;
+
+    &:after{
+      height: 100%;
+    }
     @media (max-width: 768px) {
       padding-top: 1.5rem !important;
     }
@@ -19,6 +23,7 @@ const GlobalStyle = createGlobalStyle`
 `;
 
 const ContentWrapper = styled.div`
+  .uds-image-overlap.content-right &.content-wrapper,
   .uds-image-overlap.content-left &.content-wrapper {
     height: fit-content;
   }
@@ -48,9 +53,12 @@ const OverlapImage = styled.img`
   .uds-image-overlap & {
     width: 100%;
     height: 100%;
-    grid-column: 2 / span 4;
     grid-row: 2/5;
     object-fit: cover;
+  }
+
+  .uds-image-overlap.content-right & {
+    grid-row: 1 / span 3;
   }
 `;
 


### PR DESCRIPTION
In this PR:

# Description
There is an issue with overlap image section in both Listing Page and Detail Page

Before this PR
![image](https://user-images.githubusercontent.com/7423476/130622143-3a022aa3-78bd-41d2-a309-bbd402c17a3e.png)

After this PR

![image](https://user-images.githubusercontent.com/7423476/130622286-d503fc58-7672-4be7-8221-f539245d039f.png)

