### PR TITLE
fix(component-carouselcomponent-carousel): UDS-911 - storybook broken

### DIFF
--- a/packages/component-carousel/.storybook/main.js
+++ b/packages/component-carousel/.storybook/main.js
@@ -12,6 +12,7 @@ module.exports = {
   webpackFinal: async config => {
     return {
       ...config,
+      module: { ...config.module, rules: devConfig.module.rules },
       resolve: {
         extensions: [".js", ".jsx"],
         alias: {

--- a/packages/component-carousel/package.json
+++ b/packages/component-carousel/package.json
@@ -69,6 +69,8 @@
     "jsdom-screenshot": "^4.0.0",
     "postcss": "^7.0.2",
     "postcss-flexbugs-fixes": "^5.0.2",
+    "sass": "^1.39.2",
+    "sass-loader": "^10",
     "semantic-release": "^17.4.2",
     "semantic-release-monorepo": "^7.0.4",
     "storybook-css-modules-preset": "^1.0.7",

--- a/packages/component-carousel/src/core/components/BaseCarousel/styles.scss
+++ b/packages/component-carousel/src/core/components/BaseCarousel/styles.scss
@@ -1,10 +1,9 @@
 // Required Core Stylesheet for @glidejs/glide - Import with loader inline.
-import "!style-loader!css-loader!sass-loader!../../../../../../node_modules/@glidejs/glide/src/assets/sass/glide.core.scss";
-
+@import "@glidejs/glide/src/assets/sass/glide.core.scss";
 // Optional styles can be included ala...
 //import "!style-loader!css-loader!sass-loader!../../../../../node_modules/@glidejs/glide/src/assets/sass/glide.theme.scss";
 // Copy that and drop into this directory and adapt for us...
-import "!style-loader!css-loader!sass-loader!./glide/glide.theme.scss";
+@import "./glide/glide.theme.scss";
 
 // Alternatively, Core scss for @glidejs/glide can be included from preview.js with
 //import "!style-loader!css-loader!sass-loader!../../../node_modules/@glidejs/glide/src/assets/sass/glide.core.scss";

--- a/packages/component-carousel/webpack/webpack.common.js
+++ b/packages/component-carousel/webpack/webpack.common.js
@@ -8,6 +8,17 @@ const common = {
   module: {
     rules: [
       {
+        test: /\.s[ac]ss$/i,
+        use: [
+          // Creates `style` nodes from JS strings
+          "style-loader",
+          // Translates CSS into CommonJS
+          "css-loader",
+          // Compiles Sass to CSS
+          "sass-loader",
+        ],
+      },
+      {
         test: /\.(jsx|js)?$/,
         exclude: /node_modules/,
         use: [


### PR DESCRIPTION
 In this PR:

# Description

The new version of style/css/loader breaks the storybook. 
To  address the issue  I updated the SCSS loader strategy, I add  a new rule in webpack config.
I also updated the syntax of how the GlideJS base style is loaded