### PR TITLE
fix(app-degree-pages):  update ApplicationRequirements to show content based on Degree type

### DIFF
--- a/packages/app-degree-pages/src/components/DetailPage/components/ApplicationRequirements/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/components/ApplicationRequirements/index.js
@@ -1,17 +1,16 @@
+/* eslint-disable react/no-danger */
 // @ts-check
 import {
   Button,
   Accordion,
-} from "@asu-design-system/components-core/src/components";
+  sanitizeDangerousMarkup,
+} from "@asu-design-system/components-core";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
 
-import {
-  accordionCardPropShape,
-  progDetailSectionIds,
-} from "../../../../core/models";
+import { progDetailSectionIds } from "../../../../core/models";
 
 /**
  * @typedef {import('../../../../core/models/program-detail-types').ApplicationRequirementsProps} ApplicationRequirementsProps
@@ -35,12 +34,11 @@ const ButtonList = styled.ul`
   }
 `;
 
-/**
- * @param {ApplicationRequirementsProps} props
- * @returns {JSX.Element}
- */
-function ApplicationRequirements({ accordionCards }) {
-  const items = [
+const undergraduateTemplate = (
+  additionalRequirements = "",
+  transferRequirements = ""
+) => {
+  const generalRequirements = [
     {
       label: "Freshman",
       href: "https://admission.asu.edu/freshman/apply",
@@ -56,30 +54,36 @@ function ApplicationRequirements({ accordionCards }) {
     },
   ];
 
-  // clean up those records with `header` or `body` with empty/null values
-  const reqList = accordionCards.filter(
-    ({ content }) => content.body?.trim() && content.header?.trim()
-  );
+  const undergradRequirements = [];
+
+  if (additionalRequirements.trim())
+    undergradRequirements.push({
+      content: {
+        header: "Additional Requirements",
+        body: additionalRequirements,
+      },
+    });
+
+  if (transferRequirements.trim())
+    undergradRequirements.push({
+      content: {
+        header: "Transfer Admission Requirements",
+        body: transferRequirements,
+      },
+    });
 
   return (
-    <section
-      id={progDetailSectionIds.applicationRequirements.targetIdName}
-      data-testid="application-requirements"
-    >
-      <h2>
-        <span className="highlight-gold">Application requirements</span>
-      </h2>
-      <h3 className="mt-4">General university admission requirements</h3>
+    <>
       <p>
         All students are required to meet general university admission
         requirements
       </p>
       <ButtonList
         className={classNames("", {
-          "mb-0": reqList.length === 0,
+          "mb-0": undergradRequirements.length === 0,
         })}
       >
-        {items.map(({ label, href }) => (
+        {generalRequirements.map(({ label, href }) => (
           <li key={label}>
             <Button
               ariaLabel={label}
@@ -91,17 +95,50 @@ function ApplicationRequirements({ accordionCards }) {
           </li>
         ))}
       </ButtonList>
-      {reqList.length > 0 && (
+      {undergradRequirements.length > 0 && (
         <div className="mt-2 mb-4">
-          <Accordion cards={reqList} openedCard={1} />
+          <Accordion cards={undergradRequirements} openedCard={1} />
         </div>
+      )}
+    </>
+  );
+};
+
+/**
+ * @param {ApplicationRequirementsProps} props
+ * @returns {JSX.Element}
+ */
+function ApplicationRequirements({
+  graduateRequirements,
+  transferRequirements,
+  additionalRequirements,
+}) {
+  return (
+    <section
+      id={progDetailSectionIds.applicationRequirements.targetIdName}
+      data-testid="application-requirements"
+    >
+      <h2>
+        <span className="highlight-gold">Application requirements</span>
+      </h2>
+      <h3 className="mt-4">General university admission requirements</h3>
+      {graduateRequirements ? (
+        <div
+          dangerouslySetInnerHTML={sanitizeDangerousMarkup(
+            graduateRequirements
+          )}
+        />
+      ) : (
+        undergraduateTemplate(transferRequirements, additionalRequirements)
       )}
     </section>
   );
 }
 
 ApplicationRequirements.propTypes = {
-  accordionCards: PropTypes.arrayOf(accordionCardPropShape).isRequired,
+  graduateRequirements: PropTypes.string,
+  transferRequirements: PropTypes.string,
+  additionalRequirements: PropTypes.string,
 };
 
 export { ApplicationRequirements };

--- a/packages/app-degree-pages/src/components/DetailPage/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/index.js
@@ -187,20 +187,13 @@ const DetailPage = ({
 
                 {!applicationRequirements?.hide ? (
                   <ApplicationRequirements
-                    accordionCards={[
-                      {
-                        content: {
-                          header: "Additional Requirements",
-                          body: resolver.getAdditionalRequirements(),
-                        },
-                      },
-                      {
-                        content: {
-                          header: "Transfer Admission Requirements",
-                          body: resolver.getTransferAdmission(),
-                        },
-                      },
-                    ]}
+                    graduateRequirements={
+                      resolver.isGradProgram()
+                        ? resolver.getGraduateRequirements()
+                        : null
+                    }
+                    additionalRequirements={resolver.getDescrLongExtented5()}
+                    transferRequirements={resolver.getTransferAdmission()}
                   />
                 ) : null}
 

--- a/packages/app-degree-pages/src/components/DetailPage/index.stories.js
+++ b/packages/app-degree-pages/src/components/DetailPage/index.stories.js
@@ -297,6 +297,18 @@ Default.args = {
 /**
  * @type {{ args: AppProps }}
  */
+export const DefaultWithGraduateDegree = Template.bind({});
+DefaultWithGraduateDegree.args = {
+  ...defaultArgs,
+  dataSource: {
+    ...defaultArgs.dataSource,
+    acadPlan: "LAAUDAUDD",
+  },
+};
+
+/**
+ * @type {{ args: AppProps }}
+ */
 export const WithContent = Template.bind({});
 WithContent.args = {
   ...defaultArgs,

--- a/packages/app-degree-pages/src/core/constants/web-api-constants.js
+++ b/packages/app-degree-pages/src/core/constants/web-api-constants.js
@@ -46,7 +46,7 @@ const detailPageDefaultDataSource = {
     // program contact
     `DepartmentName,PlanUrl,EmailAddr,Phone,CollegeDescr100,` +
     // application requirement
-    `DescrlongExtn5,gradAdditionalRequirements,TransferAdmission,` +
+    `DescrlongExtn5,TransferAdmission,gradAdditionalRequirements,AdmissionsDegRequirements,` +
     `AdmissionsDegRequirements,` +
     // Global opportunity
     `globalExp,` +

--- a/packages/app-degree-pages/src/core/models/program-detail-types.js
+++ b/packages/app-degree-pages/src/core/models/program-detail-types.js
@@ -67,7 +67,9 @@
 
 /**
  * @typedef {{
- *  accordionCards: import("./shared-types").AccordionCard []
+ *  graduateRequirements?: string
+ *  additionalRequirements?: string
+ *  transferRequirements?: string
  * }} ApplicationRequirementsProps
  */
 

--- a/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
@@ -37,6 +37,7 @@ function degreeDataPropResolverService(row = {}) {
     getAcadPlan: () => row["AcadPlan"],
     getDegree: () => row["Degree"],
     isUndergradProgram: () => isUndergradProgram(row),
+    isGradProgram: () => !isUndergradProgram(row),
     /** @returns {"undergrad" |  "graduate"} */
     getProgramType: () => (isUndergradProgram(row) ? "undergrad" : "graduate"),
     getDegreeDesc: () => row["DegreeDescr"],
@@ -45,24 +46,27 @@ function degreeDataPropResolverService(row = {}) {
     getCurriculumUrl: () => row["CurriculumUrl"]?.trim(),
     getDescrLongExtented5: () => row["DescrlongExtn5"],
     getTransferAdmission: () => row["TransferAdmission"],
-    getAdditionalRequirements: () => {
-      if (isUndergradProgram(row)) {
-        return row["DescrlongExtn5"];
-      }
-
+    getGraduateRequirements: () => {
       /** @type {Array<Array>} */
-      const requirementList = row["gradAdditionalRequirements"];
-      if (requirementList?.length > 0) {
+      const rawRequirement1 = row["gradAdditionalRequirements"];
+      let gradRequirement1 = "";
+      if (rawRequirement1?.length > 0) {
         // requirement[0]: acadPlan. ex `LAAUDAUDD`
         // requirement[1]: brief decription of requirement
         // ex 88 credit hours, a written and oral comprehensive exam
         // requirement[2]: unknown code. ex AUD88AUDD
-        const requirements = requirementList
+        const flatRequirement1 = rawRequirement1
           .map(requirement => requirement?.[1])
           .join(" ");
-        return requirements ? `<p>${requirements}</p>` : "";
+
+        // AdmissionsDegRequirements
+        gradRequirement1 = flatRequirement1 ? `<p>${flatRequirement1}</p>` : "";
       }
-      return "";
+
+      /** @type {string} */
+      const gradRequirement2 = row["AdmissionsDegRequirements"];
+
+      return `${gradRequirement1}${gradRequirement2}`;
     },
     isOnline: () => row["managedOnlineCampus"],
     getOnlineMajorMapURL: () => row["onlineMajorMapURL"],


### PR DESCRIPTION
# Description

This PR contains an update for **Application Requirements** section, 
This section will display different content based on degree type (grad / undergrad)

Based on the information I collected in this [ticket UDS-597](https://asudev.jira.com/browse/UDS-597)   the logic should be 

> If the degree is an undergraduate degree:
> 
> Additional requirements (if there) = DescrlongExtn5 
> 
> Transfer admission (if there) = TransferAdmission
> 
> If the degree is a grad degree:
> 
> Additional requirements (if there) = gradAdditionalRequirements
> 
> Transfer admission (if there) = TransferAdmission

II tried the field **gradAdditionalRequirements** which does not look to provide much information, 
this is what i get using the acad plan code LAAUDAUDD 
https://degreesearch-proxy.apps.asu.edu/degreesearch/?fields=gradAdditionalRequirements&method=findDegreeByAcadPlan&init=false&acadPlan=LAAUDAUDD

```JSON
{
    "programs": [
        {
            "gradAdditionalRequirements": [
                [
                    "LAAUDAUDD",
                    "88 credit hours, a written and oral comprehensive exam",
                    "AUD88AUDD"]
                ]
        }
      ]
  }

```

Assuming that we interested only on the second item, the degree page would display something like this
![image](https://user-images.githubusercontent.com/7423476/137302987-00df098a-1d7d-4e16-b1a9-54753326f57d.png)

Which is close to the [other degree page ](https://webapp4.asu.edu/programs/t5/majorinfo/ASU00/LAAUDAUDD/graduate/false) 

![image](https://user-images.githubusercontent.com/7423476/137303090-b75bc52d-6f38-41a3-99b2-ea0b15b2eb66.png)

But I  feel there are missing informations

let me know your thoughts