### PR TITLE
fix: update logic on animated title header

### DIFF
--- a/packages/component-header/src/components/HeaderMain/Title/index.js
+++ b/packages/component-header/src/components/HeaderMain/Title/index.js
@@ -13,11 +13,7 @@ const Title = () => {
     useAppContext();
 
   useEffect(() => {
-    if (animateTitle || animateTitle === false) {
-      setActive(animateTitle);
-      return;
-    }
-    if (animateTitle) {
+    if (animateTitle !== false) {
       // If a custom baseUrl is passed in, it will be used to check for first page load
       let root = baseUrl === "/" ? window.location.hostname : baseUrl;
       // If relative baseURL given, append to the hostname for checking first page load

--- a/packages/component-header/src/header.js
+++ b/packages/component-header/src/header.js
@@ -91,7 +91,6 @@ ASUHeader.defaultProps = {
   isPartner: false,
   baseUrl: "/",
   breakpoint: "Xl",
-  animateTitle: false,
   expandOnHover: false,
 };
 

--- a/packages/components-library/src/components/Header/examples.js
+++ b/packages/components-library/src/components/Header/examples.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable react/prop-types */
 
 import { useState } from "preact/compat";
@@ -8,7 +7,7 @@ import { Header } from "./";
 import { Button } from "../Button";
 import { BasicNavTree } from "../Nav/NavTreeExample";
 
-const AnimatedHeaderTitleExample = (props) => {
+const AnimatedHeaderTitleExample = props => {
   const [animate, setAnimate] = useState(false);
 
   return (

--- a/packages/components-library/src/components/Title/index.js
+++ b/packages/components-library/src/components/Title/index.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable react/prop-types */
 
 import { forwardRef, useEffect, useState } from "preact/compat";
@@ -19,11 +18,6 @@ const Title = forwardRef(({ children, baseUrl, animate, ...props }, ref) => {
    * the first page load, then we set the 'active' state to animate the header with gold highlight.
    */
   useEffect(() => {
-    if (animate === true || animate === false) {
-      setActive(animate);
-      return;
-    }
-
     if (animate !== false) {
       // If a custom baseUrl is passed in, it will be used to check for first page load
       let root = baseUrl == "/" ? window.location.hostname : baseUrl;


### PR DESCRIPTION
## Description

Update logic on animated title header, to set as `true` when no `animatedTitle` value is provided and also when is properly set.
To test this out, comment the lines with the code `!document.referrer.includes(siteRoot)` on the respective helper file of each header component(`components-library` and `component-header`).