### PR TITLE
feat(component-carousel): add focus rule for bullet image items

### DIFF
--- a/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
+++ b/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
@@ -313,6 +313,9 @@ $uds-color-brand-gold: #ffc627; // ASU Gold brand color
                 margin: 0;
               }
             }
+            .bullet-image-container:focus {
+              box-shadow: 0px 0px 0px 2px #fff, 0px 0px 0px 4px #191919 !important;
+            }
 
             .#{$glide-class}__bullet--active {
               background-color: transparent;


### PR DESCRIPTION
This solves a bug[ raised here](https://asudev.jira.com/browse/ACMSD9-439), whereby the focus is blue.