### PR TITLE
fix(components-core): fix regex is null when document.currentScript is undefined

### DIFF
--- a/packages/components-core/src/core/utils/script-utils.js
+++ b/packages/components-core/src/core/utils/script-utils.js
@@ -3,7 +3,7 @@
 function getCurrentScriptPath() {
   // @ts-ignore
   const match = ((document.currentScript && document.currentScript.src) || "").match(/(.*\/)/);
-  return match.length > 0 ? match[0].substr(0, match[0].length - 1) : "/";
+  return (match && match.length > 0) ? match[0].substr(0, match[0].length - 1) : "/";
 }
 
 export { getCurrentScriptPath };


### PR DESCRIPTION
fix: `Cannot read length of null` when document.currentScript is undefined