### PR TITLE
fix(app-rfi): dedupe degree terms for grad programs

### DIFF
--- a/packages/app-rfi/src/components/steps/AboutMe.js
+++ b/packages/app-rfi/src/components/steps/AboutMe.js
@@ -80,7 +80,13 @@ const AboutMe = () => {
                 }`,
                 text: termValue[1].split(":")[0],
               }));
-            setTermOptions(termData);
+            // Dedupe based on object key property as dupe terms can occur due
+            // to multiple campus offerings.
+            // Explanation: https://stackoverflow.com/a/56768137
+            const dedupedTermData = [
+              ...new Map(termData.map(item => [item.key, item])).values(),
+            ];
+            setTermOptions(dedupedTermData);
           })
           .catch(error => new Error(error));
       }


### PR DESCRIPTION
ERFI-101 For Grad program we pull the term data from the degree search REST API program record… and in some cases, the applyInfo value includes entries for terms per multiple campuses. Because the value we send to the RFI Submit Handler strips out those additional details, the solution here is to dedupe the options based on the key.