### PR TITLE
fix(component-events,component-news): no feed default text fixes

### DIFF
--- a/packages/component-events/src/core/components/BaseFeed/index.js
+++ b/packages/component-events/src/core/components/BaseFeed/index.js
@@ -36,6 +36,7 @@ const BaseFeed = ({ children, header, ctaButton, dataSource, maxItems }) => (
     dataFilter={filterData}
     dataSource={dataSource}
     defaultProps={defaultProps}
+    noFeedText="No events to show."
     maxItems={maxItems || defaultProps.maxItems}
   />
 );

--- a/packages/component-news/src/core/components/BaseFeed/index.js
+++ b/packages/component-news/src/core/components/BaseFeed/index.js
@@ -52,6 +52,7 @@ const BaseFeed = ({
       dataFilter={filterData}
       dataSource={dataSource}
       defaultProps={defaultProps}
+      noFeedText="No news to show."
       maxItems={maxItems || defaultProps.maxItems}
     />
   );

--- a/packages/components-core/src/components/FeedAnatomy/FeedContainerContext.js
+++ b/packages/components-core/src/components/FeedAnatomy/FeedContainerContext.js
@@ -20,6 +20,7 @@ const FeedContext = createContext(null);
  *  dataTransformer?: (data: object) => object
  *  dataFilter?: (data: object, filters: string) => object
  *  defaultProps: import("./feed-types").FeedType
+ *  noFeedText: string
  * }} props
  * @returns {JSX.Element}
  *
@@ -27,6 +28,7 @@ const FeedContext = createContext(null);
 const FeedContainerProvider = ({
   defaultProps,
   dataSource: pDataSource,
+  noFeedText,
   renderHeader,
   renderBody,
   dataTransformer = item => item,
@@ -58,16 +60,14 @@ const FeedContainerProvider = ({
           <span>Error, try again!</span>
         ) : (
           <>
-            {loading && !feeds && (
+            {loading && !feeds?.length && (
               <div className="text-center mt-4">
                 <Loader />
               </div>
             )}
-            {feeds?.length ? (
-              renderBody
-            ) : (
-              <p className="text-center">No news to show.</p>
-            )}
+            {feeds?.length
+              ? renderBody
+              : !loading && <p className="text-center">{noFeedText}</p>}
           </>
         )}
       </Container>
@@ -81,6 +81,7 @@ FeedContainerProvider.propTypes = {
   maxItems: PropTypes.number,
   dataTransformer: PropTypes.func,
   dataFilter: PropTypes.func,
+  noFeedText: PropTypes.string,
 };
 
 export { FeedContainerProvider, FeedContext };


### PR DESCRIPTION
## Description

Pr to address fixes on the default text when no feed is presented, on `component-events` and `component-news`. Also fixes issue that the default text was showed on loading state