### PR TITLE
fix(unity-bootstrap-theme): add IE11 css support

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_accordion.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_accordion.scss
@@ -1,0 +1,15 @@
+.accordion-button:not(.collapsed)::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%230c63e4'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+  transform: rotate(-180deg);
+}
+
+.accordion-button::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23212529'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+  transition: transform 0.2s ease-in-out;
+}
+
+.accordion-flush .accordion-item,
+.accordion-flush .accordion-item .accordion-button,
+.accordion-flush .accordion-item .accordion-button.collapsed {
+  border-radius: 0 !important;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_breadcrumb.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_breadcrumb.scss
@@ -1,0 +1,7 @@
+.breadcrumb-item {
+  display: flex;
+}
+
+.breadcrumb-item + .breadcrumb-item::before {
+  display: inline-block;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_buttons.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_buttons.scss
@@ -1,0 +1,26 @@
+.btn {
+  -ms-user-select: none;
+}
+
+.btn-close {
+  background-clip: content-box;
+}
+
+.btn-close:disabled,
+.btn-close.disabled {
+  -ms-user-select: none;
+}
+
+.btn-group > :not(:last-child).btn-group > .btn,
+.btn-group > :first-child.btn.dropdown-toggle-split,
+.btn-group > :not(:last-child):not(.dropdown-toggle).btn {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.btn-group > :not(:first-child).btn-group > .btn,
+.btn-group > :nth-child(n + 3).btn,
+.btn-group > :not(.btn-check) + .btn {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_card.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_card.scss
@@ -1,0 +1,11 @@
+.card {
+  // Workaround for the image size bug
+  // See: https://github.com/twbs/bootstrap/pull/28855
+  min-height: 1px;
+}
+
+.card-img,
+.card-img-top,
+.card-img-bottom {
+  flex-shrink: 0;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_carousel.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_carousel.scss
@@ -1,0 +1,11 @@
+// Carousel (Dark Variant)
+
+// SVG background with dark fill as IE11 doesn't support filter invert
+.carousel-dark .carousel-control-prev-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23111' viewBox='0 0 16 16'%3e%3cpath d='M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z'/%3e%3c/svg%3e");
+}
+
+// SVG background with dark fill as IE11 doesn't support filter invert
+.carousel-dark .carousel-control-next-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23111' viewBox='0 0 16 16'%3e%3cpath d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_close.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_close.scss
@@ -1,0 +1,4 @@
+// SVG background with white fill as IE11 doesn't support filter invert
+.btn-close-white {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' viewBox='0 0 16 16'%3e%3cpath d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z'/%3e%3c/svg%3e");
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_list-group.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_list-group.scss
@@ -1,0 +1,39 @@
+.list-group-item-primary {
+  color: #084298 !important;
+  background-color: #cfe2ff !important;
+}
+
+.list-group-item-secondary {
+  color: #41464b !important;
+  background-color: #e2e3e5 !important;
+}
+
+.list-group-item-success {
+  color: #0f5132 !important;
+  background-color: #d1e7dd !important;
+}
+
+.list-group-item-danger {
+  color: #842029 !important;
+  background-color: #f8d7da !important;
+}
+
+.list-group-item-warning {
+  color: #664d03 !important;
+  background-color: #fff3cd !important;
+}
+
+.list-group-item-info {
+  color: #055160 !important;
+  background-color: #cff4fc !important;
+}
+
+.list-group-item-light {
+  color: #636464 !important;
+  background-color: #fefefe !important;
+}
+
+.list-group-item-dark {
+  color: #141619 !important;
+  background-color: #d3d3d4 !important;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_modal.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_modal.scss
@@ -1,0 +1,35 @@
+.modal-dialog-scrollable {
+  display: flex;
+}
+
+.modal-dialog-scrollable .modal-content {
+  max-height: calc(100vh - 1rem);
+}
+
+// Ensure `modal-dialog-centered` extends the full height of the view
+.modal-dialog-centered::before {
+  display: block;
+  height: calc(100vh - 1rem);
+  content: "";
+}
+
+// Ensure `.modal-body` shows scrollbar
+.modal-dialog-centered.modal-dialog-scrollable {
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+}
+
+.modal-dialog-centered.modal-dialog-scrollable .modal-content {
+  max-height: none;
+}
+
+.modal-dialog-centered.modal-dialog-scrollable::before {
+  content: none;
+}
+
+// Ensures that modals are horizontally centered
+.modal-dialog {
+  margin-right: auto !important;
+  margin-left: auto !important;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_progress.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_progress.scss
@@ -1,0 +1,3 @@
+.progress {
+  line-height: 1;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_reboot.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_reboot.scss
@@ -1,0 +1,41 @@
+// Workaround for the SVG overflow bug.
+// See https://github.com/twbs/bootstrap/issues/26878
+svg {
+  overflow: hidden;
+}
+
+// Remove the default vertical scrollbar
+textarea {
+  overflow: auto;
+}
+
+hr {
+  overflow: visible;
+}
+
+button,
+input {
+  overflow: visible;
+}
+
+// 1. Correct the color inheritance from `fieldset` elements
+// 2. Correct the text wrapping
+legend {
+  color: inherit;
+  white-space: normal;
+}
+
+pre {
+  // Disable auto-hiding scrollbar to avoid overlap,
+  // making it impossible to interact with the content
+  -ms-overflow-style: scrollbar;
+}
+
+// Add the correct display for template & main
+template {
+  display: none;
+}
+
+main {
+  display: block;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_tables.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_tables.scss
@@ -1,0 +1,35 @@
+  .table > :not(caption) > * > * {
+  box-shadow: none !important;
+}
+
+.table.table-striped:not(.table-dark) > tbody > tr:nth-child(odd) > * {
+  background-color: rgba(0 0 0 / 5%) !important;
+}
+
+.table-dark.table-striped > :not(caption) > *:nth-child(odd) > * {
+  opacity: 0.9;
+}
+
+.table-dark.table-striped > thead > tr > th {
+  opacity: 1 !important;
+}
+
+.table.table-hover:not(.table-dark) > tbody > tr:hover > * {
+  background-color: rgba(0 0 0 / 5%) !important;
+}
+
+.table.table-hover.table-dark > tbody > tr:hover > * {
+  opacity: 0.9;
+}
+
+.table.table-hover.table-striped > tbody > tr:hover > * {
+  background-color: rgba(0 0 0 / 5%) !important;
+}
+
+.table-striped-columns > :not(caption) > tr > :nth-child(2n) {
+  background-color: rgba(0 0 0 / 5%) !important;
+}
+
+.table-dark.table-striped-columns > :not(caption) > tr > :nth-child(2n) {
+  background-color: rgba(0, 0, 0, 5) !important;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_tooltip.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_tooltip.scss
@@ -1,0 +1,6 @@
+// fix for  form validation feedback not being positioned correctly
+.invalid-tooltip,
+.valid-tooltip {
+  left: 0;
+  margin-left: 8px;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/_utilities.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/_utilities.scss
@@ -1,0 +1,318 @@
+// `pointer-events: none` isn't supported by IE11, setting `cursor: default` just makes it appear less like a link
+.pe-none {
+  cursor: default;
+}
+
+.text-break {
+  word-wrap: break-word !important;
+}
+
+.user-select-none {
+  -ms-user-select: none !important;
+}
+
+.user-select-auto {
+  -ms-user-select: auto !important;
+}
+
+// Text opacity
+.text-opacity-75 {
+  opacity: 0.75;
+}
+
+.text-opacity-50 {
+  opacity: 0.5;
+}
+
+.text-opacity-25 {
+  opacity: 0.25;
+}
+
+// Border colors
+.border {
+  border-color: #dee2e6;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.border-primary {
+  border-color: rgb(13, 110, 253);
+}
+
+.border-secondary {
+  border-color: rgb(108, 117, 125);
+}
+
+.border-success {
+  border-color: rgb(25, 135, 84);
+}
+
+.border-danger {
+  border-color: rgb(220, 53, 69);
+}
+
+.border-warning {
+  border-color: rgb(255, 193, 7);
+}
+
+.border-info {
+  border-color: rgb(13, 202, 240);
+}
+
+.border-light {
+  border-color: rgb(248, 249, 250);
+}
+
+.border-dark {
+  border-color: rgb(33, 37, 41);
+}
+
+.border-white {
+  border-color: rgb(255, 255, 255);
+}
+
+.border-top {
+  border-top-color: #dee2e6;
+  border-top-style: solid;
+  border-top-width: 1px;
+}
+
+.border-bottom {
+  border-bottom-color: #dee2e6;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+}
+
+.border-start {
+  border-left-color: #dee2e6;
+  border-left-style: solid;
+  border-left-width: 1px;
+}
+
+.border-end {
+  border-right-color: #dee2e6;
+  border-right-style: solid;
+  border-right-width: 1px;
+}
+
+// Border Width
+.border-1 {
+  border-width: 1px !important;
+}
+
+.border-2 {
+  border-width: 2px !important;
+}
+
+.border-3 {
+  border-width: 3px !important;
+}
+
+.border-4 {
+  border-width: 4px !important;
+}
+
+.border-5 {
+  border-width: 5px !important;
+}
+
+// Radius
+.rounded {
+  border-radius: 0.375rem;
+}
+
+.rounded-bottom {
+  border-bottom-right-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-end {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.rounded-start {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-top {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
+// Border Radius Size
+.rounded-1 {
+  border-radius: 0.375rem;
+}
+
+.rounded-2 {
+  border-radius: 0.25rem;
+}
+
+.rounded-3 {
+  border-radius: 0.5rem;
+}
+
+.rounded-4 {
+  border-radius: 1rem;
+}
+
+.rounded-5 {
+  border-radius: 2rem;
+}
+
+.rounded-pill {
+  border-radius: 50rem;
+}
+
+// Text colors
+.text-primary {
+  color: rgb(13, 110, 253) !important;
+}
+
+.text-secondary {
+  color: rgb(108, 117, 125) !important;
+}
+
+.text-success {
+  color: rgb(25, 135, 84) !important;
+}
+
+.text-danger {
+  color: rgb(220, 53, 69) !important;
+}
+
+.text-warning {
+  color: rgb(255, 193, 7) !important;
+}
+
+.text-info {
+  color: rgb(13, 202, 240) !important;
+}
+
+.text-light {
+  color: rgb(248, 249, 250) !important;
+}
+
+.text-dark {
+  color: rgb(33, 37, 41) !important;
+}
+
+.text-body {
+  color: rgb(33, 37, 41) !important;
+}
+
+.text-muted {
+  color: rgb(108, 117, 125) !important;
+}
+
+.text-white {
+  color: rgb(255, 255, 255) !important;
+}
+
+// IE11 doesn't support :not(:focus-within) so the rules defined in Bootstrap 5 are repeated here
+.visually-hidden,
+.visually-hidden-focusable:not(:focus) {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+// horizontal stack gap
+.hstack.gap-1 > * {
+  margin-right: 0.25rem;
+}
+
+.hstack.gap-1 > *:last-child {
+  margin-right: 0;
+}
+
+.hstack.gap-2 > * {
+  margin-right: 0.5rem;
+}
+
+.hstack.gap-2 > *:last-child {
+  margin-right: 0;
+}
+
+.hstack.gap-3 > * {
+  margin-right: 1rem;
+}
+
+.hstack.gap-3 > *:last-child {
+  margin-right: 0;
+}
+
+.hstack.gap-4 > * {
+  margin-right: 1.5rem;
+}
+
+.hstack.gap-4 > *:last-child {
+  margin-right: 0;
+}
+
+.hstack.gap-5 > * {
+  margin-right: 3rem;
+}
+
+.hstack.gap-5 > *:last-child {
+  margin-right: 0;
+}
+
+// vertical stack gap
+.vstack.gap-1 > * {
+  margin-bottom: 0.25rem;
+}
+
+.vstack.gap-1 > *:last-child {
+  margin-bottom: 0;
+}
+
+.vstack.gap-2 > * {
+  margin-bottom: 0.5rem;
+}
+
+.vstack.gap-2 > *:last-child {
+  margin-bottom: 0;
+}
+
+.vstack.gap-3 > * {
+  margin-bottom: 1rem;
+}
+
+.vstack.gap-3 > *:last-child {
+  margin-bottom: 0;
+}
+
+.vstack.gap-4 > * {
+  margin-bottom: 1.5rem;
+}
+
+.vstack.gap-4 > *:last-child {
+  margin-bottom: 0;
+}
+
+.vstack.gap-5 > * {
+  margin-bottom: 3rem;
+}
+
+.vstack.gap-5 > *:last-child {
+  margin-bottom: 0;
+}
+
+// vertical-rule
+.vr {
+  border-right: 1px solid rgb(33, 37, 41);
+}
+
+// flex
+.justify-content-evenly {
+  justify-content: space-around !important;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/bootstrap-ie11.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/bootstrap-ie11.scss
@@ -1,0 +1,25 @@
+/* stylelint-disable no-invalid-position-at-import-rule */
+
+@media all and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  @import "reboot";
+  @import "tables";
+  @import "utilities";
+  @import "breadcrumb";
+  @import "buttons";
+  @import "forms/form-check";
+  @import "forms/form-control";
+  @import "forms/form-floating-labels";
+  @import "forms/form-range";
+  @import "forms/form-select";
+  @import "card";
+  @import "accordion";
+  @import "modal";
+  @import "progress";
+  @import "list-group";
+  @import "close";
+  @import "carousel";
+  @import "tooltip";
+  @import "helpers/ratio";
+}
+
+/* stylelint-enable no-invalid-position-at-import-rule */

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-check.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-check.scss
@@ -1,0 +1,39 @@
+//
+// Check/radio
+//
+
+// makes the default checkbox icon nicer
+.form-check-input {
+  border-color: rgba(0, 0, 0, .25);
+  box-shadow: 0 0 0 1px rgba(111, 111, 111, 0.4);
+}
+
+// Hides the default caret
+.form-check-input::-ms-check {
+  color: transparent;
+  background-color: transparent;
+  border: 0;
+}
+
+// Unstyle the caret on `<select>`s
+select::-ms-expand {
+  display: none;
+}
+
+.form-check .form-check-input[type="radio"] {
+  margin-top: 0.27em;
+  margin-left: -1.3em;
+}
+
+//
+// Switch
+//
+
+.form-switch .form-check-input,
+.form-switch .form-check-input:focus {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 -4 8 8'%3e%3ccircle r='3' fill='%23ccc'/%3e%3c/svg%3e");
+}
+
+.form-switch :checked.form-check-input {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-8 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e");
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-control.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-control.scss
@@ -1,0 +1,14 @@
+.form-control:-ms-input-placeholder {
+  color: #6c757d;
+  opacity: 1;
+}
+
+// IE11 doesn't support input=color.
+// This changes the input so its not too narrow to allow a hex input (e.g. #FFFFFF)
+.form-control-color {
+  width: 5rem;
+}
+
+.form-control:disabled {
+  -ms-user-select: none !important;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-floating-labels.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-floating-labels.scss
@@ -1,0 +1,34 @@
+.form-floating {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.form-floating > .form-control::-ms-input-placeholder {
+  color: #6c757d;
+}
+
+.form-floating > .form-control:not(:-ms-input-placeholder) ~ label {
+  opacity: 0.65;
+  transform: scale(0.9) translateY(-0.01rem) translateX(0.15rem);
+}
+
+.form-floating input:-ms-input-placeholder,
+.form-floating select:-ms-input-placeholder,
+.form-floating textarea:-ms-input-placeholder {
+  color: transparent;
+}
+
+.form-floating input:not(:-ms-input-placeholder) {
+  padding-top: 1.25rem;
+  padding-bottom: .25rem;
+}
+
+.form-floating input:not(:-ms-input-placeholder) ~ label,
+.form-floating select:not(:-ms-input-placeholder) ~ label,
+.form-floating textarea:not(:-ms-input-placeholder) ~ label {
+  padding-top: .25rem;
+  padding-bottom: .25rem;
+  font-size: 14px;
+  color: #777;
+  opacity: .65;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-range.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-range.scss
@@ -1,0 +1,48 @@
+.form-range:focus::-ms-thumb {
+  box-shadow: 0 0 0 1px #fff, 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+.form-range::-ms-thumb {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0;
+  margin-right: 0.25rem;
+  margin-left: 0.25rem;
+  background-color: #0d6efd;
+  border: 0;
+  border-radius: 1rem;
+  transition:
+    background-color 0.15s ease-in-out, // stylelint-disable-line
+    border-color 0.15s ease-in-out, // stylelint-disable-line
+    box-shadow 0.15s ease-in-out;
+  appearance: none;
+}
+
+.form-range::-ms-thumb:active {
+  background-color: #b6d4fe;
+}
+
+.form-range::-ms-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: transparent;
+  border-color: transparent;
+  border-width: 0.5rem;
+}
+
+.form-range::-ms-fill-lower {
+  background-color: #dee2e6;
+  border-radius: 1rem;
+}
+
+.form-range::-ms-fill-upper {
+  margin-right: 15px;
+  background-color: #dee2e6;
+  border-radius: 1rem;
+}
+
+.form-range:disabled::-ms-thumb {
+  background-color: #adb5bd;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-select.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/forms/_form-select.scss
@@ -1,0 +1,4 @@
+.form-select:focus::-ms-value {
+  color: #495057;
+  background-color: #fff;
+}

--- a/packages/unity-bootstrap-theme/src/scss/ie11/scss/helpers/_ratio.scss
+++ b/packages/unity-bootstrap-theme/src/scss/ie11/scss/helpers/_ratio.scss
@@ -1,0 +1,15 @@
+.ratio-1x1::before {
+  padding-top: 100%;
+}
+
+.ratio-4x3::before {
+  padding-top: calc(3 / 4 * 100%);
+}
+
+.ratio-16x9::before {
+  padding-top: calc(9 / 16 * 100%);
+}
+
+.ratio-21x9::before {
+  padding-top: calc(9 / 21 * 100%);
+}

--- a/packages/unity-bootstrap-theme/webpack.config.js
+++ b/packages/unity-bootstrap-theme/webpack.config.js
@@ -19,6 +19,7 @@ const paths = {
   sass: path.resolve(__dirname, "src/scss"),
   css: path.resolve(__dirname, "dist/css"),
   node: path.resolve(__dirname, "node_modules"),
+  ie11Scss: path.resolve(__dirname, "src/scss/ie11/scss"),
 };
 
 const devtool = "source-map";
@@ -96,6 +97,10 @@ const cssConfig = {
     },
     "unity-bootstrap-footer": {
       import: path.resolve(paths.sass, "unity-bootstrap-footer.scss"),
+      filename: "../.tmp/[name].js",
+    },
+    "unity-bootstrap-ie11": {
+      import: path.resolve(paths.ie11Scss, "bootstrap-ie11.scss"),
       filename: "../.tmp/[name].js",
     },
   },


### PR DESCRIPTION
## Description
### This adds workarounds for the following IE11 bugs:

* Workaround for the SVG overflow bug
* Remove the default vertical scrollbar from textarea
* Correct the text-wrapping and color inheritance for legend
* Disable auto-hiding scrollbar to avoid overlap on `pre`
* Fixes for card image size bug
* Fixes for text color and text opacity utility classes
* Improved layout for justify-content-evenly flex utility
* Fixes for stacks gap spacing
* Add the correct display values for template and main
* Fixes for modals (.modal-dialog-centered and .modal-dialog-scrollable)
* Fixes for forms (inputs, checkboxes, radio buttons, switches, selects, ranges, placeholders and floating labels)
* Fix for the btn-close-white SVG icon color
* Fix for dark carousel previous and next SVG icon colors
* Fix for valid-tooltip & invalid-tooltip positioning
* Adds vendor prefixes for user-select-auto and user-select-none utilities
* Fix for .visually-hidden utility class
* Fix for vertical rule .vr class
* Fixes for Accordion button icons


### Links
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1289?atlOrigin=eyJpIjoiYWZiYzljZmY2YjdkNDBkYmFmYmE5ZjhlZWY1Nzc4MTciLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Edge

