### PR TITLE
fix(bootstrap4-theme): mobile sidebar margin

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_sidebar.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_sidebar.scss
@@ -175,6 +175,6 @@ Sidebar Navigation
 
   @include media-breakpoint-down(md) {
     border-top: 0;
-    margin: 0 $uds-size-spacing-4;
+    margin: 0 1.25rem;
   }
 }


### PR DESCRIPTION
This pr is to fix a wrong margin setter on the sidebar for the mobile version. Is a fixed requested from @duarte-daniela.

There is no ticket for this.