### PR TITLE
fix(app-degree-pages): fix req's flip-flop and web standards cleanup

### DIFF
--- a/packages/app-degree-pages/src/components/DetailPage/components/ApplicationRequirements/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/components/ApplicationRequirements/index.js
@@ -32,10 +32,10 @@ const ButtonList = styled.ul`
   }
 `;
 
-const undergraduateTemplate = (
+const undergraduateTemplate = ({
+  transferRequirements = "",
   additionalRequirements = "",
-  transferRequirements = ""
-) => {
+}) => {
   const generalRequirements = [
     {
       label: "Freshman",
@@ -139,7 +139,10 @@ function ApplicationRequirements({
             )}
           />
         ) : (
-          undergraduateTemplate(transferRequirements, additionalRequirements)
+          undergraduateTemplate({
+            transferRequirements,
+            additionalRequirements,
+          })
         )}
       </section>
 

--- a/packages/app-degree-pages/src/components/DetailPage/components/RequiredCourse/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/components/RequiredCourse/index.js
@@ -7,8 +7,8 @@ import React from "react";
 const CHANGEMAJOR_URL = "https://changemajor.apps.asu.edu/";
 const ONLINE = "ONLINE";
 
-const ONCAMPUS_TITLE = "ON-CAMPUS STUDENTS";
-const ONLINE_TITLE = "ONLINE STUDENTS";
+const ONCAMPUS_TITLE = "On-campus students";
+const ONLINE_TITLE = "Online students";
 const VIEW_MAJOR_MAP_WITH_SLASH = "View major map -";
 const VIEW_MAJOR_MAP = "View major map";
 /**
@@ -87,7 +87,7 @@ function RequiredCourse({
   // Template component for required courses section
   const RequiredCourseSection = () => (
     <section className="container pl-0" data-testid="required-course">
-      <h4>Required Courses (Major Map)</h4>
+      <h4>Required courses (major map)</h4>
       {oncampusLinks.length > 0 && renderLinks(ONCAMPUS_TITLE, oncampusLinks)}
       {onlineLinks.length > 0 && renderLinks(ONLINE_TITLE, onlineLinks)}
       <div className="mt-3">


### PR DESCRIPTION
[UDS-1269](https://asudev.jira.com/browse/UDS-1269)

Addresses headings that didn't match Web Standard's sentence case policy
and
fixes parameter order issue with `undergraduateTemplate()` by using named parameters. Note, I reordered the parameters, but with the addition of `{}`'s that was actually uncessary. Just didn't want to cause any confusion so thought I'd point that out.