### PR TITLE
style(bootstrap4-theme):  fix inconsistent CTA button sizes

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_cards.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_cards.scss
@@ -189,12 +189,15 @@ Cards - Table of Contents
     padding: 0 24px 24px 24px;
   }
 
-  .card-button .btn {
-    font-size: $uds-component-button-small-font-size;
-    padding: $uds-component-button-padding-y-small
-      $uds-component-button-padding-x-small;
-    line-height: 1rem;
-  }
+  // TODO: This block of rules causes inconsistency between buttons side
+  // TODO: removed ad per request on ticket UDS-866
+  // TODO: we should consider to review all CSS, for any button types, in small viewport
+  // .card-button .btn {
+  //   font-size: $uds-component-button-small-font-size;
+  //   padding: $uds-component-button-padding-y-small
+  //     $uds-component-button-padding-x-small;
+  //   line-height: 1rem;
+  // }
 
   .card > div:last-child {
     padding-bottom: 24px;


### PR DESCRIPTION
# Description

In the "Card Image and Content" block, the primary and secondary CTA buttons have inconsistent sizes across desktop and mobile. https://dev-final-release-candidate-2.ws.asu.edu/card-image-and-content-0

This issue is happening in card component-core. You could review it in the carousels:
  https://dev-final-stable-release.ws.asu.edu/carousels

# Before this PR
![image](https://user-images.githubusercontent.com/7423476/130800495-3699fe37-db19-4f4f-b680-b6d27e303454.png)

# After this PR

![image](https://user-images.githubusercontent.com/7423476/130800573-ccff71f0-457d-4469-b12c-a29683ae6897.png)
