### PR TITLE
fix(component-footer): check if contact prop is present before rend…

### DIFF
--- a/packages/component-footer/src/components/Contact/index.js
+++ b/packages/component-footer/src/components/Contact/index.js
@@ -19,9 +19,11 @@ const Contact = ({
         <div className="row" data-testid="columns-container">
           <div className="col-xl-3" id="info-column">
             <h5>{title}</h5>
-            <p className="contact-link">
-              <a href={contactLink}>Contact Us</a>
-            </p>
+            {contactLink && (
+              <p className="contact-link">
+                <a href={contactLink}>Contact Us</a>
+              </p>
+            )}
             {contributionLink && (
               <p
                 className="contribute-button"

--- a/packages/component-footer/src/footer.stories.js
+++ b/packages/component-footer/src/footer.stories.js
@@ -30,6 +30,13 @@ UnitLogo.args = {
   },
 };
 
+export const OneColumnNoLinks = Template.bind({});
+OneColumnNoLinks.args = {
+  contact: {
+    title: "No props passed should omit the button and the contact link",
+  },
+};
+
 export const OneColumnNoLogo = Template.bind({});
 OneColumnNoLogo.args = {
   contact: {


### PR DESCRIPTION
Check if contact prop is present before rendering link.

### Description
When using the component-footer library, there is currently no way to omit the contact us link within the `#info-columns` portion of the footer. Not passing the prop to React when rendering still produces an an anchor tag and a visible "Contact Us" link on the screen.

The solution:
 - Wraps the contact us link in a conditional check that looks for the prop to be set before outputting the result.
 - The pattern used is similar to what is happening with the Contribute button immediately below it.

Notes:
- This is one of those "how do you design a story to illustrate a negative outcome" situations.
- I made an additional story in Storybook to illustrate that the absence of the contributeButton URL and/or the contactLink URL props would produce a footer without either of these parts.
- However, this could be viewed by the general ASU public as an error. 
- If it's confusing. let me know and I'll pull the additional "negation" story and resubmit.

### Links

- [Unity reference site][(https://unity.web.asu.edu/@asu/component-footer/index.html?path=/story/uds-asu-footer--one-column-no-logo](https://unity.web.asu.edu/@asu/component-footer/index.html?path=/story/uds-asu-footer--one-column-no-logo)
- [JIRA ticket][(https://asudev.jira.com/browse/UDS-1328)](https://asudev.jira.com/browse/UDS-1328)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge
