### PR TITLE
UDS-930 fix blockquotes bug

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_blockquotes.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_blockquotes.scss
@@ -262,7 +262,7 @@ blockquote:before {
   cite.name,
   cite.description {
     display: flex;
-    justify-content: flex-start;
+    justify-content: center;
   }
 
   &.with-image img {

--- a/packages/bootstrap4-theme/stories/components/blockquote/blockquote.stories.js
+++ b/packages/bootstrap4-theme/stories/components/blockquote/blockquote.stories.js
@@ -79,7 +79,7 @@ export const BlockquoteWithImage = createStory(
       </blockquote>
     </div>
 
-    <section class="bg-gray-2 my-12 py-4">
+    <section class="bg-gray-2">
       <div class="uds-blockquote with-image reversed uds-content-align">
         <img
           src="https://placeimg.com/300/300/any"
@@ -123,7 +123,7 @@ export const BlockquoteNoCitation = createStory(
     </div>
 
 
-    <div class="p-md-4 bg-gray-7">
+    <div class="bg-gray-7">
       <div class="uds-blockquote no-citation with-image reversed uds-content-align">
         <img
           src="https://placeimg.com/300/300/tech"
@@ -167,7 +167,7 @@ export const BlockquoteAltCitation = createStory(
       </blockquote>
     </div>
 
-    <section class="bg-gray-1 mt-8 pt-md-4">
+    <section class="bg-gray-1">
       <div class="uds-blockquote alt-citation accent-maroon uds-content-align">
         <svg
           title="Open quote"
@@ -219,7 +219,7 @@ export const TestimonialsNoImage = createStory(
     </div>
 
 
-    <div class="pt-md-4 bg-gray-2">
+    <div class="bg-gray-2">
       <div class="uds-blockquote uds-testimonial accent-maroon uds-content-align">
         <svg
           title="Open quote"
@@ -247,7 +247,7 @@ export const TestimonialsNoImage = createStory(
 );
 
 export const TestimonialsWithImage = createStory(
-  <div class="mt-8">
+  <div>
     <div class="uds-blockquote uds-testimonial with-image alt-citation accent-maroon uds-content-align">
       <img
         src="https://placeimg.com/600/400/arch"
@@ -273,7 +273,7 @@ export const TestimonialsWithImage = createStory(
       </blockquote>
     </div>
 
-    <div class="pt-md-4 bg-gray-7">
+    <div class="bg-gray-7">
       <div class="uds-blockquote uds-testimonial with-image alt-citation accent-gold text-white uds-content-align">
         <img
           src="https://placeimg.com/400/400/tech"


### PR DESCRIPTION
I'm not even sure if this is something we want to do, given the impact it'll have. The bug [is here](https://asudev.jira.com/browse/UDS-930). The padding issue is simple to solve, but the alignment of the citation is more problematic. It will be a bigger problem if the `name` is longer, as it'll happen in wider spaces. I think this markup makes more sense, as both the name and description should be aligned to the right of the line, but it might be annoying for people who have to update.