### PR TITLE
style(bootstrap4-theme):  fix heading space UDS-934

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_image-overlap.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_image-overlap.scss
@@ -23,8 +23,12 @@
 
   .content-wrapper {
     background-color: $uds-color-base-white;
-    padding: 40px;
+    padding: 32px;
     overflow: hidden;
+
+    h1, h2, h3, h4, h5 {
+      margin-top: 0;
+    }
   }
 }
 
@@ -53,6 +57,7 @@
     }
 
     .content-wrapper {
+      padding: 40px;
       grid-column: 3 / span 2;
       grid-row: 2 / span 1;
     }


### PR DESCRIPTION
In this PR:

# Description

I fixed the following style issues:

- Text on mobile has extra padding added and it makes it too narrow. 
- Too much spacing between image and header on mobile. 

I set a pdding of 40px on desktop and 32px on mobile
[XD FILE ](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/674ebe9d-bcfd-48c9-a3eb-37efe95f4f4a/)

# Before this PR

## Desktop

<img height = "300px"  src = "https://user-images.githubusercontent.com/7423476/134337505-1539f716-d5d8-41f2-999b-0d11ff3ae7f8.png" />

# After this PR

## Desktop
<img height = "300px"  src = "https://user-images.githubusercontent.com/7423476/134337673-98e72c3a-d7af-4e29-94b8-a5de6b394d16.png" />

# Before this PR

## Mobile
<img height = "300px"  src = "https://user-images.githubusercontent.com/7423476/134337542-827e09aa-cd48-4298-993e-deacecc81873.png" />

# After this PR

## Mobile
<img height = "300px"  src = "https://user-images.githubusercontent.com/7423476/134337736-e7fddc90-1a1d-4753-99fe-ef17ae2ed491.png" />



