### PR TITLE
chore(unity-bootstrap-theme): focus HTML example area

### DIFF
--- a/packages/unity-bootstrap-theme/.storybook/preview.js
+++ b/packages/unity-bootstrap-theme/.storybook/preview.js
@@ -17,10 +17,13 @@ export const parameters = {
       tabWidth: 4,
       htmlWhitespaceSensitivity: "ignore",
     },
-    root: ".row", // can be customized to wrap an element
+    root: "#html-root", // can be customized to wrap an element
     removeComments: /^\s*\s*$/,
     transform: (code) => {
-      return code.replace(/<svg.*<\/svg>/g, "");
+      // remove Fontawesome transforming span into svg
+      code = code.replace(/<svg.*?<\/svg>/gi, "");
+      code = code.replace(/(<!--\s)(<span.*?class=.*?fa-.*?><\/span>)(\s-->)/gi, "$2");
+      return code;
     }
   },
 };

--- a/packages/unity-bootstrap-theme/helpers/templates/1-column.js
+++ b/packages/unity-bootstrap-theme/helpers/templates/1-column.js
@@ -4,7 +4,7 @@ export default (content) => {
   return (
     <div class="container">
       <div class="row">
-        <div class="col-12">
+        <div id="html-root" class="col-12">
           {content}
         </div>
       </div>

--- a/packages/unity-bootstrap-theme/helpers/templates/2-column.js
+++ b/packages/unity-bootstrap-theme/helpers/templates/2-column.js
@@ -4,7 +4,7 @@ export default (content) => {
   return (
     <div class="container">
       <div class="row">
-        <div class="col-6">
+        <div id="html-root" class="col-6">
           {content}
         </div>
         <div class="col-6">

--- a/packages/unity-bootstrap-theme/helpers/templates/3-column.js
+++ b/packages/unity-bootstrap-theme/helpers/templates/3-column.js
@@ -4,7 +4,7 @@ export default (content) => {
   return (
     <div class="container">
       <div class="row">
-        <div class="col-4">
+        <div id="html-root" class="col-4">
           {content}
         </div>
         <div class="col-4">

--- a/packages/unity-bootstrap-theme/helpers/templates/4-column.js
+++ b/packages/unity-bootstrap-theme/helpers/templates/4-column.js
@@ -4,7 +4,7 @@ export default (content) => {
   return (
     <div class="container">
       <div class="row">
-        <div class="col-3">
+        <div id="html-root" class="col-3">
           {content}
         </div>
         <div class="col-3">

--- a/packages/unity-bootstrap-theme/helpers/templates/full-width.js
+++ b/packages/unity-bootstrap-theme/helpers/templates/full-width.js
@@ -4,7 +4,7 @@ export default (content) => {
   return (
     <div> {/* Storybook Bug, all options must have equal depth when using controls to switch */}
       <div class="row no-gutters">
-        <div class="col uds-full-width">
+        <div id="html-root" class="col uds-full-width">
           {/* Component start */}
             { content }
           {/* Component end */}


### PR DESCRIPTION
### Description

HTML shown in storybook should be limited to the component without the wrapper HTML or multiple columns

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1310)

### Checklist

- [x] Commits do not contain multiple scopes
- [x] No new console errors

### Images
![image](https://user-images.githubusercontent.com/5209283/231902429-eb14501c-6f69-4e45-8855-74316285580b.png)

<img width="818" alt="image" src="https://user-images.githubusercontent.com/5209283/231902540-83fd575a-a6eb-473c-b563-13456fa4710d.png">


