### PR TITLE
feat(bootstrap4-theme): allow header and footer comparison testing

### DIFF
--- a/packages/bootstrap4-theme/stories/components/global-footer/global-footer.stories.js
+++ b/packages/bootstrap4-theme/stories/components/global-footer/global-footer.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
-export default { title: 'Components/Global Footer' };
+import { createComponent, createStory } from '../../../helpers/wrapper.js';
+export default createComponent('Global Footer');
 
 import {
   GlobalElementsOnly,
@@ -13,34 +14,12 @@ import {
   SixColumns,
 } from './global-footer.components.js';
 
-const GlobalElementsOnlyTemplate = ({ ...args }) => (
-  <div>{GlobalElementsOnly}</div>
-);
-export const GlobalElementsOnlyHeader = GlobalElementsOnlyTemplate.bind({});
-
-const ZeroColumnsTemplate = ({ ...args }) => <div>{ZeroColumns}</div>;
-export const ZeroColumnsHeader = ZeroColumnsTemplate.bind({});
-
-const OneColumnTemplate = ({ ...args }) => <div>{OneColumn}</div>;
-export const OneColumnHeader = OneColumnTemplate.bind({});
-
-const OneColumnNoLogoOrSocialTemplate = ({ ...args }) => (
-  <div>{OneColumnNoLogoOrSocial}</div>
-);
-export const OneColumnNoLogoOrSocialHeader =
-  OneColumnNoLogoOrSocialTemplate.bind({});
-
-const TwoColumnsTemplate = ({ ...args }) => <div>{TwoColumns}</div>;
-export const TwoColumnsHeader = TwoColumnsTemplate.bind({});
-
-const ThreeColumnsTemplate = ({ ...args }) => <div>{ThreeColumns}</div>;
-export const ThreeColumnsHeader = ThreeColumnsTemplate.bind({});
-
-const FourColumnsTemplate = ({ ...args }) => <div>{FourColumns}</div>;
-export const FourColumnsHeader = FourColumnsTemplate.bind({});
-
-const FiveColumnsTemplate = ({ ...args }) => <div>{FiveColumns}</div>;
-export const FiveColumnsHeader = FiveColumnsTemplate.bind({});
-
-const SixColumnsTemplate = ({ ...args }) => <div>{SixColumns}</div>;
-export const SixColumnsHeader = SixColumnsTemplate.bind({});
+export const GlobalElementsOnlyExample = createStory(GlobalElementsOnly);
+export const ZeroColumnsExample = createStory(ZeroColumns);
+export const OneColumnExample = createStory(OneColumn);
+export const OneColumnNoLogoOrSocialExample = createStory(OneColumnNoLogoOrSocial);
+export const TwoColumnsExample = createStory(TwoColumns);
+export const ThreeColumnsExample = createStory(ThreeColumns);
+export const FourColumnsExample = createStory(FourColumns);
+export const FiveColumnsExample = createStory(FiveColumns);
+export const SixColumnsExample = createStory(SixColumns);

--- a/packages/bootstrap4-theme/stories/components/global-header/global-header.stories.js
+++ b/packages/bootstrap4-theme/stories/components/global-header/global-header.stories.js
@@ -1,3 +1,7 @@
+import React from 'react';
+import { createComponent, createStory } from '../../../helpers/wrapper.js';
+export default createComponent('Global Header');
+
 import {
   Basic,
   DropDownMenus,
@@ -6,27 +10,10 @@ import {
   ScrolledState,
   Partner,
 } from './global-header.components.js';
-import React from 'react';
-export default { title: 'Components/Global Header' };
 
-const BasicTemplate = ({ ...args }) => <div>{Basic}</div>;
-
-const DropDownMenusTemplate = ({ ...args }) => <div>{DropDownMenus}</div>;
-
-const NoNavigationTemplate = ({ ...args }) => <div>{NoNavigation}</div>;
-
-const NoNavigationAndWithButtonsTemplate = ({ ...args }) => (
-  <div>{NoNavigationAndWithButtons}</div>
-);
-
-const ScrolledStateTemplate = ({ ...args }) => <div>{ScrolledState}</div>;
-
-const PartnerTemplate = ({ ...args }) => <div>{Partner}</div>;
-
-export const BasicExample = BasicTemplate.bind({});
-export const DropDownMenusExample = DropDownMenusTemplate.bind({});
-export const NoNavigationExample = NoNavigationTemplate.bind({});
-export const NoNavigationAndWithButtonsExample =
-  NoNavigationAndWithButtonsTemplate.bind({});
-export const ScrolledStateExample = ScrolledStateTemplate.bind({});
-export const PartnerExample = PartnerTemplate.bind({});
+export const BasicExample = createStory(Basic);
+export const DropDownMenusExample = createStory(DropDownMenus);
+export const NoNavigationExample = createStory(NoNavigation);
+export const NoNavigationAndWithButtonsExample = createStory(NoNavigationAndWithButtons);
+export const ScrolledStateExample = createStory(ScrolledState);
+export const PartnerExample = createStory(Partner);


### PR DESCRIPTION
This allows the header and footer to be shown in the header and footer stories, which was blocked before. It's not always sensible, the header will draw on top of itself if you turn on the header in a header story, but I think the benefit outweighs that because you can now do a header / footer comparison with more ease.