### PR TITLE
feat(component-news): enable optional header

### DIFF
--- a/packages/component-news/src/core/components/BaseFeed/index.js
+++ b/packages/component-news/src/core/components/BaseFeed/index.js
@@ -33,11 +33,13 @@ const BaseFeed = ({
   return (
     <FeedContainerProvider
       renderHeader={
-        <FeedHeader
-          header={header}
-          ctaButton={ctaButton}
-          defaultProps={defaultProps}
-        />
+        header && ctaButton ? (
+          <FeedHeader
+            header={header}
+            ctaButton={ctaButton}
+            defaultProps={defaultProps}
+          />
+        ) : null
       }
       renderBody={<FeedBody>{children}</FeedBody>}
       dataTransformer={transformData}


### PR DESCRIPTION
In this PR:

# Description

I implement the `header` to be optional.

so if the user does not provide the `header` prop the component will not show neither the `header` nor the `cta button`
I simply copied the same behaviour which is still place for the **Events Component**
