### PR TITLE
fix(bootstrap4-theme): fix typo

### DIFF
--- a/packages/bootstrap4-theme/helpers/templates/full-width.js
+++ b/packages/bootstrap4-theme/helpers/templates/full-width.js
@@ -3,8 +3,8 @@ import React from "react";
 export default (content) => {
   return (
     <div> {/* Storybook Bug, all options must have equal depth when using controls to switch */}
-      <div class="row no-gutter">
-        <div class="col-md-12 uds-full-width">
+      <div class="row no-gutters">
+        <div class="col uds-full-width">
           {/* Component start */}
             { content }
           {/* Component end */}


### PR DESCRIPTION
This fixes the full width issue seen in ASUCMS and Webspark