### PR TITLE
fix(app-webdir-ui):  Remove sort option and reduce renders of webdir

### DIFF
--- a/packages/app-webdir-ui/src/SearchResultsList/index.js
+++ b/packages/app-webdir-ui/src/SearchResultsList/index.js
@@ -39,7 +39,7 @@ const ASUSearchResultsList = ({
   icon,
 }) => {
   const [results, setResults] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [subtitle, setSubtitle] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalResults, setTotalResults] = useState(null);

--- a/packages/app-webdir-ui/src/WebDirectoryComponent/index.js
+++ b/packages/app-webdir-ui/src/WebDirectoryComponent/index.js
@@ -1,6 +1,7 @@
 // @ts-check
+/* eslint no-use-before-define: 0 */
 import PropTypes from "prop-types";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 
 import { FacultyRankTabPanels } from "../FacultyRankComponent";
 import { engineNames, engines } from "../helpers/search";
@@ -19,17 +20,46 @@ function WebDirectory({
   display,
   filters,
 }) {
-  const [sort, setSort] = useState(display.defaultSort);
-  const [requestFilters, setRequestFilters] = useState();
+  const [sort, setSort] = useState(defaultSortSetter);
+  const [requestFilters] = useState(doSearch);
   const RES_PER_PAGE = 6;
 
-  /**
-   * This function returns an array of custom sort options based on the webDirSearchType and departmentIds parameters.
-   *
-   * @param {string} webDirSearchType - A string that specifies the type of search component.
-   * @param {string} departmentIds - A string of comma-separated department IDs.
-   * @returns {Array} An array of custom sort options.
-   */
+  // Initializer functions for requestFilters and sort. Only runs on first render.
+
+  function doSearch() {
+    const tempFilters = filters ? { ...filters } : {};
+    if (searchType === "departments" || searchType === "faculty_rank") {
+      tempFilters["deptIds"] = deptIds.split(",");
+      return tempFilters;
+    }
+    tempFilters["peopleInDepts"] = ids
+      .split(",")
+      .filter(id => id.includes(":"))
+      .map(pair => pair.split(":"))
+      .map(pair => {
+        return { asurite_id: pair[0], dept_id: pair[1] };
+      });
+    return tempFilters;
+  }
+
+  function defaultSortSetter() {
+    const defaultCMSOptions = {
+      last_name: "last_name_asc",
+      webdir_customized: "employee_weight",
+      people_order: "people_order",
+    };
+    if (
+      Object.prototype.hasOwnProperty.call(
+        defaultCMSOptions,
+        display?.defaultSort
+      )
+    ) {
+      return defaultCMSOptions[display.defaultSort];
+    }
+    return "last_name_asc"; // defaults to last_name_asc if no default sort is set in CMS
+  }
+
+  // Function returns an array of custom sort options based on the webDirSearchType and departmentIds parameters.
   function sortOptionsFunc(webDirSearchType, departmentIds) {
     if (
       webDirSearchType === "departments" &&
@@ -59,7 +89,6 @@ function WebDirectory({
     appPathFolder,
   };
 
-
   const enginesWithParams = {
     [engineNames.WEB_DIRECTORY_DEPARTMENTS]: {
       ...engines[engineNames.WEB_DIRECTORY_DEPARTMENTS],
@@ -82,11 +111,6 @@ function WebDirectory({
     },
   };
 
-  const defaultCMSOptions = {
-    last_name: "last_name_asc",
-    webdir_customized: "employee_weight",
-    people_order: "people_order",
-  };
   const setNewSort = newSort => {
     setSort(prev => newSort);
   };
@@ -97,38 +121,6 @@ function WebDirectory({
     people_departments: engineNames.WEB_DIRECTORY_PEOPLE_AND_DEPS,
     faculty_rank: engineNames.WEB_DIRECTORY_FACULTY_RANK,
   };
-  function doSearch() {
-    const tempFilters = { ...filters };
-    if (searchType === "departments") {
-      tempFilters["deptIds"] = deptIds.split(",");
-    } else {
-      tempFilters["peopleInDepts"] = ids
-        .split(",")
-        .filter(id => id.includes(":"))
-        .map(pair => pair.split(":"))
-        .map(pair => {
-          return { asurite_id: pair[0], dept_id: pair[1] };
-        });
-    }
-    setRequestFilters(tempFilters);
-  }
-
-  useEffect(() => {
-    if (
-      Object.prototype.hasOwnProperty.call(
-        defaultCMSOptions,
-        display.defaultSort
-      )
-    ) {
-      setNewSort(defaultCMSOptions[display.defaultSort]);
-    }
-  }, [display.defaultSort]);
-
-  useEffect(() => {
-    if ((searchType === "departments" && deptIds) || ids) {
-      doSearch();
-    }
-  }, [sort]);
 
   if (searchType !== "faculty_rank") {
     return (


### PR DESCRIPTION
### Description
If multiple deptIds are given as props, the department defined option is removed.
Also reduce initial renders of component to one.

- [ASUIS-969](https://asudev.jira.com/browse/ASUIS-969?atlOrigin=eyJpIjoiMGUwNjc4ZDdkOThmNDYxY2E4NTkwMjBlYTAzYWZkYjciLCJwIjoiaiJ9)
- [ASUIS-975](https://asudev.jira.com/browse/ASUIS-975?atlOrigin=eyJpIjoiYzcwOGM4YzgyYTg5NDAwMGFjNTJkM2Y2Yjg1NjNiMjAiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors
- [x] Accessibility checks
