### PR TITLE
feat(component-header): fix animated title on storybook

### DIFF
--- a/packages/component-header/src/core/utils/helpers/title.js
+++ b/packages/component-header/src/core/utils/helpers/title.js
@@ -16,20 +16,26 @@ const addMinutesToDate = (date, minutes) => {
  * @param {string} root - The full URL of the site root, used to check against document.referrer
  */
 const checkFirstLoad = root => {
+  const LOCALHOST = "localhost";
+  const KEY_TITLE_LOADED = "title_loaded";
   const now = new Date();
-  const { localStorage } = window;
+
   const siteRoot = root || window.location.hostname;
   // Check if title_loaded is set
   const titleLoaded = localStorage.getItem("title_loaded");
   const titleLoadedExpired = now.getTime() > parseInt(titleLoaded, 10);
 
-  if (
-    !document.referrer.includes(siteRoot) &&
-    (!titleLoaded || titleLoadedExpired)
-  ) {
+  // Check for localhost to avoid the other validations (Storybook use case)
+  const isLocalSite = siteRoot === LOCALHOST;
+  // check if referrer matches site
+  const hasMatchingReferrer = document.referrer.includes(siteRoot);
+  // check if title is loaded and not expired
+  const hasValidTitle = !titleLoaded || titleLoadedExpired;
+
+  if (isLocalSite || (!hasMatchingReferrer && hasValidTitle)) {
     // Set 10 minutes to now date and set it as expiration time
     const expirationTime = addMinutesToDate(now, 10).getTime();
-    localStorage.setItem("title_loaded", expirationTime.toString());
+    localStorage.setItem(KEY_TITLE_LOADED, expirationTime.toString());
     return true;
   }
 

--- a/packages/component-header/src/index.stories.js
+++ b/packages/component-header/src/index.stories.js
@@ -34,17 +34,25 @@ const Template = args => (
 );
 
 const AnimatedTitleTemplate = args => {
-  const [animate, setAnimate] = useState(false);
+  const handleClick = () => {
+    // get curent local storage value
+    const titleTimestamp = localStorage.getItem("title_loaded");
+
+    if (titleTimestamp) {
+      localStorage.removeItem("title_loaded");
+    }
+
+    setTimeout(() => {
+      // reload the page with button
+      window.location.reload();
+    }, 1000);
+  };
 
   return (
     <>
-      <ASUHeader {...{ ...args, animateTitle: animate }} />
+      <ASUHeader {...{ ...args, animateTitle: true }} />
       <div style={{ marginTop: 200, textAlign: "center" }}>
-        <Button
-          text="Animate Title"
-          color="dark"
-          onClick={() => setAnimate(prevState => !prevState)}
-        />
+        <Button text="Animate Title" color="dark" onClick={handleClick} />
       </div>
     </>
   );

--- a/packages/component-header/src/index.stories.js
+++ b/packages/component-header/src/index.stories.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { Button } from "./components/Button";
 import {


### PR DESCRIPTION
The title animation button now works correctly in Storybook. A validation has been added to prevent unnecessary checks on localhost. The animation is now controlled from the story by triggering a reload(), simulating entering the page for the first time.