### PR TITLE
fix(unity-bootstrap-theme): added container within navbar in examples

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_global-header.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_global-header.scss
@@ -614,7 +614,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
       @include transition;
     }
 
-    &.show svg.fa-chevron-down {
+    .show svg.fa-chevron-down {
       transform: rotate(180deg);
     }
 
@@ -622,7 +622,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
       @include gold-underline-mobile;
     }
 
-    &.active:after {
+    &:has(.nav-link.show)::after {
       @include gold-underline-expand-mobile;
     }
 
@@ -948,7 +948,7 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
         @include gold-underline-expand-desktop;
       }
 
-      &.dropdown.show:after {
+      &:has(.nav-link.show)::after {
         @include gold-underline-expand-desktop;
       }
 

--- a/packages/unity-bootstrap-theme/src/scss/extends/_global-header.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_global-header.scss
@@ -622,8 +622,10 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
       @include gold-underline-mobile;
     }
 
-    &:has(.nav-link.show)::after {
+    .nav-link.show::after {
       @include gold-underline-expand-mobile;
+      margin-left: 0;
+      width: 100%;
     }
 
     &.show:after {
@@ -948,8 +950,10 @@ $fa-search: url($image-assets-path + '/font-awesome-svg/search.svg');
         @include gold-underline-expand-desktop;
       }
 
-      &:has(.nav-link.show)::after {
+      .nav-link.show::after {
         @include gold-underline-expand-desktop;
+        margin-left: -.75rem; // parent element has left padding of .75rem
+        width: calc(100% + 1.5rem);
       }
 
       &.dropdown.megamenu.show:after {

--- a/packages/unity-bootstrap-theme/stories/organisms/global-header/global-header.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/organisms/global-header/global-header.templates.stories.js
@@ -100,6 +100,7 @@ export const Basic = (
           <div class="row">
             <div id="header-main" class="col-12">
               <div class="navbar navbar-expand-xl">
+                <div class="container-fluid">
                 <a class="navbar-brand" href="#" data-ga-header="asu logo">
                   <img
                     class="vert"
@@ -321,6 +322,7 @@ export const Basic = (
                     </div>
                   </div>
                 </div>
+                </div>
               </div>
             </div>
           </div>
@@ -433,6 +435,7 @@ export const DropDownMenus = (
           <div class="row">
             <div id="header-main" class="col-12">
               <div class="navbar navbar-expand-xl">
+                <div class="container-fluid">
                 <a class="navbar-brand" href="#" data-ga-header="asu logo">
                   <img
                     class="vert"
@@ -1413,6 +1416,7 @@ export const DropDownMenus = (
                     </div>
                   </div>
                 </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1524,6 +1528,7 @@ export const NoNavigation = (
           <div class="row">
             <div id="header-main" class="col-12">
               <div class="navbar navbar-expand-xl">
+                <div class="container-fluid">
                 <a class="navbar-brand" href="#" data-ga-header="asu logo">
                   <img
                     class="vert"
@@ -1651,6 +1656,7 @@ export const NoNavigation = (
                     </div>
                   </div>
                 </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1759,6 +1765,7 @@ export const NoNavigationAndWithButtons = (
           <div class="row">
             <div id="header-main" class="col-12">
               <div class="navbar navbar-expand-xl">
+                <div class="container-fluid">
                 <a class="navbar-brand" href="#" data-ga-header="asu logo">
                   <img
                     class="vert"
@@ -1904,6 +1911,7 @@ export const NoNavigationAndWithButtons = (
                     </div>
                   </div>
                 </div>
+                </div>
               </div>
             </div>
           </div>
@@ -2015,6 +2023,7 @@ export const ScrolledState = (
           <div class="row">
             <div id="header-main" class="col-12">
               <div class="navbar navbar-expand-xl">
+                <div class="container-fluid">
                 <a class="navbar-brand" href="#" asu-ga="asu logo">
                   <img
                     class="vert"
@@ -2340,6 +2349,7 @@ export const ScrolledState = (
                       </div>
                     </div>
                   </div>
+                </div>
                 </div>
               </div>
             </div>

--- a/packages/unity-bootstrap-theme/stories/organisms/global-header/global-header.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/organisms/global-header/global-header.templates.stories.js
@@ -698,7 +698,7 @@ export const DropDownMenus = (
                             </div>
                           </div>
                         </div>
-                        <div class="nav-item dropdown megamenu active header-dropdown-3">
+                        <div class="nav-item dropdown megamenu header-dropdown-3">
                           <a
                             class="nav-link"
                             href="#"


### PR DESCRIPTION
### Description
Containers are now supposed to be within `.navbar` classes. This is to simplify new css.
Mobile and desktop yellow underline on dropdowns did not come up anymore.
SVG's were not transforming on active

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1321?atlOrigin=eyJpIjoiOTkzODc3N2Q5YTZmNGZjZGI1ZmY3MTliNmZkMDczYTEiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

