### PR TITLE
style(bootstrap4-theme): fix style for quote  image background

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_quote-image-background.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_quote-image-background.scss
@@ -9,7 +9,7 @@
   height: auto;
   justify-content: center;
   max-width: 1920px;
-  padding: 48px 96px;
+  padding: 2rem;
   width: 100%;
 
   @media screen and (max-width: $uds-breakpoint-sm) {

--- a/packages/bootstrap4-theme/stories/components/quote-image-background/quote-image-background.stories.js
+++ b/packages/bootstrap4-theme/stories/components/quote-image-background/quote-image-background.stories.js
@@ -10,48 +10,8 @@ export const Default = createStory(
         "linear-gradient(180deg, #19191900 0%, #191919c9 100%), url('https://source.unsplash.com/random/1920x1200')",
     }}
   >
-    <div class="uds-quote-image-background-container uds-content-align">
-      <div class="uds-blockquote uds-testimonial accent-gold">
-        <svg
-          title="Open quote"
-          role="presentation"
-          viewBox="0 0 302.87 245.82"
-        >
-          <path d="M113.61,245.82H0V164.56q0-49.34,8.69-77.83T40.84,35.58Q64.29,12.95,100.67,0l22.24,46.9q-34,11.33-48.72,31.54T58.63,132.21h55Zm180,0H180V164.56q0-49.74,8.7-78T221,35.58Q244.65,12.95,280.63,0l22.24,46.9q-34,11.33-48.72,31.54t-15.57,53.77h55Z" />
-        </svg>
-        <blockquote>
-          <p>
-            We hold these truths to be self-evident, that all men are
-            created equal, that they are endowed by their Creator with
-            certain unalienable Rights, that among these are Life, Liberty
-            and the pursuit of Happiness.
-          </p>
-          <div class="citation">
-            <cite class="name">Thomas Jefferson</cite>
-            <cite class="description">
-              The Declaration of Independence
-            </cite>
-          </div>
-        </blockquote>
-      </div>
-    </div>
-  </div>
-);
-
-export const WithImage = createStory(
-  <div
-    class="uds-quote-image-background"
-    style={{
-      'background-image':
-        "linear-gradient(180deg, #19191900 0%, #191919c9 100%), url('https://source.unsplash.com/random/1920x1200')",
-    }}
-  >
-    <div class="uds-quote-image-background-container uds-content-align">
-      <div class="uds-blockquote uds-testimonial with-image accent-gold">
-        <img
-          src="https://placeimg.com/600/400/arch"
-          alt="Pretend this is Han Solo"
-        />
+    <div class="uds-content-align">
+      <div class="uds-blockquote accent-gold">
         <svg
           title="Open quote"
           role="presentation"


### PR DESCRIPTION
In this PR:

# Description

I fixed the following issues:

- The quote’s text should be left aligned. 
- Delete  “With image” story from storybook

@imorale2 about 
> Image should be full width in mobile
this looks already working as expected

# Before this PR

<img height = "300px"  
src = "https://user-images.githubusercontent.com/7423476/134500581-9a47c1ce-b916-4e1f-b72d-21e07fea4af8.png" />

#  After this PR

<img height = "300px"  
src = "https://user-images.githubusercontent.com/7423476/134500610-938d9e3b-6383-4b53-8dac-41c056becf47.png" />
