### PR TITLE
fix(bootstrap4-theme): adjust elements to align with BS4 grid

### DIFF
--- a/packages/bootstrap4-theme/README.md
+++ b/packages/bootstrap4-theme/README.md
@@ -223,7 +223,7 @@ yarn gulp               # Execute the default Gulp task (validate)
 
 ### Publish Package Releases
 
-#### TODO 
+#### TODO
 
 ![divider](./divider.png)
 
@@ -239,12 +239,33 @@ yarn gulp               # Execute the default Gulp task (validate)
 | **test/e2e/** *.test.ts           | End-2-End tests (Not Yet Implemented) |
 | **test/integration/** *.test.ts   | Integration tests (Not Yet Implemented) |
 
-
 ![divider](./divider.png)
 
 ## ❯ Contribute to Project
 
 View our [Contributing Guidelines](./CONTRIBUTING.md)
+
+
+### Component Start / Component End
+
+Stories in Storybook should all maintain the following general structure to clearly deliniate where native Boostrap markup is to be included in a particular element.
+
+* Add comments on the beginning and end of the markup of each element.
+* Wrap each element in a basic Bootstrap container/row/column structure to verify that it aligns with the header and footer.
+
+  ```html
+  <div class="container">
+    <div class="row">
+      <div class="col">
+        <!-- Component start -->
+        ...
+        <!-- Component end -->
+      </div>
+    </div>
+  </div>
+  ```
+
+Most Bootstrap UI elements can be used independently of the Bootstrap grid elements if your project requires you to complete your page layout using some other method. (CSS Grid, Flexbox, an alternate grid markup.)
 
 ![divider](./divider.png)
 

--- a/packages/bootstrap4-theme/stories/components/accordion/accordion.stories.js
+++ b/packages/bootstrap4-theme/stories/components/accordion/accordion.stories.js
@@ -3,24 +3,12 @@ import { createComponent, createStory } from '../../../helpers/wrapper.js'
 export default createComponent('Accordions');
 
 
-export const FoldableCardComponent = createStory(
-  <div class="container my-5">
-
+export const FoldableCard = createStory(
+  <div class="container my-6">
     <div class="row">
-      <div class="col-md-12 px-4">
-        <h4>Foldable Card</h4>
-        <p>The <code>.card-foldable</code> class is a wrapper for a generic card which creates a single section that expands and contracts independently of other surrounding foldable cards.</p>
-        <ul>
-          <li>The cards will conform to the width of the surrounding container.</li>
-          <li>There is a recommended character limit of 75 characters for the text within the header of a foldable card.</li>
-        </ul>
-      </div>
-    </div>
+      <div class="col-md-6">
 
-    <div class="row mt-4">
-      <div class="col-md-4 px-0">
-
-        <div class="card card-foldable mt-3">
+        <div class="card card-foldable">
           <div class="card-header">
             <h4>
               <a id="example-header-1" class="collapsed" data-toggle="collapse" href="#example-content-1" role="button" aria-expanded="false" aria-controls="example-content-1">This card unfolds.
@@ -38,35 +26,10 @@ export const FoldableCardComponent = createStory(
         </div>
 
       </div>
-    </div>
 
-    <div class="row mt-4">
-      <div class="col-md-6  px-0">
+      <div class="col-md-6">
 
-        <div class="card card-foldable mt-3">
-          <div class="card-header">
-            <h4>
-              <a id="example-header-2" class="collapsed" data-toggle="collapse" href="#example-content-2" role="button" aria-expanded="false" aria-controls="example-content-2">This starts off folded and has a really long title which wraps to a second line.
-                <span class="fas fa-chevron-up"></span>
-              </a>
-            </h4>
-          </div>
-          <div id="example-content-2" class="collapse card-body" aria-labelledby="example-header-2">
-            <h4>This is a quaternary headline</h4>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud</p>
-            <h5>This is a level five headline. There's a fancy word for that too.</h5>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud</p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</p>
-          </div>
-        </div>
-
-      </div>
-    </div>
-
-    <div class="row mt-4">
-      <div class="col-md-9 px-0">
-
-        <div class="card card-foldable mt-3">
+        <div class="card card-foldable">
           <div class="card-header">
             <h4>
               <a id="example-header-3" data-toggle="collapse" href="#example-content-3" role="button" aria-expanded="true" aria-controls="example-content-3">This card starts off in an unfolded state.
@@ -91,19 +54,12 @@ export const FoldableCardComponent = createStory(
 
 
 
-export const AccordionComponent = createStory(
-  <div class="container my-5">
+export const Accordion = createStory(
+  <div class="container my-6">
 
-    <div class="row mt-4">
-      <div class="col-md-10 px-0">
-        <div class="px-4">
-          <h4>Accordion</h4>
-          <p>With some small modifications of the <strong>foldable card</strong> code, a series of foldable cards can be connected together to form an accordion.</p>
-          <ul style={{padding:'1rem 3rem'}}>
-            <li>Wrap the collection of foldable cards with an element containing the class of <code>.accordion</code> and a unique ID.</li>
-            <li>Include the <code>data-parent</code> attribute within the card body element to properly toggle the folded/expanded state.</li>
-          </ul>
-        </div>
+    <div class="row">
+      <div class="col-md-10">
+
         <div class="accordion" id="accordionExample">
 
           <div class="card card-foldable mt-3">
@@ -162,24 +118,11 @@ export const AccordionComponent = createStory(
 );
 
 
-export const AccordionWithColorCombinationsComponent = createStory(
-  <div class="container my-5">
-    <div class="row mt-4">
-      <div class="col-md-10 px-0">
-        <div class="px-4">
-          <h4>Accordion with color combinations</h4>
-          <p>With some small modifications of the <strong>foldable card</strong> code, different color styles can be applied.</p>
+export const ColorAccents = createStory(
+  <div class="container my-6">
+    <div class="row">
+      <div class="col-md-10">
 
-          <p>
-            Identify the element wich has the class <code>.card-foldable</code>
-          </p>
-          <ul style={{padding:'0 3rem'}}>
-            <li>Gold is the default style no change needed</li>
-            <li>To set the marron color add the class <code>.card-maroon</code></li>
-            <li>To set the gray color add the class <code>.card-gray</code></li>
-            <li>To set the dark color add the class <code>.card-dark</code></li>
-          </ul>
-        </div>
         <div class="accordion" id="accordionExample">
 
           <div class="card card-foldable mt-3">
@@ -256,57 +199,11 @@ export const AccordionWithColorCombinationsComponent = createStory(
 );
 
 
-export const AccordionWithIconsComponent = createStory(
+export const IncludedIcons = createStory(
   <div class="container my-5">
-    <div class="row mt-4">
-      <div class="col-md-10 px-0">
-        <div class="px-4">
-          <h4>Accordion with icons</h4>
-          <p>With some small modifications of the <strong>foldable card</strong> code, different icons can be inserted.</p>
+    <div class="row">
+      <div class="col-md-10">
 
-          <ul style={{padding:'0 3rem'}}>
-            <li>Identify the card which you want to add the icon</li>
-            <li>Identify element header with class <code>.card-header</code>
-              and add the class <code>.card-header-icon</code>
-            </li>
-            <li>
-              Wrap the cart title content into a new
-              <code>
-                &lt;span class=&quot;card-icon&quot;&gt; ...content  &lt;/span&gt;
-              </code> tag
-              <br/> Example:
-              <br/>
-
-              <code style={{background: '#e3e1e1', display: 'block', padding: '5px', border: '1px solid gray'}}>
-              <pre>
-                &lt;div class=&quot;card card-foldable mt-3&quot;&gt;
-                  &lt;div class=&quot;card-header card-header-icon&quot;&gt;
-                    &lt;h4&gt;
-                      &lt;a
-                        id=&quot;cardOne&quot;
-                        class=&quot;collapsed&quot;
-                        href=&quot;#cardBodyOne&quot;
-                        data-toggle=&quot;collapse&quot;
-                        data-target=&quot;#cardBodyOne&quot;
-                        role=&quot;button&quot;
-                        aria-expanded=&quot;false&quot;
-                        aria-controls=&quot;cardBodyOne&quot;&gt;
-
-                        &lt;span class=&quot;card-icon&quot;&gt;
-                            &lt;i class=&quot;fas fa-dog mr-2&quot; role=&quot;img&quot; aria-label=&quot;...&quot;&gt;&lt;/i&gt;
-                            Accordion with icon and gold color.
-                        &lt;/span&gt;
-
-                        &lt;span class=&quot;fas fa-chevron-up&quot;&gt;&lt;/span&gt;
-
-                      &lt;/a&gt;
-                    &lt;/h4&gt;
-                  &lt;/div&gt;
-                  </pre>
-                  </code>
-            </li>
-          </ul>
-        </div>
         <div class="accordion" id="accordionExample">
 
           <div class="card card-foldable mt-3">
@@ -356,45 +253,15 @@ export const AccordionWithIconsComponent = createStory(
 );
 
 
-export const DisableFoldAtBreakpointComponent = createStory(
+export const DisableFold = createStory(
   <div class="container my-5">
 
-    <div class="row">
-      <div class="col px-4">
-
-        <h4>Foldable cards, disabled at breakpoints</h4>
-        <p>Several utility class were created to allow an foldable card to display as a fully expanded normal card upon reaching a screen size of a specific breakpoint.</p>
-
-        <p>Use a variant of the <code>.desktop-disable</code> along with a <code>.card-foldable</code> class to enable the functionality.</p>
-      </div>
-    </div>
-
     <div class="row mt-4">
-      <div class="col-md-7 px-0 mb-4">
-        <div class="card card-foldable desktop-disable-md">
-          <div class="card-header">
-            <h4>
-              <a id="example-header-1" data-toggle="collapse" href="#example-content-1" role="button" aria-expanded="false" aria-controls="example-content-1">This should look like a normal card until the md breakpoint
-                <span class="fas fa-chevron-up"></span>
-              </a>
-            </h4>
-          </div>
-          <div id="example-content-1" class="collapse card-body" aria-labelledby="example-header-1">
-          <p>This uses the <code>.desktop-disable-md</code> class.</p>
-          <p>Lorem ipsum dolor sit amet, consectetuer adipiscing
-            elit. Aenean commodo ligula eget dolor. Aenean massa.
-            Cum sociis natoque penatibus et magnis dis parturient
-            montes, nascetur ridiculus mus. Donec quam felis,
-            ultricies nec, pellentesque eu, pretium quis, sem.</p>
-          </div>
-        </div>
-      </div>{/* end .col */}
-
-      <div class="col-md-7 px-0 mb-4">
+      <div class="col-md-7">
         <div class="card card-foldable desktop-disable-lg">
           <div class="card-header">
             <h4>
-              <a id="example-header-2" data-toggle="collapse" href="#example-content-2" role="button" aria-expanded="false" aria-controls="example-content-2">This will become an accordion at the lg breakpoint.
+              <a id="example-header-2" data-toggle="collapse" href="#example-content-2" role="button" aria-expanded="false" aria-controls="example-content-2">This will become an foldable card at the lg breakpoint.
                 <span class="fas fa-chevron-up"></span>
               </a>
             </h4>
@@ -409,12 +276,15 @@ export const DisableFoldAtBreakpointComponent = createStory(
           </div>
         </div>
       </div>{/* end .col */}
+    </div>{/* end .row */}
 
-      <div class="col-md-7 px-0 mb-4">
+    <div class="row mt-4">
+      <div class="col-md-7">
+
         <div class="card card-foldable desktop-disable-xl">
           <div class="card-header">
             <h4>
-              <a id="example-header-3" data-toggle="collapse" href="#example-content-3" role="button" aria-expanded="false" aria-controls="example-content-3">Collapses to an accordion at the xl breakpoint
+              <a id="example-header-3" data-toggle="collapse" href="#example-content-3" role="button" aria-expanded="false" aria-controls="example-content-3">Collapses to an foldable card at the xl breakpoint.
                 <span class="fas fa-chevron-up"></span>
               </a>
             </h4>

--- a/packages/bootstrap4-theme/stories/components/alerts/alerts.stories.js
+++ b/packages/bootstrap4-theme/stories/components/alerts/alerts.stories.js
@@ -5,65 +5,91 @@ export default createComponent('Alerts');
 
 export const AlertsComponent = createStory(
   <div>
-    <div class="alert alert-warning" role="alert">
-      <div class="alert-icon">
-        <span title="Alert" class="fa fa-icon fa-bell"></span>
-      </div>
-      <div class="alert-content">
-        Alert (orange): This is a warning alert to alert, confirm or notify. It is
-        built using <a href="https://getbootstrap.com/docs/4.0/components/alerts">the
-        Bootstrap 4 .alert-warning class</a>.
-      </div>
-      <div class="alert-close">
-        <button type="button" class="btn btn-circle btn-circle-alt-black close" aria-label="Close" onclick="event.target.parentNode.parentNode.style.display='none';"><i class="fas fa-times"></i></button>
+    <div class="container mt-8">
+      <div class="row">
+        <div class="col-md-12">
+
+          <div class="alert alert-warning alert-dismissable" role="alert">
+            <div class="alert-icon">
+              <span title="Alert" class="fa fa-icon fa-bell"></span>
+            </div>
+            <div class="alert-content">
+              Alert (orange): This is a warning alert to alert, confirm or notify. It is
+              built using <a href="https://getbootstrap.com/docs/4.0/components/alerts">the
+              Bootstrap 4 .alert-warning class</a>.
+            </div>
+            <div class="alert-close">
+              <button type="button" class="btn btn-circle btn-circle-alt-black close" data-dismiss="alert" aria-label="Close"><i class="fas fa-times"></i></button>
+            </div>
+          </div>
+
+        </div>
       </div>
     </div>
 
-    <div class="alert alert-success" role="alert">
-      <div class="alert-icon">
-        <span title="Success" class="fa fa-icon fa-check-circle"></span>
-      </div>
-      <div class="alert-content">
-        Success (green): This is a success alert to confirm or notify. It is built
-        using <a href="https://getbootstrap.com/docs/4.0/components/alerts">the
-        Bootstrap 4 .alert-success class</a>.
-      </div>
-      <div class="alert-close">
-        <button type="button" class="btn btn-circle btn-circle-alt-black close" aria-label="Close" onclick="event.target.parentNode.parentNode.style.display='none';"><i class="fas fa-times"></i></button>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+
+          <div class="alert alert-success alert-dismissable" role="alert">
+            <div class="alert-icon">
+              <span title="Success" class="fa fa-icon fa-check-circle"></span>
+            </div>
+            <div class="alert-content">
+              Success (green): This is a success alert to confirm or notify. It is built
+              using <a href="https://getbootstrap.com/docs/4.0/components/alerts">the
+              Bootstrap 4 .alert-success class</a>.
+            </div>
+            <div class="alert-close">
+              <button type="button" class="btn btn-circle btn-circle-alt-black close" data-dismiss="alert" aria-label="Close"><i class="fas fa-times"></i></button>
+            </div>
+          </div>
+
+        </div>
       </div>
     </div>
 
-    <div class="alert alert-info" role="alert">
-      <div class="alert-icon">
-        <span title="Information" class="fa fa-icon fa-info-circle"></span>
-      </div>
-      <div class="alert-content">
-        Information (blue): This is a info alert to confirm or notify. It is built
-        using <a href="https://getbootstrap.com/docs/4.0/components/alerts">the
-        Bootstrap 4 .alert-info class</a>.
-      </div>
-      <div class="alert-close">
-        <button type="button" class="btn btn-circle btn-circle-alt-black close" aria-label="Close" onclick="event.target.parentNode.parentNode.style.display='none';"><i class="fas fa-times"></i></button>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+
+          <div class="alert alert-info" role="alert">
+            <div class="alert-icon">
+              <span title="Information" class="fa fa-icon fa-info-circle"></span>
+            </div>
+            <div class="alert-content">
+              <p>Information (blue): This is a info alert to confirm or notify. It is built
+              using <a href="https://getbootstrap.com/docs/4.0/components/alerts">the
+              Bootstrap 4 .alert-info class</a></p>
+              <p>Creating a dismissable alert box requires the inclusion of the <code>alert-dismissable</code> class along with the <code>data-dismiss="alert"</code> attribute on the close button. Alert messages do not necessarily have to be dismissable.</p>
+            </div>
+          </div>
+
+        </div>
       </div>
     </div>
 
-    <div class="alert alert-danger" role="alert">
-      <div class="alert-icon">
-        <span title="Error" class="fa fa-icon fa-exclamation-triangle"></span>
-      </div>
-      <div class="alert-content">
-        Error (red): This is a danger alert used specifically for errors. It is
-        built using <a href="https://getbootstrap.com/docs/4.0/components/alerts">the
-        Bootstrap 4 .alert-danger class</a>.
-      </div>
-      <div class="alert-close">
-        <button type="button" class="btn btn-circle btn-circle-alt-black close" aria-label="Close" onclick="event.target.parentNode.parentNode.style.display='none';"><i class="fas fa-times"></i></button>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+
+          <div class="alert alert-danger" role="alert">
+            <div class="alert-icon">
+              <span title="Error" class="fa fa-icon fa-exclamation-triangle"></span>
+            </div>
+            <div class="alert-content">
+              Error (red): This is a danger alert used specifically for errors. It is
+              built using <a href="https://getbootstrap.com/docs/4.0/components/alerts">the
+              Bootstrap 4 .alert-danger class</a>.
+            </div>
+            <div class="alert-close">
+              <button type="button" class="btn btn-circle btn-circle-alt-black close" aria-label="Close" onclick="event.target.parentNode.parentNode.style.display='none';"><i class="fas fa-times"></i></button>
+            </div>
+          </div>
+
+        </div>
       </div>
     </div>
 
-    <p>Note: On the actual page, you will need to provide a container with
-    <code>role="alert"</code> to accept any changes. See the example for
-    <a href="https://www.w3.org/TR/wai-aria-practices/#alert">
-    https://www.w3.org/TR/wai-aria-practices/#alert</a></p>
   </div>
 )

--- a/packages/bootstrap4-theme/stories/components/blockquote/blockquote.stories.js
+++ b/packages/bootstrap4-theme/stories/components/blockquote/blockquote.stories.js
@@ -4,80 +4,69 @@ export default createComponent('Blockquotes and Testimonials');
 
 
 export const BlockquoteNoImage = createStory(
-  <div class="container">
-    <div class="row">
-      <div class="col-md-8 px-0">
+  <div>
 
-        <div class="uds-blockquote accent-maroon">
-          <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
-            <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
-          </svg>
-          <blockquote>
-            <p>We hold these truths to be self-evident, that all men are created equal, that they are endowed by their Creator with certain unalienable Rights, that among these are Life, Liberty and the pursuit of Happiness.</p>
-            <div class="citation">
-              <cite class="name">Thomas Jefferson</cite>
-              <cite class="description">The Declaration of Independence</cite>
-            </div>
-          </blockquote>
-        </div>
+    <div class="container mt-8">
+      <div class="row">
+        <div class="col-md-8">
 
-      </div>
-    </div>
-
-    <div class="row pt-6">
-      <div class="col-md-8 px-0">
-
-        <div class="pt-4 pt-sm-6 bg-gray-7">
-
-          <div class="uds-blockquote accent-gold text-white">
+          <div class="uds-blockquote accent-maroon">
             <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
               <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
             </svg>
             <blockquote>
-              <p>Four score and seven years ago our fathers brought forth upon this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.</p>
+              <p>We hold these truths to be self-evident, that all men are created equal, that they are endowed by their Creator with certain unalienable Rights, that among these are Life, Liberty and the pursuit of Happiness.</p>
               <div class="citation">
-                <cite class="name">Abraham Lincoln</cite>
-                <cite class="description">Gettysburg Address</cite>
+                <cite class="name">Thomas Jefferson</cite>
+                <cite class="description">The Declaration of Independence</cite>
               </div>
             </blockquote>
           </div>
 
         </div>
-
       </div>
     </div>
+
+    <div class="container mt-8">
+      <div class="row">
+        <div class="col-md-8">
+
+          <div class="p-md-4 bg-gray-7">
+
+            <div class="uds-blockquote accent-gold text-white">
+              <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
+                <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
+              </svg>
+              <blockquote>
+                <p>Four score and seven years ago our fathers brought forth upon this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.</p>
+                <div class="citation">
+                  <cite class="name">Abraham Lincoln</cite>
+                  <cite class="description">Gettysburg Address</cite>
+                </div>
+              </blockquote>
+            </div>
+
+          </div>
+
+        </div>
+      </div>
+    </div>
+
   </div>
 );
 
 
 export const BlockquoteWithImage = createStory(
-  <div class="container">
-    <div class="row">
-      <div class="col-md-8 px-0">
+  <div>
 
-        <div class="uds-blockquote with-image">
-          <img src="https://placeimg.com/600/400/any" alt="Pretend this is Michael M. Crow, President of ASU"/>
-          <blockquote>
-            <p>ASU is a comprehensive public research university, measured not by whom we exclude, but rather by whom we include and how they succeed; advancing research and discovery of public value; and assuming fundamental responsibility for the economic, social, cultural and overall health of the communities it serves.</p>
-            <div class="citation">
-              <cite class="name">Michael M. Crow</cite>
-              <cite class="description">ASU Charter</cite>
-            </div>
-          </blockquote>
-        </div>
+    <div class="container mt-8">
+      <div class="row">
+        <div class="col-md-8">
 
-      </div>
-    </div>
-
-    <div class="row mt-6">
-      <div class="col-md-10 px-0">
-
-        <div class="pt-4 pt-sm-6 bg-gray-2">
-
-          <div class="uds-blockquote with-image reversed">
-            <img src="https://placeimg.com/300/300/any" alt="Pretend this is Michael M. Crow, President of ASU"/>
+          <div class="uds-blockquote with-image">
+            <img src="https://placeimg.com/600/400/any" alt="Pretend this is Michael M. Crow, President of ASU"/>
             <blockquote>
-              <p>Eight design aspirations guide the ongoing evolution of ASU as a New American University. These institutional objectives are integrated in innovative ways throughout the university to achieve excellence, access and impact.</p>
+              <p>ASU is a comprehensive public research university, measured not by whom we exclude, but rather by whom we include and how they succeed; advancing research and discovery of public value; and assuming fundamental responsibility for the economic, social, cultural and overall health of the communities it serves.</p>
               <div class="citation">
                 <cite class="name">Michael M. Crow</cite>
                 <cite class="description">ASU Charter</cite>
@@ -86,82 +75,90 @@ export const BlockquoteWithImage = createStory(
           </div>
 
         </div>
-
       </div>
     </div>
+
+    <section class="bg-gray-2 my-12 py-4">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-10">
+
+            <div class="uds-blockquote with-image reversed">
+              <img src="https://placeimg.com/300/300/any" alt="Pretend this is Michael M. Crow, President of ASU"/>
+              <blockquote>
+                <p>Eight design aspirations guide the ongoing evolution of ASU as a New American University. These institutional objectives are integrated in innovative ways throughout the university to achieve excellence, access and impact.</p>
+                <div class="citation">
+                  <cite class="name">Michael M. Crow</cite>
+                  <cite class="description">ASU Charter</cite>
+                </div>
+              </blockquote>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </section>
+
   </div>
 );
 
 
 export const BlockquoteNoCitation = createStory(
-  <div class="container">
-    <div class="row">
-      <div class="col-md-8 px-0">
+  <div>
 
-        <div class="uds-blockquote no-citation with-image">
-          <img src="https://placeimg.com/300/300/nature" alt="Image of Walt Disney"/>
-          <blockquote>
-            <h3><span class="highlight-black">Walt Disney</span></h3>
-            <p>Laughter is timeless, imagination has no age, dreams are forever.</p>
-          </blockquote>
-        </div>
+    <div class="container mt-8">
+      <div class="row">
+        <div class="col-md-8">
 
-      </div>{/*  end .col  */}
-    </div>{/*  end .row  */}
-
-    <div class="row pt-6">
-      <div class="col-md-8 px-0">
-
-        <div class="pt-4 pt-sm-6 bg-gray-7">
-
-        <div class="uds-blockquote no-citation with-image reversed">
-          <img src="https://placeimg.com/300/300/tech" alt="Image of Walt Disney"/>
-          <blockquote>
-            <h3><span class="highlight-gold">Walt Disney</span></h3>
-            <p class="text-white">We keep opening new doors and doing new things, because we’re curious and curiosity keeps leading us down new paths.</p>
-          </blockquote>
-        </div>
+          <div class="uds-blockquote no-citation with-image">
+            <img src="https://placeimg.com/300/300/nature" alt="Image of Walt Disney"/>
+            <blockquote>
+              <h3><span class="highlight-black">Walt Disney</span></h3>
+              <p>Laughter is timeless, imagination has no age, dreams are forever.</p>
+            </blockquote>
+          </div>
 
         </div>
-
       </div>
     </div>
+
+    <div class="container mt-12">
+      <div class="row">
+        <div class="col-md-8 ">
+
+          <div class="p-md-4 bg-gray-7">
+
+            <div class="uds-blockquote no-citation with-image reversed">
+              <img src="https://placeimg.com/300/300/tech" alt="Image of Walt Disney"/>
+              <blockquote>
+                <h3><span class="highlight-gold">Walt Disney</span></h3>
+                <p class="text-white">We keep opening new doors and doing new things, because we’re curious and curiosity keeps leading us down new paths.</p>
+              </blockquote>
+            </div>
+
+          </div>
+
+        </div>
+      </div>
+    </div>
+
   </div>
 );
 
 
 export const BlockquoteAltCitation = createStory(
-  <div class="container">
-    <div class="row">
-      <div class="col-md-8 px-0">
+  <div>
 
-        <div class="uds-blockquote alt-citation accent-gold">
-          <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
-            <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
-          </svg>
-          <blockquote>
-            <p>Some people want it to happen, some people wish it would happen and some people make it happen.</p>
-            <div class="citation">
-              <cite class="name">Michael Jordan</cite>
-              <cite class="description">NBA Superstar</cite>
-            </div>
-          </blockquote>
-        </div>
+    <div class="container mt-8">
+      <div class="row">
+        <div class="col-md-8">
 
-      </div>
-    </div>
-
-    <div class="row pt-6">
-      <div class="col-md-9 px-0">
-
-        <div class="pt-4 pt-sm-6 bg-gray-1">
-
-          <div class="uds-blockquote alt-citation accent-maroon">
+          <div class="uds-blockquote alt-citation accent-gold">
             <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
               <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
             </svg>
             <blockquote>
-              <p>Talent wins games, but teamwork and intelligence wins championships.</p>
+              <p>Some people want it to happen, some people wish it would happen and some people make it happen.</p>
               <div class="citation">
                 <cite class="name">Michael Jordan</cite>
                 <cite class="description">NBA Superstar</cite>
@@ -170,45 +167,49 @@ export const BlockquoteAltCitation = createStory(
           </div>
 
         </div>
-
       </div>
     </div>
+
+    <section class="bg-gray-1 mt-8 p-md-4">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-9">
+
+            <div class="uds-blockquote alt-citation accent-maroon">
+              <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
+                <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
+              </svg>
+              <blockquote>
+                <p>Talent wins games, but teamwork and intelligence wins championships.</p>
+                <div class="citation">
+                  <cite class="name">Michael Jordan</cite>
+                  <cite class="description">NBA Superstar</cite>
+                </div>
+              </blockquote>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </section>
+
   </div>
 );
 
 
 export const TestimonialsNoImage = createStory(
-  <div class="container">
-    <div class="row">
-      <div class="col-md-6 px-0">
+  <div>
 
-        <div class="uds-blockquote uds-testimonial accent-gold">
-          <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
-            <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
-          </svg>
-          <blockquote>
-            <p>Computers make excellent and efficient servants, but I have no wish to serve under them.</p>
-            <div class="citation">
-              <cite class="name">Spock</cite>
-              <cite class="description">First officer, USS Enterprise</cite>
-            </div>
-          </blockquote>
-        </div>
+    <div class="container mt-8">
+      <div class="row">
+        <div class="col-md-6">
 
-      </div>
-    </div>
-
-    <div class="row mt-6">
-      <div class="col-md-8 px-0">
-
-        <div class="pt-4 pt-sm-6 bg-gray-2">
-
-          <div class="uds-blockquote uds-testimonial accent-maroon">
+          <div class="uds-blockquote uds-testimonial accent-gold">
             <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
               <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
             </svg>
             <blockquote>
-              <p>I could not deprive you of the revelation of all that you could accomplish together, of a friendship that will define you both in ways you cannot yet realize.</p>
+              <p>Computers make excellent and efficient servants, but I have no wish to serve under them.</p>
               <div class="citation">
                 <cite class="name">Spock</cite>
                 <cite class="description">First officer, USS Enterprise</cite>
@@ -217,17 +218,42 @@ export const TestimonialsNoImage = createStory(
           </div>
 
         </div>
-
       </div>
     </div>
+
+    <div class="container mt-6">
+      <div class="row">
+        <div class="col-md-8">
+
+          <div class="p-md-4 bg-gray-2">
+
+            <div class="uds-blockquote uds-testimonial accent-maroon">
+              <svg title="Open quote" role="presentation" viewBox="0 0 302.87 245.82">
+                <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z"/>
+              </svg>
+              <blockquote>
+                <p>I could not deprive you of the revelation of all that you could accomplish together, of a friendship that will define you both in ways you cannot yet realize.</p>
+                <div class="citation">
+                  <cite class="name">Spock</cite>
+                  <cite class="description">First officer, USS Enterprise</cite>
+                </div>
+              </blockquote>
+            </div>
+
+          </div>
+
+        </div>
+      </div>
+    </div>
+
   </div>
 );
 
 
 export const TestimonialsWithImage = createStory(
-  <div class="container">
+  <div class="container mt-8">
     <div class="row">
-      <div class="col-md-6 px-0">
+      <div class="col-md-6">
 
         <div class="uds-blockquote uds-testimonial with-image alt-citation accent-maroon">
           <img src="https://placeimg.com/600/400/arch" alt="Pretend this is Han Solo"/>
@@ -246,9 +272,9 @@ export const TestimonialsWithImage = createStory(
     </div>
 
     <div class="row mt-6">
-      <div class="col-md-8 px-0">
+      <div class="col-md-8">
 
-        <div class="pt-6 pt-sm-4 bg-gray-7">
+        <div class="p-md-4 bg-gray-7">
 
           <div class="uds-blockquote uds-testimonial with-image alt-citation accent-gold text-white">
             <img src="https://placeimg.com/400/400/tech" alt="Pretend this is Han Solo"/>

--- a/packages/bootstrap4-theme/stories/docs/accordion/accordion-basics.stories.mdx
+++ b/packages/bootstrap4-theme/stories/docs/accordion/accordion-basics.stories.mdx
@@ -1,0 +1,123 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+
+<Meta title="Docs/Accordions" />
+
+## Foldable Card
+
+The `.card-foldable` class is a modifying class for a generic card which creates a single section that expands and contracts independently of other surrounding foldable cards.
+
+- The cards will conform to the width of the surrounding container.
+- There is a recommended character limit of 75 characters for the text within the header of a foldable card.
+
+The recommended markup for a foldable card begins from the following pattern.
+
+```
+<div class="card card-foldable">
+  <div class="card-header">
+    <h4>
+      <a id="example-header-1" class="collapsed" data-toggle="collapse" href="#example-content-1" role="button" aria-expanded="false" aria-controls="example-content-1">Header Text
+        <span class="fas fa-chevron-up"></span>
+      </a>
+    </h4>
+  </div>
+  <div id="example-content-1" class="collapse card-body" aria-labelledby="example-header-1">
+    <h4>Content headline. Recommend H4 or H5.</h4>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud</p>
+  </div>
+</div>
+```
+
+## Accent Colors and Icons
+
+Foldable cards can be accented with different colors from the ASU palette. The header of a foldable card can also include an optional icon from Font Awesome.
+
+Include a modifying class along side of `.card-foldable` to produce different accent colors. Allowable colors are below:
+
+| Modifier class  | Produced Color                |
+| --------------- | ----------------------------- |
+| (none)          | ASU Gold (default)            |
+| .card-maroon    | ASU Maroon                    |
+| .card-gray      | ASU Gray 4                    |
+| .card-dark      | ASU Gray 7 (Black)            |
+
+To add an icon:
+
+- Include the modifying class `.card-header-icon` next to the `.card-header` declaration.
+- Any Font Awesome icon from the collection may be used.
+
+A foldable card with an icon and and accent color might look like this:
+
+```
+<div class="card card-foldable mt-3 card-maroon">
+  <div class="card-header card-header-icon">
+    <h4>
+      <a id="cardOne" class="collapsed" href="#cardBodyOne" data-toggle="collapse" data-target="#cardBodyOne" role="button" aria-expanded="false" aria-controls="cardBodyOne">
+        <span class="card-icon">
+            <i class="fas fa-dog mr-2" role="img" aria-label="..."></i>
+            Accordion with icon and gold color.
+        </span>
+        <span class="fas fa-chevron-up"></span>
+      </a>
+    </h4>
+  </div>
+  <div id="cardOne" class="collapse card-body" aria-labelledby="cardOne">
+    ...
+  </div>
+</div>
+```
+
+## Disable fold at breakpoint
+
+You may choose to disable the "fold" of a foldable card at a particular breakpoint in order to have an element appear expanded on desktop and collapsed on mobile.
+
+Include one of the following modifier classes next to the `.card-foldable` class to enable the functionality.
+
+- `.desktop-disable-md` disables the fold at the `md` breakpoint and above.
+- `.desktop-disable-lg` and `.desktop-disable-xl` are also available.
+
+Example:
+```
+<div class="card card-foldable desktop-disable-lg">
+  <div class="card-header">
+    ...
+  </div>
+  <div id="cardOne" class="collapse card-body" aria-labelledby="cardOne">
+    ...
+  </div>
+</div>
+```
+
+## Accordions
+
+With some small modifications, a series of foldable cards can be connected together to form an accordion.
+
+- Wrap the collection of foldable cards with an element containing the class of `.accordion` and a unique ID.
+- Include the `data-parent` attribute within the card body element to properly toggle the folded/expanded state.
+- By default, foldable cards wrapped in an accordion will stack together with no spacing between them. Include a utility margin class between each card to space them apart properly. (`.mt-3` is recommended.)
+
+That markup looks like this when completed:
+
+```
+<div class="accordion" id="accordionExample">
+
+  <div class="card card-foldable mt-3">
+    <div class="card-header">
+      ...
+    </div>
+    <div id="cardBodyOne" class="collapse card-body" aria-labelledby="cardOne" data-parent="#accordionExample">
+      ...
+    </div>
+  </div>
+
+  <div class="card card-foldable mt-3">
+    <div class="card-header">
+        ...
+    </div>
+    <div id="cardBodyTwo" class="collapse card-body" aria-labelledby="cardTwo" data-parent="#accordionExample">
+      ...
+    </div>
+  </div>
+
+</div>
+```
+


### PR DESCRIPTION
Makes adjustments to the stories of three elements within our collection. 

**Foldable Cards (Accordion)**

- Aligns examples to the Bootstrap 4 grid. Removes extra padding from the examples.
- Relocate documentation to new documentation story. (`?path=/story/docs-accordions--page`)

**Alerts**

- Aligned element examples to the Bootstrap grid.
- Provided a working example of a non-dismissable alert.
- Provided context for creating a dismissable alert using the native `.alert-dismissable` classes from Bootstrap.

Note: Storybook strips the recommended inline JS of `onclick="event.target.parentNode.parentNode.style.display='none';"` from the story upon render, which is why none of the previous examples were actually dismissable. The jQuery/Bootstrap version works as expected.

**Blockquotes**

- Reworked examples so that any represented padding was applied to the correct element.
- - One "correct" way to apply padding here was to wrap the `uds-blockquote` element in it's own `<div>` and apply both the padding and background color to that wrapper.
- - The other "correct" way is to wrap the outer `.container` with a dedicated `<section>` or other block-level element and apply the background color / padding to that. 
- These examples were intensionally provided here as a recommended way to handle ANY need for a background color/pattern against another element. Further adjustments to other stories within the collection will use one of these two techniques.

**README**

- Made a recommendation to clearly delineate the markup of a UI element from its surrounding context with an inline comment. (Proceeded to ignore this rule for the three things above. 😨 Will fix it eventually. )
- Alluded to the fact that certain elements may in fact include/require Bootstrap grid markup in order to produce the desired result. If that's the case, we should change the included comments to include EVERYTHING that's needed to reproduce the result.