### PR TITLE
style(bootstrap4-theme): uds-838 update text white color

### DIFF
--- a/packages/bootstrap4-theme/src/scss/bootstrap-asu.scss
+++ b/packages/bootstrap4-theme/src/scss/bootstrap-asu.scss
@@ -16,7 +16,6 @@ $image-assets-path: '/img' !default;
 @import 'variables/alerts';
 @import 'variables/banners';
 @import 'variables/spacing';
-@import 'variables/typography';
 @import 'variables/buttons';
 @import 'variables/blockquotes';
 @import 'variables/cards';
@@ -127,6 +126,9 @@ $theme-colors: map-remove($theme-colors, 1, 3, 5);
 @import '../../node_modules/bootstrap/scss/spinners';
 @import '../../node_modules/bootstrap/scss/utilities';
 @import '../../node_modules/bootstrap/scss/print';
+
+// move here every import which needs to override bootstrap classes
+@import 'variables/typography';
 
 // css Bootstrap doesn't have variables for
 @import 'bootstrap-asu-extends';

--- a/packages/bootstrap4-theme/src/scss/variables/_typography.scss
+++ b/packages/bootstrap4-theme/src/scss/variables/_typography.scss
@@ -25,7 +25,7 @@ body {
 
 // Text formatting
 .text-white {
-  color: $light !important;
+  color: $uds-color-font-light-base !important;
 }
 
 .text-underline {


### PR DESCRIPTION
In this PR:

# Description

The color of the text in Storybook at https://unity.web.asu.edu/@asu-design-system/bootstrap4-theme/index.html?path=/story/design-typography--componentbody-copy-gray-7 is probably incorrect. 
The text is set to #fff but according to the XD file, white should never be used except for background colors. The "text-white" class should probably be changed to color: #fafafa.

To achieve this I had to change color and move the import `@import 'variables/typography';`
just after Bootstrap imports

# Before this PR
![image](https://user-images.githubusercontent.com/7423476/130630471-6cf5a1a8-5d77-4af8-8ffb-69dcafb2579a.png)

# After this PR
![image](https://user-images.githubusercontent.com/7423476/130630394-9bfd6e45-1a28-49f4-81ad-30bec8ab5d20.png)
