### PR TITLE
fix: label improvements for degree pages

### DIFF
--- a/packages/app-degree-pages/src/components/DetailPage/components/ApplicationRequirements/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/components/ApplicationRequirements/index.js
@@ -112,8 +112,19 @@ const undergraduateTemplate = (
 function ApplicationRequirements({
   graduateRequirements,
   transferRequirements,
+  isMinorOrCertificate,
   additionalRequirements,
 }) {
+  let reqsLabel;
+  if (graduateRequirements) {
+    reqsLabel = !isMinorOrCertificate
+      ? "Degree requirements"
+      : "Program requirements";
+  } else {
+    reqsLabel = !isMinorOrCertificate
+      ? "Admission requirements"
+      : "Program requirements";
+  }
   return (
     <>
       <section
@@ -121,7 +132,7 @@ function ApplicationRequirements({
         data-testid="application-requirements"
       >
         <h2>
-          <span className="highlight-gold">Degree requirements</span>
+          <span className="highlight-gold">{reqsLabel}</span>
         </h2>
         {graduateRequirements ? (
           <div
@@ -156,6 +167,7 @@ function ApplicationRequirements({
 ApplicationRequirements.propTypes = {
   graduateRequirements: PropTypes.string,
   transferRequirements: PropTypes.string,
+  isMinorOrCertificate: PropTypes.bool,
   additionalRequirements: PropTypes.string,
 };
 

--- a/packages/app-degree-pages/src/components/DetailPage/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/index.js
@@ -191,7 +191,8 @@ const DetailPage = ({
                   />
                 ) : null}
 
-                {!introContent?.hideRequiredCourses ? (
+                {!introContent?.hideRequiredCourses &&
+                !resolver.isMinorOrCertificate() ? (
                   <RequiredCourse
                     concurrentDegreeMajorMaps={resolver.getConcurrentDegreeMajorMaps()}
                     onlineMajorMapURL={resolver.getOnlineMajorMapURL()}
@@ -206,12 +207,15 @@ const DetailPage = ({
                         ? resolver.getGraduateRequirements()
                         : null
                     }
+                    isMinorOrCertificate={resolver.isMinorOrCertificate()}
                     additionalRequirements={resolver.getDescrLongExtented5()}
                     transferRequirements={resolver.getTransferAdmission()}
                   />
                 ) : null}
 
-                {!changeMajorRequirements?.hide ? (
+                {!changeMajorRequirements?.hide &&
+                !resolver.isMinorOrCertificate() &&
+                !resolver.isGradProgram() ? (
                   <ChangeYourMajor content={resolver.getChangeMajor()} />
                 ) : null}
               </div>

--- a/packages/app-degree-pages/src/core/types/detail-page-types.js
+++ b/packages/app-degree-pages/src/core/types/detail-page-types.js
@@ -109,6 +109,7 @@
 /**
  * @typedef {Object} ApplicationRequirementsProps
  * @property {string} graduateRequirements
+ * @property {boolean} isMinorOrCertificate
  * @property {string} additionalRequirements
  * @property {string} transferRequirements
  */


### PR DESCRIPTION
Addresses following testing feedback from Brian S:
For undergraduate degrees pages only:
X- The "Degree requirements" label should read "Admission requirements"

For minors and certificates pages only:
X- Hide the "major map" for these pages since the requirements are now listed on the page (and they are not "majors")
X- "Degree requirements" label should be changed, since minors and certificates are not "degrees". "Program requirements" is how it appears in the catalog.
X- "Change your major requirements" should probably be hidden for minors and certificates, as I assume this is always an empty field.

For graduate pages only:
X- "Change your major requirements" should be hidden for graduate degrees.
