### PR TITLE
fix(app-rfi ): UDS-1086  - publish without dist folder

### DIFF
--- a/packages/app-rfi/.gitignore
+++ b/packages/app-rfi/.gitignore
@@ -2,6 +2,5 @@ node_modules
 /*.log
 *.lock
 package-lock.json
-dist
 docs/**
 !docs/README.props.md


### PR DESCRIPTION
# Desctiption 

It looks like the  `.gitignore` rule prevents publishing the `dist` folder.
I removed that rule. Hopefully, that fixes it


# Ticket 

https://asudev.jira.com/browse/UDS-1086

#  PR Reference 
 @georgebaev PR https://github.com/ASUWebPlatforms/webspark-module-asu_degree_rfi/pull/29