### PR TITLE
feat(app-degree-pages): use collegeOrg filter

### DIFF
--- a/packages/app-degree-pages/src/core/constants/web-api-constants.js
+++ b/packages/app-degree-pages/src/core/constants/web-api-constants.js
@@ -11,7 +11,7 @@ const listingPageDefaultDataSource = {
   init: "false",
   fields:
     `graduateApplyDates,planDeadlines,AsuDegSrchFlg,` +
-    "CollegeAcadOrg,DepartmentCode," +
+    "CollegeAcadOrg,CollegeAcadOrgJoint,DepartmentCode," +
     "Descr100,Institution,AcadPlan," +
     "Degree,DegreeDescr,DegreeDescrlong," +
     "concurrentDegreeMajorMaps,managedOnlineCampus,onlineMajorMapURL," +

--- a/packages/app-degree-pages/src/core/models/http-type-response.js
+++ b/packages/app-degree-pages/src/core/models/http-type-response.js
@@ -7,6 +7,7 @@
         EmailAddr: string;
         AsuCritTrackUrl: string;
         CollegeAcadOrg: string;
+        CollegeAcadOrgJoint: string[];
         Degree: string;
         CollegeDescr100: string;
         AsuOfficeLoc: string;

--- a/packages/app-degree-pages/src/core/services/degree-data-manager-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-manager-service.js
@@ -28,10 +28,11 @@ function filterData({
   },
 }) {
   // ============================================================
+  // See WS2-1391 for details on why we use CollegeAcadOrgJoint field.
   /** @param {PropResolver} resolver   */
   const isValidCollegeAcadOrg = resolver =>
     collegeAcadOrg
-      ? resolver.getCollegeAcadOrg().includes(collegeAcadOrg)
+      ? resolver.getCollegeAcadOrgJoint().includes(collegeAcadOrg)
       : true;
   // ============================================================
   /** @param {PropResolver} resolver   */

--- a/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
@@ -131,6 +131,8 @@ function degreeDataPropResolverService(row = {}) {
     getGlobalExp: () => row["globalExp"]?.trim(),
     /** @return {string} */
     getCollegeAcadOrg: () => row["CollegeAcadOrg"],
+    /** @return {Array} */
+    getCollegeAcadOrgJoint: () => row["CollegeAcadOrgJoint"],
     /** @return {string} */
     getDepartmentCode: () => row["DepartmentCode"],
     /** @return {Object.<string, string>} */

--- a/packages/app-degree-pages/src/core/utils/http-url-resolver.js
+++ b/packages/app-degree-pages/src/core/utils/http-url-resolver.js
@@ -7,12 +7,22 @@
  * @returns {string}
  */
 function urlResolver(dataSource, defaultDataSource) {
-  const httpParamters = { ...defaultDataSource, ...dataSource };
-  const { endpoint, fields, ...keyValues } = httpParamters;
+  const httpParameters = { ...defaultDataSource, ...dataSource };
+  if (httpParameters.collegeAcadOrg) {
+    // Convert `collegeAcadOrg` (from props) to `collegeOrg` for use as paramter
+    // to accommodate Degree Search API changes. collegeOrg was added to solve
+    // primary ownership issues for degrees that are owned by multiple colleges.
+    // See WS2-1391 for more details. We've opted to keep the props interface
+    // the same and re-map the name here for a smooth transition.
+    httpParameters["collegeOrg"] = httpParameters["collegeAcadOrg"];
+    delete httpParameters["collegeAcadOrg"];
+  }
+
+  const { endpoint, fields, ...keyValues } = httpParameters;
 
   const params = Object.keys(keyValues).reduce(
     (accumulator, paramName) =>
-      `${accumulator}&${paramName}=${httpParamters[paramName]}`,
+      `${accumulator}&${paramName}=${httpParameters[paramName]}`,
     ""
   );
 


### PR DESCRIPTION
[WS2-1391](https://asudev.jira.com/browse/WS2-1391) - use the new `collegeOrg` filter and do client side filtering for college based on the more inclusive `collegeAcadOrgJoint` field so we avoid oddball issues with degrees owned by multiple colleges.

This update depends on updates to the Degree Search API. To test:

```
// In ListingPage/index.stories.js, lines 53-66
// Set endpoint to use QA version of Degree Search - and be logged into the VPN
// And set program to "graduate" then test listings with 
// collegeAcadOrg values: CBA, CES, CHI and no value
// And with and without the departmentCode.
// Note: different collegeAcadOrg values will result different listings, but
// all should include the "Innovation and Venture Development, MS" with 
// AcadPlan value "HIIVDMS"
const dataSource = {
  // OPTIONAL - endpoint: "https://degrees.apps.asu.edu/t5/service",
  endpoint: "https://degrees-qa.apps.asu.edu/t5/service",
  // another example: dataSource: "/api/mocks/degree-search",

  // method: "findAllDegrees", // OPTIONAL
  // init: "false",  // OPTIONAL "true" | "false"
  program: "graduate", // graduate | undergrad
  // cert: "true", // "true" | "false" // OPTIONAL
  collegeAcadOrg: "CBA", // OPTIONAL example values: CLW, CTB, CTE
  departmentCode: "CHIDN", // OPTIONAL example values: CMANAGE, CHUMARTCLT, CHL
  // blacklistAcadPlans: ["BAACCBS", "LAACTBS"],
};
```