### PR TITLE
fix(bootstrap4-theme): remove padding

### DIFF
--- a/packages/bootstrap4-theme/helpers/templates/1-column.js
+++ b/packages/bootstrap4-theme/helpers/templates/1-column.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export default (content) => {
   return (
-    <div class="container py-5">
+    <div class="container">
       <div class="row">
         <div class="col-12">
           {content}

--- a/packages/bootstrap4-theme/helpers/templates/2-column.js
+++ b/packages/bootstrap4-theme/helpers/templates/2-column.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export default (content) => {
   return (
-    <div class="container py-5">
+    <div class="container">
       <div class="row">
         <div class="col-6">
           {content}

--- a/packages/bootstrap4-theme/helpers/templates/3-column.js
+++ b/packages/bootstrap4-theme/helpers/templates/3-column.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export default (content) => {
   return (
-    <div class="container py-5">
+    <div class="container">
       <div class="row">
         <div class="col-4">
           {content}

--- a/packages/bootstrap4-theme/helpers/templates/4-column.js
+++ b/packages/bootstrap4-theme/helpers/templates/4-column.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export default (content) => {
   return (
-    <div class="container py-5">
+    <div class="container">
       <div class="row">
         <div class="col-3">
           {content}

--- a/packages/bootstrap4-theme/helpers/templates/full-width.js
+++ b/packages/bootstrap4-theme/helpers/templates/full-width.js
@@ -3,7 +3,7 @@ import React from "react";
 export default (content) => {
   return (
     <div> {/* Storybook Bug, all options must have equal depth when using controls to switch */}
-      <div class="row no-gutter py-5">
+      <div class="row no-gutter">
         <div class="col-md-12 uds-full-width">
           {/* Component start */}
             { content }


### PR DESCRIPTION
The intention of this padding was to make Storybook stories look a bit more 'real' by not having the components touch the header and footer, but I think having something here that CMSs shouldn't have in their templates introduces the type of confusion we're trying to avoid with recent work. 