### PR TITLE
fix(app-webdir-ui): title case for search UI tabbed panels labels

### DIFF
--- a/packages/app-webdir-ui/src/SearchPage/index.js
+++ b/packages/app-webdir-ui/src/SearchPage/index.js
@@ -164,7 +164,7 @@ function SearchPage({
         </div>
       </div>
       <TabbedPanels id={searchTabsId} onTabChange={() => true}>
-        <Tab id={tabIds.all} title="All ASU search">
+        <Tab id={tabIds.all} title="All ASU Search">
           {preSearchOrContent(
             <AllTab
               totalResults={totalResults}
@@ -183,7 +183,7 @@ function SearchPage({
             )}
           </Tab>
         )}
-        <Tab id={tabIds.faculty} title="Faculty and staff">
+        <Tab id={tabIds.faculty} title="Faculty and Staff">
           {preSearchOrContent(
             <FacultyTab
               engines={enginesWithParams}


### PR DESCRIPTION
[ASUIS-849](https://asudev.jira.com/browse/ASUIS-849) Title Case for search UI tabbed panels.

We have a new [XD for the search UI](https://xd.adobe.com/view/9014e47c-c346-4105-a384-86e28c484972-c547/) that properly depicts this.