### PR TITLE
style(component-carousel): Uds 1011 carousel remove image caption width restriction

### DIFF
--- a/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
+++ b/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
@@ -425,6 +425,7 @@ $uds-color-brand-gold: #ffc627; // ASU Gold brand color
       figcaption *,
       .uds-caption-text {
         color: $uds-color-base-gray-7;
+        max-width: 100%;
       }
 
       @include li-inactive-border;


### PR DESCRIPTION
# Description

Image caption contains max width of 75ch set it in uds-bootstrap
I override the rule to fix the only the image carousel caption, 
the UDS-boostrap CSS it work as usual with a max width of **75ch**

# Before this PR

![image](https://user-images.githubusercontent.com/7423476/137475834-a448ecbd-e3d7-4828-a7a3-2b19aa26690f.png)

# After this PR

![image](https://user-images.githubusercontent.com/7423476/137475895-068e5933-93b8-4e17-9700-b39caf073b79.png)
