### PR TITLE
build: added checks before deploying static site

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ spec:
 
                         withEnv(["GH_TOKEN=${RAW_GH_TOKEN_PSW}"]) {
                             echo '# Prebuild Storybook static site as dry-run...'
-                            sh 'yarn deploy-storybook --dry-run'
+                            sh 'yarn deploy-storybook:dev'
                             echo '# Compile templates and copy files for build deploy...'
                             sh 'yarn gulp'
                             echo '# Storybook static site final build and deploy...'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "percy": "lerna run percy",
     "start": "node server/server.js",
     "stop": "node server/server.stop.js",
-    "deploy-storybook": "storybook-to-ghpages --out=build --packages packages --monorepo-index-generator server/storybook-index-generator.js --source-branch=dev --ci",
+    "deploy-storybook:dev": "storybook-to-ghpages --out=build --packages packages --monorepo-index-generator server/storybook-index-generator.js --source-branch=dev --ci --dry-run",
+    "deploy-storybook": "node ./scripts/deploy-check.js && storybook-to-ghpages --out=build --packages packages --monorepo-index-generator server/storybook-index-generator.js --source-branch=dev --ci",
     "prepare": "husky install",
     "commit": "cz",
     "check-element-changes": "node ./scripts/check-element-changes.js -d"

--- a/scripts/deploy-check.js
+++ b/scripts/deploy-check.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const PATH_TO_CNAME = path.join(__dirname, '..', 'build', 'CNAME');
+
+if (!fs.existsSync(PATH_TO_CNAME)) {
+  console.error('ERR: no CNAME file found, cancelling build');
+  process.exit(1);
+} else {
+  console.log('CNAME file found or --dry-run flag added, continuing build');
+}


### PR DESCRIPTION
### Description
Added checks before deploying static storybook site by checking for CNAME file to ensure correct domain

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1347?atlOrigin=eyJpIjoiOWNkMmFiZWMyMTJhNDhlOWJjZmE2OTIwYjE5ZGUxZjQiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors