### PR TITLE
fix(component-header): header breakpoints fixes

### DIFF
--- a/packages/component-header/src/components/HeaderMain/Title/index.styles.js
+++ b/packages/component-header/src/components/HeaderMain/Title/index.styles.js
@@ -1,5 +1,10 @@
 import styled from "styled-components";
 
+const breakpointMap = {
+  "992px": "993px",
+  "1260px": "1261px",
+};
+
 const TitleWrapper = styled.div`
   line-height: 1;
   font-size: 1rem;
@@ -33,7 +38,7 @@ const TitleWrapper = styled.div`
   .title-subunit-name {
     color: #191919;
   }
-  @media (min-width: ${({ breakpoint }) => breakpoint}) {
+  @media (min-width: ${({ breakpoint }) => breakpointMap[breakpoint]}) {
     line-height: 1;
     font-weight: 700;
     padding: 0;

--- a/packages/component-header/src/components/HeaderMain/index.styles.js
+++ b/packages/component-header/src/components/HeaderMain/index.styles.js
@@ -8,6 +8,7 @@ const HeaderMainWrapper = styled.div`
     padding: 0;
     display: flex;
     align-items: flex-start;
+    flex-wrap: nowrap;
   }
   .navbar-brand {
     .vert {


### PR DESCRIPTION
## Description

This pr contains fixes on the `component-header` breakpoints that the title and navigation floats behind the logo and breaks the header styles.