### PR TITLE
fix(unity-bootstrap-theme): change classname for no gutters feature

### DIFF
--- a/packages/unity-bootstrap-theme/helpers/templates/full-width.js
+++ b/packages/unity-bootstrap-theme/helpers/templates/full-width.js
@@ -1,15 +1,16 @@
 import React from "react";
 
-export default (content) => {
+export default content => {
   return (
-    <div> {/* Storybook Bug, all options must have equal depth when using controls to switch */}
-      <div class="row no-gutters">
+    <div>
+      {/* Storybook Bug, all options must have equal depth when using controls to switch */}
+      <div class="row g-0">
         <div id="html-root" class="col uds-full-width">
           {/* Component start */}
-            { content }
+          {content}
           {/* Component end */}
         </div>
       </div>
     </div>
-  )
-}
+  );
+};


### PR DESCRIPTION
### Description

Align to new classes for BS5

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1329)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [x] No new console errors
- [ ] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
