### PR TITLE
fix(app-webdir-ui): set threshold score check for people promotions

### DIFF
--- a/packages/app-webdir-ui/src/helpers/search.js
+++ b/packages/app-webdir-ui/src/helpers/search.js
@@ -24,19 +24,23 @@ export const engineNames = {
   WEB_DIRECTORY_PEOPLE_AND_DEPS: "profiles_dept_and_people",
 };
 
-const getTopResult = results => {
+const getTopResult = (results, engineName) => {
   const topResult = results.reduce((prev, curr) => {
     return prev === null || prev["_meta"].score < curr["_meta"].score
       ? curr
       : prev;
   }, null);
-  if (topResult && topResult["_meta"].score >= 1) {
+  // Set threshold bar for identifying promoted results to display based on
+  // whether it's the web_dir_faculty_staff engine or web_sites engine
+  // resultset.
+  const thresholdScore = engineName === "web_dir_faculty_staff" ? 100 : 1;
+  if (topResult && topResult["_meta"].score >= thresholdScore) {
     return topResult;
   }
   return null;
 };
 const standardFormatter = (engineName, results, cardSize, appPathFolder) => {
-  const topResult = getTopResult(results.results);
+  const topResult = getTopResult(results.results, engineName);
   return {
     tab: engineName,
     page: results.meta.page,


### PR DESCRIPTION
We won't set a people promotion for any match with a score less than 100. Depends on relevancy tuning to be adjusted per the notes on the ticket in JIRA:
[ASUIS-725](https://asudev.jira.com/browse/ASUIS-725) 