### PR TITLE
Uds-1128 - fix a11y link in header

### DIFF
--- a/packages/component-footer/src/components/Legal/index.js
+++ b/packages/component-footer/src/components/Legal/index.js
@@ -32,7 +32,7 @@ const Legal = () => {
               </a>
               <a
                 className="nav-link"
-                href="https://www.asu.edu/accessibility/"
+                href="https://accessibility.asu.edu/report"
                 onFocus={() =>
                   trackGAEvent({
                     ...DEFAULT_GA_EVENT,

--- a/packages/component-footer/src/components/Legal/index.js
+++ b/packages/component-footer/src/components/Legal/index.js
@@ -9,6 +9,16 @@ const DEFAULT_GA_EVENT = {
 };
 
 const Legal = () => {
+  function getURL() {
+    try {
+      const URL = window.location.href;
+      return URL;
+    } catch (error) {
+      console.error(error);
+      return "";
+    }
+  }
+
   return (
     <div className="wrapper" id="wrapper-footer-colophon" data-testid="legal">
       <div className="container" id="footer-colophon">
@@ -32,7 +42,7 @@ const Legal = () => {
               </a>
               <a
                 className="nav-link"
-                href="https://accessibility.asu.edu/report"
+                href={`https://accessibility.asu.edu/report?a11yref=${getURL()}`}
                 onFocus={() =>
                   trackGAEvent({
                     ...DEFAULT_GA_EVENT,

--- a/packages/component-header/src/components/UniversalNavbar/index.js
+++ b/packages/component-header/src/components/UniversalNavbar/index.js
@@ -14,6 +14,16 @@ const DEFAUL_GA_EVENT = {
 const UniversalNavbar = () => {
   const { breakpoint } = useAppContext();
 
+  function getURL() {
+    try {
+      const URL = window.location.href;
+      return URL;
+    } catch (error) {
+      console.error(error);
+      return "";
+    }
+  }
+
   return (
     <Wrapper
       // @ts-ignore
@@ -34,7 +44,7 @@ const UniversalNavbar = () => {
               </a>
               <a
                 className="nav-link sr-only sr-only-focusable"
-                href="https://accessibility.asu.edu/report"
+                href={`https://accessibility.asu.edu/report?a11yref=${getURL()}`}
               >
                 Report an accessibility problem
               </a>


### PR DESCRIPTION
Correct accessibility link in react header and footer and add dynamic window.location.
Ticket: https://asudev.jira.com/browse/UDS-1128?atlOrigin=eyJpIjoiYWU4NmNiZjk1NzdkNGRjZWI3ZGM5OGQ3NTU3NGQ1ODciLCJwIjoiaiJ9