### PR TITLE
fix(components-core): remove post install scripts on components core

### DIFF
--- a/packages/components-core/package.json
+++ b/packages/components-core/package.json
@@ -22,8 +22,7 @@
     "jsdoc": "jsdoc -c jsdoc.config.js",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",
-    "postdocs": "node ../../scripts/process-readme-props.js",
-    "postinstall": "yarn build"
+    "postdocs": "node ../../scripts/process-readme-props.js"
   },
   "bugs": {
     "url": "https://github.com/ASU/asu-unity-stack/issues"


### PR DESCRIPTION
## Description 

I remove the post install script on `components-core` package.json, it was not necessary to have it there and It breaks on Drupal. @duarte-daniela need it!