### PR TITLE
fix(bootstrap4-theme): tabbed panels content scroll

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_tabbed-panels.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_tabbed-panels.scss
@@ -125,7 +125,8 @@
 }
 
 .tab-content {
-  overflow-x: auto;
+  overflow-x: hidden;
+  word-break: break-word;
   padding: $uds-size-spacing-4;
   margin-bottom: $uds-size-spacing-4;
 }


### PR DESCRIPTION
This pr is to address some changes made before on the tabbed panels that weren't the deserved ones!