### PR TITLE
build(unity-bootstrap-theme): removed brackets that were causing error

### DIFF
--- a/packages/unity-bootstrap-theme/.storybook/preview.js
+++ b/packages/unity-bootstrap-theme/.storybook/preview.js
@@ -16,8 +16,8 @@ export const parameters = {
     },
     root: ".row", // can be customized to wrap an element
     removeComments: /^\s*\s*$/,
-    transform: (code) => {
-      return code.replace(/<svg.*<\/svg>/g, "");
-    }
+    transform: code => {
+      return code.replace(/<svg.*?<\/svg>/g, "").replace(/()/gi, "$2");
+    },
   },
 };

--- a/packages/unity-bootstrap-theme/package.json
+++ b/packages/unity-bootstrap-theme/package.json
@@ -21,8 +21,8 @@
     "build:dev": "rimraf ./dist && webpack  --progress --bail",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "lint": "eslint \"**/*.{js}\"",
-    "lint:fix": "eslint \"**/*.{js}\" --fix"
+    "lint": "eslint \"**/*.js\"",
+    "lint:fix": "eslint \"**/*.js\" --fix"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
### Description

<!-- Description of problem -->
ESLInt was throwing errors because of the brackets
<!-- Solution -->
Removed brackets

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1315?atlOrigin=eyJpIjoiZjEwOGU2ZTgyOTVlNDQ2ZWE5NTRlYzQ0OGM1MmU2NGMiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes