### PR TITLE
fix(bootstrap4-theme): fix path to design-tokens img folder

### DIFF
--- a/packages/bootstrap4-theme/gulpfile.js
+++ b/packages/bootstrap4-theme/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('scripts', function () {
 gulp.task('copy-assets', function (done) {
   // Copy the master ASU images from the design-token
   gulp
-    .src(`${paths.node}/@asu/build/assets/img/**/*`)
+    .src(`${paths.node}/@asu/design-tokens/build/assets/img/**/*`)
     .pipe(gulp.dest('./src/img'));
 
   // Copy font-awesome from design-token into src/


### PR DESCRIPTION
This issue didn't allow adding new images to the bootstrap package from the design-tokens package.