### PR TITLE
feat(app-degree-pages): add blacklistAcadPlans prop and story

### DIFF
--- a/packages/app-degree-pages/examples/listing-page.html
+++ b/packages/app-degree-pages/examples/listing-page.html
@@ -50,6 +50,7 @@
         cert: "false", // "true" | "false"
         // collegeAcadOrg: "CGF", // OPTIONAL example values: CLW, CTB, CTE
         // departmentCode: "CSFIS", // OPTIONAL example values: CMANAGE, CHUMARTCLT, CHL
+        // blacklistAcadPlans: ["BAACCBS", "LAACTBS"], // OPTIONAL example filters out Accountancy and Actuarial Science
       };
 
       // those links are just examples

--- a/packages/app-degree-pages/src/components/ListingPage/components/Filters/index.js
+++ b/packages/app-degree-pages/src/components/ListingPage/components/Filters/index.js
@@ -45,6 +45,7 @@ const INITIAL_FILTER_STATE = {
   asuLocals: [],
   acceleratedConcurrent: { value: "all", text: "" },
   keyword: null,
+  blacklistAcadPlans: [],
 };
 
 const getOptionProps = option => ({

--- a/packages/app-degree-pages/src/components/ListingPage/index.js
+++ b/packages/app-degree-pages/src/components/ListingPage/index.js
@@ -98,8 +98,12 @@ const ListingPage = ({
   const { defaultState } = useContext(AppContext);
   const { listingPageDefault } = defaultState;
   // These filter are input props which never change.
-  const { collegeAcadOrg, departmentCode, showInactivePrograms } =
-    programList.dataSource;
+  const {
+    collegeAcadOrg,
+    departmentCode,
+    showInactivePrograms,
+    blacklistAcadPlans,
+  } = programList.dataSource;
 
   /** @type {UseFiltersState} */
   const [stateFilters, setStateFilters] = useState({
@@ -134,6 +138,7 @@ const ListingPage = ({
         collegeAcadOrg,
         departmentCode,
         showInactivePrograms: showInactivePrograms ?? false,
+        blacklistAcadPlans,
       },
     });
 
@@ -163,6 +168,7 @@ const ListingPage = ({
           asuLocals.length > 0 ? locations.concat(onlneOption) : locations,
         keyword,
         showInactivePrograms: showInactivePrograms ?? false,
+        blacklistAcadPlans,
       },
     });
 

--- a/packages/app-degree-pages/src/components/ListingPage/index.stories.js
+++ b/packages/app-degree-pages/src/components/ListingPage/index.stories.js
@@ -61,6 +61,7 @@ const dataSource = {
   // cert: "true", // "true" | "false" // OPTIONAL
   // collegeAcadOrg: "CGF", // OPTIONAL example values: CLW, CTB, CTE
   // departmentCode: "CSFIS", // OPTIONAL example values: CMANAGE, CHUMARTCLT, CHL
+  // blacklistAcadPlans: ["BAACCBS", "LAACTBS"],
 };
 
 /** @type {AppProps} */
@@ -110,6 +111,23 @@ Default.args = {
   ...defaultArgs,
   introContent: null,
 };
+
+/**
+ * @type {{ args: AppProps }}
+ */
+export const DefaultWithBlacklistedPlanCodes = Template.bind({});
+DefaultWithBlacklistedPlanCodes.args = {
+  ...defaultArgs,
+  introContent: null,
+  programList: {
+    ...defaultArgs.programList,
+    dataSource: {
+      ...defaultArgs.programList.dataSource,
+      blacklistAcadPlans: ["BAACCBS", "LAACTBS"],
+    },
+  },
+};
+
 /**
  * @type {{ args: AppProps }}
  */

--- a/packages/app-degree-pages/src/core/services/degree-data-manager-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-manager-service.js
@@ -24,6 +24,7 @@ function filterData({
     locations = [],
     keyword,
     showInactivePrograms,
+    blacklistAcadPlans,
   },
 }) {
   // ============================================================
@@ -63,6 +64,10 @@ function filterData({
       ? resolver.isValidActiveProgram()
       : true;
   // ============================================================
+  /** @param {PropResolver} resolver   */
+  const isNotOnBlacklist = resolver =>
+    !blacklistAcadPlans?.includes(resolver.getAcadPlan());
+  // ============================================================
   /** @param {Object.<string, any>} row  */
   const doFilter = row => {
     const resolver = degreeDataPropResolverService(row);
@@ -73,7 +78,8 @@ function filterData({
       isValidDepartmentCode(resolver) &&
       isValidCampus(resolver) &&
       isValidAcceleratedConcurrent(row) &&
-      isValidForKeyword(resolver)
+      isValidForKeyword(resolver) &&
+      isNotOnBlacklist(resolver)
     );
   };
 

--- a/packages/app-degree-pages/src/core/types/listing-page-types.js
+++ b/packages/app-degree-pages/src/core/types/listing-page-types.js
@@ -45,6 +45,7 @@
  * @property {string} [collegeAcadOrg]
  * @property {string} [departmentCode]
  * @property {boolean | "true" | "false"} [showInactivePrograms]
+ * @property {Array} [blacklistAcadPlans]
  */
 
 /**

--- a/packages/app-degree-pages/src/core/types/shared-local-types.js
+++ b/packages/app-degree-pages/src/core/types/shared-local-types.js
@@ -77,6 +77,7 @@ const DegreeDataPropResolverServiceType = degreeDataPropResolverService({});
  *    asuLocals?: FilterOption []
  *    acceleratedConcurrent?: FilterOption
  *    showInactivePrograms?: boolean | "true" | "false"
+ *    blacklistAcadPlans?: Array
  * }} FiltersState
  */
 


### PR DESCRIPTION
UDS-1153 supports WS2-1240 by adding a new (sub) prop: `blacklistAcadPlans` which lives inside the `programList.dataSource` prop as an array of academic plan codes that if found in the listing will be filtered out and thus not displayed.

@tbutterf Marked you as a reviewer, but optional. Mainly so you're looped in for WS2-1240.