### PR TITLE
fix(app-webdir-ui): overwrite renovation

### DIFF
--- a/packages/app-webdir-ui/src/SearchPage/index.styles.js
+++ b/packages/app-webdir-ui/src/SearchPage/index.styles.js
@@ -180,6 +180,11 @@ const SearchPageLayout = styled.div`
         "links";
     }
   }
+  li.page-item:not(.active) {
+    button.page-link:hover {
+      color: #8c1d40;
+    }
+  }
 `;
 
 export { SearchPageLayout };

--- a/packages/app-webdir-ui/src/WebDirectoryComponent/index.styles.js
+++ b/packages/app-webdir-ui/src/WebDirectoryComponent/index.styles.js
@@ -39,6 +39,11 @@ const WebDirLayout = styled.div`
   .results {
     grid-area: results;
   }
+  li.page-item:not(.active) {
+    button.page-link:hover {
+      color: #8c1d40;
+    }
+  }
 `;
 
 export { WebDirLayout };


### PR DESCRIPTION
[David found an issue](https://asudev.jira.com/browse/ASUIS-445?focusedCommentId=1476436) whereby the text in the Pagination buttons appears blue when you hover. I’ve found that this CSS comes from renovation but can’t see it in bootstrap.
If you go to [to dev](https://dev-asu-isearch.ws.asu.edu/?search-tabs=all&q=Michael+Crow) and right-click -> inspect on the buttons of the paginatior (Like ‘1’, ‘2’, etc.) you can see there’s a rule for hovering as below:
![image](https://user-images.githubusercontent.com/8904644/165553365-87793b01-4acb-4455-9ec6-8efd99a535e9.png)

This PR will attempt to overwrite that rule but:
* I think it would be better to remove it or scope it more conservatively at the CMS level if possible, overwriting an overwrite is a messy addition to the codebase.
* I can't test whether or not this will actually work, I think there's a good chance the renovation css will take priority over this on the site.

In saying that, if you think this is the easier solution @mlsamuelson @georgebaev , here it is. 