### PR TITLE
fix(app-degree-pages): show market text instead of description

### DIFF
--- a/packages/app-degree-pages/src/components/DetailPage/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/index.js
@@ -144,21 +144,14 @@ const DetailPage = ({
                     <CustomText content={resolver.getAsuCustomText()} />
                   ) : null}
 
-                  {!introContent?.hideMarketText && resolver.getMarketText() ? (
-                    <MarketText
-                      contents={
-                        introContent?.contents || [
-                          { text: resolver.getMarketText() },
-                        ]
-                      }
-                    />
-                  ) : null}
-
-                  {!introContent?.hideProgramDesc ? (
+                  {!introContent?.hideProgramDesc &&
+                  resolver.getMarketText() ? (
+                    <ProgramDescription content={resolver.getMarketText()} />
+                  ) : (
                     <ProgramDescription
                       content={resolver.getDescrLongExtented()}
                     />
-                  ) : null}
+                  )}
 
                   {/* {!introContent?.hideRequiredCourses ? (
                     <RequiredCourse

--- a/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
@@ -116,7 +116,6 @@ function degreeDataPropResolverService(row = {}) {
     getMathIntensity: () => mathintensity[row["MathIntensity"]],
     getMathIntensityRawValue: () => row["MathIntensity"],
     getMinMathReq: () => row["MinMathReq"] || "",
-    /** @return {string} */
     getMarketText: () => row["marketText"]?.trim(),
     /** @return {string} */
     getAsuOfficeLoc: () => row["AsuOfficeLoc"] || "",


### PR DESCRIPTION
If market text is available, detail page defaults to that. If none is available, defaults to extended description