### PR TITLE
feat(app-rfi): render message when no terms are available

### DIFF
--- a/packages/app-rfi/src/components/controls/RfiTextArea.js
+++ b/packages/app-rfi/src/components/controls/RfiTextArea.js
@@ -14,6 +14,8 @@ const RfiTextArea = ({
   requiredIcon,
   required,
   autoFocus,
+  disabled,
+  helperText,
 }) => {
   return (
     <Field name={name}>
@@ -35,6 +37,8 @@ const RfiTextArea = ({
               className="form-control"
               required={required}
               autoFocus={autoFocus}
+              disabled={disabled}
+              placeholder={helperText}
             />
             <RfiError isError={!!isError} metaError={meta.error} />
           </div>
@@ -53,6 +57,8 @@ RfiTextArea.defaultProps = {
   requiredIcon: undefined,
   required: undefined,
   autoFocus: undefined,
+  disabled: false,
+  helperText: undefined,
 };
 
 RfiTextArea.propTypes = {
@@ -62,6 +68,8 @@ RfiTextArea.propTypes = {
   requiredIcon: PropTypes.bool,
   required: PropTypes.bool,
   autoFocus: PropTypes.bool,
+  disabled: PropTypes.bool,
+  helperText: PropTypes.string,
 };
 
 export { RfiTextArea };

--- a/packages/app-rfi/src/components/steps/AboutMe.js
+++ b/packages/app-rfi/src/components/steps/AboutMe.js
@@ -7,6 +7,7 @@ import * as Yup from "yup";
 
 import {
   RfiTextInput,
+  RfiTextArea,
   RfiEmailInput,
   RfiSelect,
   RfiPhone,
@@ -155,14 +156,26 @@ const AboutMe = () => {
         requiredIcon={values.Campus !== "ONLNE"}
         required={values.Campus !== "ONLNE"}
       />
-      <RfiSelect
-        label="When do you anticipate starting at ASU?"
-        id="EntryTerm"
-        name="EntryTerm"
-        options={termOptions}
-        requiredIcon={values.Campus !== "ONLNE"}
-        required={values.Campus !== "ONLNE"}
-      />
+      {termOptions.length ? (
+        <RfiSelect
+          label="When do you anticipate starting at ASU?"
+          id="EntryTerm"
+          name="EntryTerm"
+          options={termOptions}
+          requiredIcon={values.Campus !== "ONLNE"}
+          required={values.Campus !== "ONLNE"}
+        />
+      ) : (
+        <RfiTextArea
+          label="When do you anticipate starting at ASU?"
+          id="EntryTerm"
+          name="EntryTerm"
+          helperText="The program you are interested in is not accepting new students at this time. Please select a different program of interest, and then select the semester you would like to start."
+          disabled
+          requiredIcon={values.Campus !== "ONLNE"}
+          required={values.Campus !== "ONLNE"}
+        />
+      )}
       <RfiGdpr campus={values.Campus} />
     </>
   );


### PR DESCRIPTION
ERFI-100 Some degrees returned from the Degree Search API may not have any terms associated with them - in those instances, which are something of an edge-case, we want to display informational text to the user and block them from submitting the form. The best way to implement this, I decided, was to render the term field as a disabled textarea in this instance with the message to the user defined as placeholder text. This approach has the benefit of leaning on the form validation to prevent the user from continuing forward with the form.