### PR TITLE
chore(.github): add basic starting point for PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+### Description
+
+<!-- Short blurb about this work or helpful links -->
+
+- [STORYBOOK_URL](https://unity.web.asu.edu/@asu/bootstrap4-theme/index.html)
+- [JIRA ticket](https://asudev.jira.com/browse/UDS-0000)
+- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)
+
+### Checklist
+
+- [ ] `yarn run lint`
+- [ ] Add/updated examples
+- [ ] No new console errors
+- [ ] Accessibility checks
+
+### Browsers
+
+- [ ] Chrome
+- [ ] Safari
+- [ ] Firefox
+- [ ] Edge
+
+### Images
+
+<!-- Provide screenshots -->


### PR DESCRIPTION
This is just a starting point.
There are different options to mention users to be notified and using more templates incase sub-packages have unique checklists.

Documentation on PR templates:
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository