### PR TITLE
fix(app-degree-pages): fix the ProgramContactInfo section

### DIFF
--- a/packages/app-degree-pages/src/components/ProgramDetailPage/components/ProgramContactInfo/index.js
+++ b/packages/app-degree-pages/src/components/ProgramDetailPage/components/ProgramContactInfo/index.js
@@ -78,7 +78,7 @@ function ProgramContactInfo({ department, asuOfficeLoc, email, phone }) {
         </li>
         <li>
           <i className="c-icon fas icon-small fa-envelope" title="Email" />
-          <a href={email.url || email.text}>{email.text}</a>
+          <a href={`mailto:${email.url || email.text}`}>{email.text}</a>
         </li>
         <li>
           <i className="c-icon fas icon-small fa-phone" title="Phone" />

--- a/packages/app-degree-pages/src/components/ProgramDetailPage/index.js
+++ b/packages/app-degree-pages/src/components/ProgramDetailPage/index.js
@@ -303,17 +303,21 @@ const ProgramDetailPage = ({
               ) : null}
             </div>
 
-            {programContactInfo ? (
+            {!programContactInfo?.hide ? (
               <div className="row">
                 <div className="col col-sm-12 col-md-6 col-lg-6 ">
                   <ProgramContactInfo
                     department={{
-                      text: resolver.getGDepartmentName(),
-                      url: programContactInfo.departmentUrl,
+                      text: resolver.getDepartmentName(),
+                      url:
+                        programContactInfo?.departmentUrl ||
+                        resolver.getPlanUrl(),
                     }}
                     email={{
                       text: resolver.getEmailAddress(),
-                      url: programContactInfo.emailUrl,
+                      url:
+                        programContactInfo?.emailUrl ||
+                        resolver.getEmailAddress(),
                     }}
                     asuOfficeLoc={resolver.getAsuOfficeLoc()}
                     phone={resolver.getPhone()}
@@ -368,6 +372,7 @@ ProgramDetailPage.propTypes = {
     image: imagePropShape,
   }),
   programContactInfo: PropTypes.shape({
+    hide: PropTypes.bool,
     departmentUrl: PropTypes.string,
     emailUrl: PropTypes.string,
   }),

--- a/packages/app-degree-pages/src/components/ProgramDetailPage/index.stories.js
+++ b/packages/app-degree-pages/src/components/ProgramDetailPage/index.stories.js
@@ -61,7 +61,7 @@ const Template = ({
       <div className="row">
         <h4>This is a just a Place holder</h4>
         <img
-          src="/examples/assets/img/request-form-information.png"
+          src="./examples/assets/img/request-form-information.png"
           alt=""
           style={{
             opacity: "0.7",
@@ -147,7 +147,7 @@ const defaultArgs = {
     },
     // OPTIONAL
     // video: {
-    //   url: "/examples/assets/video/stock-video-person-drawing.mp4",
+    //   url: "./examples/assets/video/stock-video-person-drawing.mp4",
     //   altText: "",
     //   vttUrl: "",
     // },
@@ -267,6 +267,7 @@ const defaultArgs = {
     },
   },
   programContactInfo: {
+    // hide: true, // OPTIONAL
     departmentUrl: "#",
     emailUrl: "#",
   },
@@ -285,6 +286,7 @@ Default.args = {
   globalOpportunity: null,
   atAGlance: null,
   attendOnline: null,
+  programContactInfo: null,
 };
 
 /**
@@ -308,7 +310,7 @@ PageWithVideoAndMarketText.args.introContent = {
   ...PageWithVideoAndMarketText.args.introContent,
   image: undefined,
   video: {
-    url: "/examples/assets/video/stock-video-person-drawing.mp4",
+    url: "./examples/assets/video/stock-video-person-drawing.mp4",
     title: "",
     vttUrl: "",
   },

--- a/packages/app-degree-pages/src/core/constants/web-api-constants.js
+++ b/packages/app-degree-pages/src/core/constants/web-api-constants.js
@@ -39,7 +39,7 @@ const detailPageDefaultDataSource = {
     // career opportunity
     `AsuCareerOpp,` +
     // program contact
-    `DepartmentName,EmailAddr,Phone,CollegeDescr100,` +
+    `DepartmentName,PlanUrl,EmailAddr,Phone,CollegeDescr100,` +
     // application requirement
     `DescrlongExtn5,gradAdditionalRequirements,TransferAdmission,` +
     `AdmissionsDegRequirements,` +

--- a/packages/app-degree-pages/src/core/models/program-detail-types.js
+++ b/packages/app-degree-pages/src/core/models/program-detail-types.js
@@ -163,7 +163,7 @@
  *  exampleCareers?: HideProp
  *  globalOpportunity?: HideProp & GlobalOpportunityProps
  *  attendOnline?: HideProp &  AttendOnlineProps
- *  programContactInfo?: {
+ *  programContactInfo?: HideProp & {
  *      departmentUrl: string
  *      emailUrl: string
  *  }

--- a/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
@@ -61,7 +61,9 @@ function degreeDataPropResolverService(row = {}) {
     /** @return {string} */
     getPhone: () => row["Phone"],
     /** @return {string} */
-    getGDepartmentName: () => row["DepartmentName"],
+    getDepartmentName: () => row["DepartmentName"],
+    /** @return {string} */
+    getPlanUrl: () => row["PlanUrl"],
     // AsuProgramFee
     getAsuProgramFee: () => row["AsuProgramFee"],
     hasAsuProgramFee: () => row["AsuProgramFee"] === "Y",


### PR DESCRIPTION
In this PR:

# Description

It was raised an issue that the **Program Contact Info** - can’t be enabled, 
To fix that I update the component by the following actions:

- add the the attribute `hide` to allow the user to hide the section
- Add a new WEB API field `PlanUrl` so that we do not need anymore the user to provide the props
```
     departmentUrl: string
      emailUrl: string
` ``
