### PR TITLE
feat(bootstrap4-theme): allow p tags in tables

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_tables.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_tables.scss
@@ -25,6 +25,14 @@
         box-sizing: border-box;
         min-width: 300px;
       }
+
+      @media screen and (max-width: $uds-breakpoint-sm) {
+        :first-child {
+          width: 128px;
+          min-width: 128px;
+          max-width: 128px;
+        }
+      }
     }
 
     > thead {
@@ -40,6 +48,12 @@
         th,
         td {
           background-color: white;
+
+          p {
+            display: flex;
+            align-items: center;
+            margin-bottom: 0;
+          }
         }
         &:nth-child(2n) {
           th,
@@ -165,16 +179,6 @@
 }
 
 @media screen and (max-width: $uds-breakpoint-sm) {
-  .uds-table {
-    & > table {
-      tr > *:first-child {
-        width: 128px;
-        min-width: 128px;
-        max-width: 128px;
-      }
-    }
-  }
-
   .uds-table-fixed {
     &-wrapper {
       .scroll-control {

--- a/packages/bootstrap4-theme/stories/components/tables/tables.stories.js
+++ b/packages/bootstrap4-theme/stories/components/tables/tables.stories.js
@@ -22,8 +22,8 @@ export const DefaultComponent = createStory(
             </thead>
             <tbody>
               <tr>
-                <th scope="row">Metropolitan campus population</th>
-                <td>71,946</td>
+                <th scope="row"><p>Metropolitan campus population</p></th>
+                <td><p>71,946</p></td>
                 <td>71,946</td>
                 <td>71,946</td>
                 <td>71,946</td>


### PR DESCRIPTION
@dan-poenaru-dept has pointed out that `<p>` tags in tables break the layout, this PR addresses that.