### PR TITLE
fix: no news text and type filter

### DIFF
--- a/packages/component-events/src/core/constants/filter-fields.js
+++ b/packages/component-events/src/core/constants/filter-fields.js
@@ -1,5 +1,11 @@
 // @ts-check
 
-const filterFields = ["eventTopics", "eventUnits", "interests", "audiences"];
+const filterFields = [
+  "eventTopics",
+  "eventUnits",
+  "interests",
+  "audiences",
+  "eventTypes",
+];
 
 export { filterFields };

--- a/packages/component-events/src/core/transformers/data.transfromer.js
+++ b/packages/component-events/src/core/transformers/data.transfromer.js
@@ -16,6 +16,7 @@ const transformData = data => ({
   audiences: data.node.audiences,
   eventUnits: data.node.event_units,
   eventTopics: data.node.event_topics,
+  eventTypes: data.node.event_types,
   eventButtonUrl: data.node.ticketing_rsvp_url,
   eventButtonText: data.node.ticketing_rsvp_txt,
 });

--- a/packages/component-news/src/core/constants/filter-fields.js
+++ b/packages/component-news/src/core/constants/filter-fields.js
@@ -1,5 +1,5 @@
 // @ts-check
 
-const filterFields = ["newsUnits", "interests", "audiences"];
+const filterFields = ["newsUnits", "interests", "audiences", "eventTypes"];
 
 export { filterFields };

--- a/packages/component-news/src/core/transformers/transform-data.js
+++ b/packages/component-news/src/core/transformers/transform-data.js
@@ -12,6 +12,7 @@ const transformData = ({ node }, index) => {
     buttonLink: node.path,
     interests: node.interests,
     newsUnits: node.news_units,
+    eventTypes: node.event_types,
   };
 };
 

--- a/packages/components-core/src/components/FeedAnatomy/FeedContainerContext.js
+++ b/packages/components-core/src/components/FeedAnatomy/FeedContainerContext.js
@@ -58,12 +58,15 @@ const FeedContainerProvider = ({
           <span>Error, try again!</span>
         ) : (
           <>
-            {loading && !feeds ? (
+            {loading && !feeds && (
               <div className="text-center mt-4">
                 <Loader />
               </div>
-            ) : (
+            )}
+            {feeds?.length ? (
               renderBody
+            ) : (
+              <p className="text-center">No news to show.</p>
             )}
           </>
         )}


### PR DESCRIPTION
## Description

This pr adds the "no news" text when there is no feed and also adds the eventTypes field to the possible filters fields list.