### PR TITLE
fix(bootstrap4-theme): modal updated to skip template

### DIFF
--- a/packages/bootstrap4-theme/helpers/wrapper.js
+++ b/packages/bootstrap4-theme/helpers/wrapper.js
@@ -46,7 +46,7 @@ export const UnityStory = (props) => {
   )
 }
 
-export const createStory = (componentJSX, initFunc=null) => {
+export const createStory = (componentJSX, initFunc=null, omitTemplate=false) => {
 
   const Template = ({...args}) => {
     if(initFunc) {
@@ -60,10 +60,12 @@ export const createStory = (componentJSX, initFunc=null) => {
       }
     }
 
+    const componentCode = omitTemplate ? componentJSX : template(componentJSX, args.template);
+
     return (
       <div>
         { args.header && Basic }
-        { template(componentJSX, args.template) }
+        { componentCode }
         { args.footer && GlobalElementsOnly  }
       </div>
     )

--- a/packages/bootstrap4-theme/stories/components/modals/modals.stories.js
+++ b/packages/bootstrap4-theme/stories/components/modals/modals.stories.js
@@ -19,5 +19,6 @@ export const ModalComponent = createStory(
       </div>
     </div>
   </div>,
-  initModals
+  initModals,
+  true
 );


### PR DESCRIPTION
I would like at some point to have a single second argument to `createStory()`, an object which takes various optional parameters. Included in this would be things recently discussed in a [separate slack thread](https://asu-community.slack.com/archives/CT01Z74KY/p1631700837062500). For now I think this approach is fine.