### PR TITLE
WS2-1201: Preserve the button colors in the header

### DIFF
--- a/packages/component-header/src/components/Button/index.styles.js
+++ b/packages/component-header/src/components/Button/index.styles.js
@@ -18,9 +18,11 @@ const ButtonWrapper = styled.a`
   }
   &.button-light {
     background-color: #bfbfbf !important;
+    color: #000000 !important;
   }
   &.button-gold {
     background-color: #ffc627 !important;
+    color: #000000 !important;
   }
   &.button-dark {
     background-color: #191919 !important;


### PR DESCRIPTION
See: https://asudev.jira.com/browse/WS2-1201

Updated CSS to match the other button styles, to apply to the maroon and light button styles.