### PR TITLE
fix(bootstrap4-theme): fix css minification error

### DIFF
--- a/packages/bootstrap4-theme/src/scss/extends/_card-and-image.scss
+++ b/packages/bootstrap4-theme/src/scss/extends/_card-and-image.scss
@@ -40,7 +40,7 @@ $uds-card-height: 466px;
       padding-bottom: $uds-size-spacing-2 !important;
     }
     .card {
-      max-height: calc($uds-card-height - $uds-size-spacing-8);
+      max-height: calc(#{$uds-card-height} - #{$uds-size-spacing-8});
 
       .card-icon-top {
         // the negative value of margin bottom is a simple workaround, this allows to respect the space between the title and the icon if both elements are present or the H1 and the top border of the card if the icon is not present


### PR DESCRIPTION
### Description

`Error: CSS minification error: Lexical error on line 1: Unrecognized text.` is related to a parser not supporting unescaped variables inside an scss calc() function

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1335)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes

### Images

Before change `/dist/css/bootstrap-asu.min.css` still had sass variable

![image](https://user-images.githubusercontent.com/5209283/233200002-36bf0db6-7053-496a-9bc3-0433d16c0f71.png)
