### PR TITLE
feat(check-element-changes.js): update check changes for new theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ yarn stop # stop the testing server
 
 ### check-element-changes
 
-This tool shows outdated markup into the folder `bootstrap4-theme`
+This tool shows outdated markup into the folder `unity-bootstrap-theme`
 It takes as an argument the number of days past from the last file changes.
 
 

--- a/scripts/check-element-changes.js
+++ b/scripts/check-element-changes.js
@@ -50,7 +50,8 @@ runGit(GIT_COMMAND, (res = "") => {
 
   fileTemplates.forEach(filePath => {
     const fileName = path.parse(filePath).name;
-    printTitle(fileName);
+    const packageName = filePath.split(path.sep)[1];
+    printTitle(`${packageName}: ${fileName}`);
     printLine();
   });
 });

--- a/scripts/check-element-local-changes.js
+++ b/scripts/check-element-local-changes.js
@@ -36,7 +36,7 @@ function getFiles(dir) {
   return Array.prototype.concat(...files);
 }
 
-const BASE_URL = "./packages/bootstrap4-theme/stories";
+const BASE_URL = "./packages/unity-bootstrap-theme/stories";
 
 const fileTemplates = getFiles(BASE_URL).filter(elm =>
   elm.match(/.*\.(templates?)/gi)


### PR DESCRIPTION
https://asudev.jira.com/browse/UDS-1278

The `check-element-changes` already flags changes since new templates in unity-bootstrap-theme match the pattern. I'm not sure if this approach is correct, This change adds a package prefix to the template change.


<img width="971" alt="image" src="https://user-images.githubusercontent.com/5209283/228946516-17e34f16-405b-4750-ad12-6252c03ed3e8.png">
