### PR TITLE
style(bootstrap4-theme):  Image background with call to action broken

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_image-background-with-cta.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_image-background-with-cta.scss
@@ -8,7 +8,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
-  margin: 0 12px;
+  margin: auto;
 
   &-container {
     align-items: baseline;


### PR DESCRIPTION
In this PR:

# Description
After adding the image it initially looks fine, but once I zoom out the image isn't centered, 
it is anchored to the left side.
![image](https://user-images.githubusercontent.com/7423476/130641010-fd4dba1e-b490-4bbc-a885-3fc9b3ddbf6e.png)

This can be notice in long page, the storybook does not show big difference hpow was before