### PR TITLE
fix(bootstrap4-theme): multi-line labels no longer break checkboxes

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_form-fields.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_form-fields.scss
@@ -173,7 +173,7 @@ form.uds-form {
         // check centered right.
         &::before {
           left: -2.25rem;
-          bottom: -0.1rem;
+          top: 0.1rem;
         }
         &::after {
           left: -$uds-size-spacing-4;

--- a/packages/bootstrap4-theme/stories/atoms/form-fields/form-fields.examples.js
+++ b/packages/bootstrap4-theme/stories/atoms/form-fields/form-fields.examples.js
@@ -910,7 +910,21 @@ export const Checkboxes = createStory(
         value="option1"
       />
       <label class="form-check-label" for="loneCheckbox1">
-        I like checkboxes
+      I like checkboxes
+      </label>
+    </div>
+
+    <div class="form-check">
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="loneCheckbox2"
+        value="option1"
+      />
+      <label class="form-check-label" for="loneCheckbox2">
+      Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content
+      Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content
+      Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content Multi-line content
       </label>
     </div>
 


### PR DESCRIPTION
See issue [here](https://asudev.jira.com/browse/UDS-1053).