### PR TITLE
fix(unity-bootstrap-theme): removing Jumbotron

### DIFF
--- a/packages/unity-bootstrap-theme/stories/design/backgrounds/backgrounds.stories.js
+++ b/packages/unity-bootstrap-theme/stories/design/backgrounds/backgrounds.stories.js
@@ -86,7 +86,7 @@ export const imageBackgrounds = createStory(
 );
 
 export const backgroundsScaling = createStory(
-  <div class="jumbotron-fluid max-size-container scaling-container">
+  <div class="container-fluid max-size-container scaling-container">
     <span class="content-description">1920px max width</span>
     <div class="section-line"></div>
     <div class="content-description-container scaling-container">


### PR DESCRIPTION
### Description

Removed Jumbotron instance
Should I remove this whole comment or just the jumbotron class? https://github.com/ASU/asu-unity-stack/blob/migration-to-bs5/server/views/asuthemes/index.njk#L247

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1323)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples