### PR TITLE
fix(app-degree-pages): prop needed to be adjusted for updates

### DIFF
--- a/packages/app-degree-pages/src/components/DetailPage/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/index.js
@@ -195,7 +195,7 @@ const DetailPage = ({
                 !resolver.isMinorOrCertificate() ? (
                   <RequiredCourse
                     onlineMajorMapURL={resolver.getOnlineMajorMapURL()}
-                    majorMapOnCampusArchiveURL={resolver.getAsuCritTrackUrl()}
+                    majorMapOnCampusURL={resolver.getAsuCritTrackUrl()}
                     subPlnMajorMaps={resolver.getSubPlnMajorMaps()}
                     subPln={resolver.getSubPln()}
                   />

--- a/packages/app-degree-pages/src/components/DetailPage/index.stories.js
+++ b/packages/app-degree-pages/src/components/DetailPage/index.stories.js
@@ -93,7 +93,8 @@ const defaultArgs = {
     // endpoint: "https://degrees.apps.asu.edu/t5/service", // OPTIONAL
     // method: "findDegreeByAcadPlan", // OPTIONAL
     // init: "false", // OPTIONAL
-    acadPlan: queryAcadPlan || "TBTGMBGM",
+    acadPlan: queryAcadPlan || "TBTGMBGM", // this has major map subPlans
+    // acadPlan: "FAARTHBA", // this has one on-campus and one online major map
     // acadPlan: "LSBISBIS", // this has marketText
     // acadPlan: "ESBMEMDBSE", // this does not have required courses
   },
@@ -409,6 +410,10 @@ DefaultWithGraduateDegree.args = {
 export const WithContent = Template.bind({});
 WithContent.args = {
   ...defaultArgs,
+  dataSource: {
+    ...defaultArgs.dataSource,
+    acadPlan: "FAARTHBA", // online and on-campus major maps, no subPlans
+  },
 };
 
 /**

--- a/packages/app-degree-pages/src/core/types/detail-page-types.js
+++ b/packages/app-degree-pages/src/core/types/detail-page-types.js
@@ -93,7 +93,7 @@
 /**
  * @typedef {Object} RequiredCoursesProps
  * @property {string} onlineMajorMapURL
- * @property {string} majorMapOnCampusArchiveURL
+ * @property {string} majorMapOnCampusURL
  * @property {string} subPlnMajorMaps
  * @property {string} subPln
  */


### PR DESCRIPTION
Degree Detail page component needed to have prop name updated to match earlier prop update to RequiredCourse component.  I also added in variations in the stories so we can see the variation - when there are or aren't subPlans.  Before this update, for a planCode without subPlans, the on-campus option wasn't displaying.

[UDS-1253](https://asudev.jira.com/browse/UDS-1253)