### PR TITLE
fix(app-webdir-ui): fixed titleMatch edge case

### DIFF
--- a/packages/app-webdir-ui/src/helpers/dataConverter.js
+++ b/packages/app-webdir-ui/src/helpers/dataConverter.js
@@ -131,7 +131,13 @@ const getTitleFromProfile = (profile, titleMatch) => {
     titleMatch.depts &&
     profile.deptids &&
     profile.titles &&
-    profile.deptids.raw !== null
+    profile.deptids.raw !== null &&
+    /*
+      If titleMatch.depts[0] is '',
+      then no deptIds were supplied to query.
+      We can't use titleMatch.depts in that case.
+    */
+    !!titleMatch.depts[0]
   ) {
     console.log("title from titleMatch.deps");
     // A flow for WEB_DIRECTORY_DEPARTMENTS.


### PR DESCRIPTION
There is a case where someone can not supply deptIds to the web directory component, I added check for empty deptIds and defaults for this case
Ticket: https://asudev.jira.com/browse/ASUIS-966?atlOrigin=eyJpIjoiN2U1NTkyNGIxZmRiNDk5OGFhZDNmZTAzY2YxNDNkN2QiLCJwIjoiaiJ9