### PR TITLE
fix: update components for being included on the registry

### DIFF
--- a/packages/component-events/package.json
+++ b/packages/component-events/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@asu-design-system/component-events",
   "version": "1.2.1",
-  "description": "Events component",
+  "description": "ASU Events component",
   "main": "src/index.js",
   "author": "Nicolas Baudon",
   "license": "Unlicensed",
-  "private": true,
+  "private": false,
   "publishConfig": {
     "access": "restricted",
     "registry": "https://registry.web.asu.edu/"

--- a/packages/component-news/package.json
+++ b/packages/component-news/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@asu-design-system/component-news",
   "version": "1.2.4",
-  "description": "News component",
+  "description": "ASU News component",
   "main": "src/index.js",
   "author": "Michele Dibenedetto",
   "license": "Unlicensed",
-  "private": true,
+  "private": false,
   "publishConfig": {
     "access": "restricted",
     "registry": "https://registry.web.asu.edu/"


### PR DESCRIPTION
## Description

I update `component-events` and `component-news` so they will be listed on the registry, as they were seated to be private.
Ticket: https://asudev.jira.com/browse/UDS-1088?atlOrigin=eyJpIjoiM2Q5NjBkYzMyODk0NGRlMjkyYzllNDA0NGYwZmI4YWYiLCJwIjoiaiJ9