### PR TITLE
fix(unity-bootstrap-theme): replaced foldable card with accordion

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/_unity-bootstrap-theme-variables.scss
+++ b/packages/unity-bootstrap-theme/src/scss/_unity-bootstrap-theme-variables.scss
@@ -34,3 +34,4 @@
 @import "variables/modals";
 @import "variables/image-background-with-cta";
 @import "variables/tables";
+@import "variables/accordion";

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -113,7 +113,7 @@ Cards - Table of Contents
   }
 }
 
-.card-body {
+.card-body, .accordion-body {
   padding: 0 32px 24px 32px;
   flex-grow: 100;
 }
@@ -518,28 +518,28 @@ Cards - Table of Contents
   background-color: transparent;
 }
 
-.card-foldable {
+.accordion-item  {
   border-color: $uds-color-base-gray-3;
   border-left: $uds-size-spacing-1 solid $uds-color-base-gold;
   height: auto;
 
-  &.card-maroon {
+  &.accordion-item {
     border-left-color: $uds-color-base-maroon;
   }
 
-  &.card-gray {
+  &.accordion-item-gray {
     border-left-color: $uds-color-base-gray-4;
   }
 
-  &.card-dark {
+  &.accordion-item-dark {
     border-left-color: $uds-color-base-gray-7;
   }
 
-  .card-header {
+  .accordion-header {
     padding: $uds-size-spacing-1;
 
-    &.card-header-icon {
-      & .card-icon {
+    &.accordion-header-icon {
+      & .accordion-icon {
         display: flex;
         margin-left: calc($uds-size-spacing-3 / -2);
         align-items: flex-start;
@@ -585,12 +585,12 @@ Cards - Table of Contents
       }
     }
 
-    + .card-body {
+    + .accordion-body {
       border-top: 1px solid $uds-color-base-gray-3;
     }
   }
 
-  .card-body {
+  .accordion-body {
     background-color: $uds-color-base-gray-1;
 
     > p:first-child {
@@ -609,7 +609,7 @@ Cards - Table of Contents
 @mixin desktop-disable {
   border-left: 1px solid $uds-color-base-gray-3;
 
-  .card-header {
+  .accordion-header {
     h4 a {
       padding-top: $uds-size-spacing-4;
       padding-bottom: $uds-size-spacing-4;
@@ -628,11 +628,11 @@ Cards - Table of Contents
     }
   }
 
-  .card-header + .card-body {
+  .accordion-header + .accordion-body {
     border-top: 0;
   }
 
-  .card-body {
+  .accordion-body {
     background-color: transparent;
 
     > p:first-child {
@@ -658,19 +658,19 @@ Cards - Table of Contents
 }
 
 @include media-breakpoint-up(xl) {
-  .card-foldable.desktop-disable-xl {
+  .accordion-item.desktop-disable-xl {
     @include desktop-disable;
   }
 }
 
 @include media-breakpoint-up(lg) {
-  .card-foldable.desktop-disable-lg {
+  .accordion-item.desktop-disable-lg {
     @include desktop-disable;
   }
 }
 
 @include media-breakpoint-up(md) {
-  .card-foldable.desktop-disable-md {
+  .accordion-item.desktop-disable-md {
     @include desktop-disable;
   }
 }
@@ -679,10 +679,11 @@ Cards - Table of Contents
 7. Accordion
 --------------------------------------------------------------------*/
 .accordion {
-  .card.card-foldable {
+  .accordion-item {
     border-bottom: 1px solid $uds-color-base-gray-3;
+    border-top: 1px solid $uds-color-base-gray-3;
   }
-  .card-header .card-icon {
+  .accordion-header .accordion-icon {
     display: flex;
     align-items: center;
     margin-bottom: 0;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -523,7 +523,7 @@ Cards - Table of Contents
   border-left: $uds-size-spacing-1 solid $uds-color-base-gold;
   height: auto;
 
-  &.accordion-item {
+  &.accordion-item-maroon {
     border-left-color: $uds-color-base-maroon;
   }
 

--- a/packages/unity-bootstrap-theme/src/scss/variables/_accordion.scss
+++ b/packages/unity-bootstrap-theme/src/scss/variables/_accordion.scss
@@ -1,0 +1,3 @@
+// Bootstrap accordion variables to override.
+$accordion-border-radius: 0;
+// There are variables to override, but we just build on top of them.

--- a/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.examples.stories.js
@@ -3,8 +3,9 @@ export default createComponent("Accordions", "Atoms", "Examples");
 import { googleAnalytics as initFunc } from "../../../src/js/googleAnalytics";
 
 export const FoldableCardDefaultOpen = createStory(
-  <div class="card card-foldable">
-    <div class="card-header">
+  <div className="accordion">
+  <div class="accordion-item">
+    <div class="accordion-header">
       <h3>
         <a
           id="example-header-3"
@@ -27,7 +28,7 @@ export const FoldableCardDefaultOpen = createStory(
     </div>
     <div
       id="example-content-3"
-      class="collapse show card-body"
+      class="collapse show accordion-body"
       aria-labelledby="example-header-3"
     >
       <h4>This is a quaternary headline</h4>
@@ -47,7 +48,9 @@ export const FoldableCardDefaultOpen = createStory(
         tempor
       </p>
     </div>
-  </div>,
+  </div>
+  </div>
+  ,
   { initFunc }
 );
 FoldableCardDefaultOpen.args = {
@@ -56,8 +59,8 @@ FoldableCardDefaultOpen.args = {
 
 export const ColorAccents = createStory(
   <div class="accordion" id="accordionExample">
-    <div class="card card-foldable mt-3">
-      <div class="card-header">
+    <div class="card accordion-item mt-3">
+      <div class="accordion-header">
         <h4>
           <a
             id="cardOne"
@@ -80,10 +83,10 @@ export const ColorAccents = createStory(
           </a>
         </h4>
       </div>
-      {/* end .card-header */}
+      {/* end .accordion-header */}
       <div
         id="cardBodyOne"
-        class="collapse card-body"
+        class="collapse accordion-body"
         aria-labelledby="cardOne"
         data-bs-parent="#accordionExample"
       >
@@ -102,12 +105,12 @@ export const ColorAccents = createStory(
           minim veniam, quis nostrud
         </p>
       </div>
-      {/* end .card-body */}
+      {/* end .accordion-body */}
     </div>
     {/* end .card */}
 
-    <div class="card card-foldable mt-3 card-maroon">
-      <div class="card-header">
+    <div class="card accordion-item mt-3 accordion-item-maroon">
+      <div class="accordion-header">
         <h4>
           <a
             id="cardTwo"
@@ -131,7 +134,7 @@ export const ColorAccents = createStory(
       </div>
       <div
         id="cardBodyTwo"
-        class="collapse card-body"
+        class="collapse accordion-body"
         aria-labelledby="cardTwo"
         data-bs-parent="#accordionExample"
       >
@@ -153,12 +156,12 @@ export const ColorAccents = createStory(
           eiusmod tempor
         </p>
       </div>
-      {/* end .card-body */}
+      {/* end .accordion-body */}
     </div>
     {/* end .card */}
 
-    <div class="card card-foldable mt-3 card-gray">
-      <div class="card-header">
+    <div class="card accordion-item mt-3 accordion-item-gray">
+      <div class="accordion-header">
         <h4>
           <a
             id="cardThree"
@@ -182,7 +185,7 @@ export const ColorAccents = createStory(
       </div>
       <div
         id="cardBodyThree"
-        class="collapse card-body"
+        class="collapse accordion-body"
         aria-labelledby="cardThree"
         data-bs-parent="#accordionExample"
       >
@@ -200,12 +203,12 @@ export const ColorAccents = createStory(
           minim veniam, quis nostrud
         </p>
       </div>
-      {/* end .card-body */}
+      {/* end .accordion-body */}
     </div>
     {/* end .card */}
 
-    <div class="card card-foldable mt-3 card-dark">
-      <div class="card-header">
+    <div class="card accordion-item mt-3 accordion-item-dark">
+      <div class="accordion-header">
         <h4>
           <a
             id="cardFour"
@@ -228,10 +231,10 @@ export const ColorAccents = createStory(
           </a>
         </h4>
       </div>
-      {/* end .card-header */}
+      {/* end .accordion-header */}
       <div
         id="cardBodyFour"
-        class="collapse card-body"
+        class="collapse accordion-body"
         aria-labelledby="cardFour"
         data-bs-parent="#accordionExample"
       >
@@ -250,7 +253,7 @@ export const ColorAccents = createStory(
           minim veniam, quis nostrud
         </p>
       </div>
-      {/* end .card-body */}
+      {/* end .accordion-body */}
     </div>
     {/* end .card */}
   </div>,
@@ -259,8 +262,8 @@ export const ColorAccents = createStory(
 
 export const IncludedIcons = createStory(
   <div class="accordion" id="accordionExample">
-    <div class="card card-foldable mt-3">
-      <div class="card-header card-header-icon">
+    <div class="card accordion-item mt-3">
+      <div class="accordion-header accordion-header-icon">
         <h4>
           <a
             id="cardOne"
@@ -278,7 +281,7 @@ export const IncludedIcons = createStory(
             data-ga-region="main content"
             data-ga-section="default"
           >
-            <span class="card-icon">
+            <span class="accordion-icon">
               <i class="fas fa-dog me-2" role="img" aria-label="..."></i>
               Accordion with icon and gold color.
             </span>
@@ -286,10 +289,10 @@ export const IncludedIcons = createStory(
           </a>
         </h4>
       </div>
-      {/* end .card-header */}
+      {/* end .accordion-header */}
       <div
         id="cardBodyOne"
-        class="collapse card-body"
+        class="collapse accordion-body"
         aria-labelledby="cardOne"
         data-bs-parent="#accordionExample"
       >
@@ -308,12 +311,12 @@ export const IncludedIcons = createStory(
           minim veniam, quis nostrud
         </p>
       </div>
-      {/* end .card-body */}
+      {/* end .accordion-body */}
     </div>
     {/* end .card */}
 
-    <div class="card card-foldable mt-3 card-maroon">
-      <div class="card-header card-header-icon">
+    <div class="card accordion-item mt-3 accordion-item-maroon">
+      <div class="accordion-header accordion-header-icon">
         <h4>
           <a
             id="cardTwo"
@@ -330,7 +333,7 @@ export const IncludedIcons = createStory(
             data-ga-region="main content"
             data-ga-section="default"
           >
-            <span class="card-icon">
+            <span class="accordion-icon">
               <i class="fas fa-cat me-2" role="img" aria-label="..."></i>
               Accordion with icon and maroon color.
             </span>
@@ -340,7 +343,7 @@ export const IncludedIcons = createStory(
       </div>
       <div
         id="cardBodyTwo"
-        class="collapse card-body"
+        class="collapse accordion-body"
         aria-labelledby="cardTwo"
         data-bs-parent="#accordionExample"
       >
@@ -362,7 +365,7 @@ export const IncludedIcons = createStory(
           eiusmod tempor
         </p>
       </div>
-      {/* end .card-body */}
+      {/* end .accordion-body */}
     </div>
     {/* end .card */}
   </div>,
@@ -374,8 +377,9 @@ export const DisableFold = createStory(
     <div class="row mt-4">
       <div class="col-md-7">
         {/* Component start */}
-        <div class="card card-foldable desktop-disable-lg">
-          <div class="card-header">
+        <div class="accordion" id="accordionExample">
+        <div class="card accordion-item desktop-disable-lg">
+          <div class="accordion-header">
             <h4>
               <a
                 id="example-header-2"
@@ -398,7 +402,7 @@ export const DisableFold = createStory(
           </div>
           <div
             id="example-content-2"
-            class="collapse card-body"
+            class="collapse accordion-body"
             aria-labelledby="example-header-2"
           >
             <p>
@@ -412,6 +416,7 @@ export const DisableFold = createStory(
               sem.
             </p>
           </div>
+          </div>
         </div>
         {/* Component end */}
       </div>
@@ -420,8 +425,9 @@ export const DisableFold = createStory(
     <div class="row mt-4">
       <div class="col-md-7">
         {/* Component start */}
-        <div class="card card-foldable desktop-disable-xl">
-          <div class="card-header">
+        <div class="accordion" id="accordionExample">
+        <div class="card accordion-item desktop-disable-xl">
+          <div class="accordion-header">
             <h4>
               <a
                 id="example-header-3"
@@ -444,7 +450,7 @@ export const DisableFold = createStory(
           </div>
           <div
             id="example-content-3"
-            class="collapse card-body"
+            class="collapse accordion-body"
             aria-labelledby="example-header-3"
           >
             <p>
@@ -457,6 +463,7 @@ export const DisableFold = createStory(
               Donec quam felis, ultricies nec, pellentesque eu, pretium quis,
               sem.
             </p>
+          </div>
           </div>
         </div>
         {/* Component end */}

--- a/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.templates.stories.js
@@ -7,8 +7,8 @@ const FoldableCardElement = (
   linkID = null,
   bodyID = null
 ) => (
-  <div class="card card-foldable">
-    <div class="card-header">
+  <div class="card accordion-item">
+    <div class="accordion-header">
       <h3>
         <a
           id={`${linkID}`}
@@ -33,7 +33,7 @@ const FoldableCardElement = (
     </div>
     <div
       id={`${bodyID}`}
-      class="collapse card-body"
+      class="collapse accordion-body"
       aria-labelledby={`${linkID}`}
       data-bs-parent={accordionID ? `#${accordionID}` : ""}
     >

--- a/packages/unity-bootstrap-theme/stories/docs/accordion/accordion-basics.stories.mdx
+++ b/packages/unity-bootstrap-theme/stories/docs/accordion/accordion-basics.stories.mdx
@@ -87,7 +87,7 @@ A foldable card with an icon and and accent color might look like this:
     <h4>
       <a id="accordionOne" class="collapsed" href="#cardBodyOne" data-bs-toggle="collapse" data-bs-target="#accordionBodyOne" role="button" aria-expanded="false" aria-controls="cardBodyOne">
         <span class="accordion-icon">
-            <i class="fas fa-dog mr-2" role="img" aria-label="..."></i>
+            <i class="fas fa-dog me-2" role="img" aria-label="..."></i>
             Accordion with icon and gold color.
         </span>
         <span class="fas fa-chevron-up"></span>

--- a/packages/unity-bootstrap-theme/stories/docs/accordion/accordion-basics.stories.mdx
+++ b/packages/unity-bootstrap-theme/stories/docs/accordion/accordion-basics.stories.mdx
@@ -2,65 +2,99 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 <Meta title="Docs/Accordions" />
 
-## Foldable Card
+## Accordion
 
-The `.card-foldable` class is a modifying class for a generic card which creates a single section that expands and contracts independently of other surrounding foldable cards.
+The `.accordion` class is a bootstrap5 class that is used to create an accordion.
 
-- The cards will conform to the width of the surrounding container.
+- The accordions will conform to the width of the surrounding container.
 - There is a recommended character limit of 75 characters for the text within the header of a foldable card.
 
-The recommended markup for a foldable card begins from the following pattern.
+The recommended markup for an accordion begins from the following pattern.
 
-```
-<div class="card card-foldable">
-  <div class="card-header">
-    <h4>
-      <a id="example-header-1" class="collapsed" data-bs-toggle="collapse" href="#example-content-1" role="button" aria-expanded="false" aria-controls="example-content-1">Header Text
-        <span class="fas fa-chevron-up"></span>
-      </a>
-    </h4>
+```html
+<div className="accordion">
+  <div class="accordion-item">
+    <div class="accordion-header">
+      <h3>
+        <a
+          id="example-header-3"
+          data-bs-toggle="collapse"
+          href="#example-content-3"
+          role="button"
+          aria-expanded="true"
+          aria-controls="example-content-3"
+          data-ga="This card starts off in an unfolded state."
+          data-ga-name="onclick"
+          data-ga-event="collapse"
+          data-ga-type="click"
+          data-ga-region="main content"
+          data-ga-section="default"
+        >
+          This card starts off in an unfolded state.
+          <span class="fas fa-chevron-up"></span>
+        </a>
+      </h3>
+    </div>
+    <div
+      id="example-content-3"
+      class="collapse show accordion-body"
+      aria-labelledby="example-header-3"
+    >
+      <h4>This is a quaternary headline</h4>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud
+      </p>
+      <h5>This is a level five headline. There's a fancy word for that too.</h5>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud
+      </p>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor
+      </p>
+    </div>
   </div>
-  <div id="example-content-1" class="collapse card-body" aria-labelledby="example-header-1">
-    <h4>Content headline. Recommend H4 or H5.</h4>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud</p>
   </div>
-</div>
 ```
 
 ## Accent Colors and Icons
 
-Foldable cards can be accented with different colors from the ASU palette. The header of a foldable card can also include an optional icon from Font Awesome.
+Accordions can be accented with different colors from the ASU palette. The header of an accordion can also include an optional icon from Font Awesome.
 
-Include a modifying class along side of `.card-foldable` to produce different accent colors. Allowable colors are below:
+Include a modifying class along side of `.accordion to produce different accent colors. Allowable colors are below:
 
 | Modifier class | Produced Color     |
 | -------------- | ------------------ |
 | (none)         | ASU Gold (default) |
-| .card-maroon   | ASU Maroon         |
-| .card-gray     | ASU Gray 4         |
-| .card-dark     | ASU Gray 7 (Black) |
+| .accordion-item-maroon   | ASU Maroon         |
+| .accordion-item-gray     | ASU Gray 4         |
+| .accordion-item-dark     | ASU Gray 7 (Black) |
 
 To add an icon:
 
-- Include the modifying class `.card-header-icon` next to the `.card-header` declaration.
+- Include the modifying class `.accordion-header-icon` next to the `.accordion-header` declaration.
 - Any Font Awesome icon from the collection may be used.
 
 A foldable card with an icon and and accent color might look like this:
 
 ```
-<div class="card card-foldable mt-3 card-maroon">
-  <div class="card-header card-header-icon">
+<div class=" accordion mt-3 accordion-item-maroon">
+  <div class="accordion-header accordion-header-icon">
     <h4>
-      <a id="cardOne" class="collapsed" href="#cardBodyOne" data-bs-toggle="collapse" data-bs-target="#cardBodyOne" role="button" aria-expanded="false" aria-controls="cardBodyOne">
-        <span class="card-icon">
-            <i class="fas fa-dog me-2" role="img" aria-label="..."></i>
+      <a id="accordionOne" class="collapsed" href="#cardBodyOne" data-bs-toggle="collapse" data-bs-target="#accordionBodyOne" role="button" aria-expanded="false" aria-controls="cardBodyOne">
+        <span class="accordion-icon">
+            <i class="fas fa-dog mr-2" role="img" aria-label="..."></i>
             Accordion with icon and gold color.
         </span>
         <span class="fas fa-chevron-up"></span>
       </a>
     </h4>
   </div>
-  <div id="cardOne" class="collapse card-body" aria-labelledby="cardOne">
+  <div id="accordionTwo" class="collapse accordion-body" aria-labelledby="accordionOne">
     ...
   </div>
 </div>
@@ -70,7 +104,7 @@ A foldable card with an icon and and accent color might look like this:
 
 You may choose to disable the "fold" of a foldable card at a particular breakpoint in order to have an element appear expanded on desktop and collapsed on mobile.
 
-Include one of the following modifier classes next to the `.card-foldable` class to enable the functionality.
+Include one of the following modifier classes next to the `.accordion` class to enable the functionality.
 
 - `.desktop-disable-md` disables the fold at the `md` breakpoint and above.
 - `.desktop-disable-lg` and `.desktop-disable-xl` are also available.
@@ -78,46 +112,11 @@ Include one of the following modifier classes next to the `.card-foldable` class
 Example:
 
 ```
-<div class="card card-foldable desktop-disable-lg">
-  <div class="card-header">
+<div class="accordion desktop-disable-lg">
+  <div class="accordion-header">
     ...
   </div>
-  <div id="cardOne" class="collapse card-body" aria-labelledby="cardOne">
+  <div id="accordionOne" class="collapse accordion-body" aria-labelledby="accordionOne">
     ...
   </div>
 </div>
-```
-
-## Accordions
-
-With some small modifications, a series of foldable cards can be connected together to form an accordion.
-
-- Wrap the collection of foldable cards with an element containing the class of `.accordion` and a unique ID.
-- Include the `data-bs-parent` attribute within the card body element to properly toggle the folded/expanded state.
-- By default, foldable cards wrapped in an accordion will stack together with no spacing between them. Include a utility margin class between each card to space them apart properly. (`.mt-3` is recommended.)
-
-That markup looks like this when completed:
-
-```
-<div class="accordion" id="accordionExample">
-
-  <div class="card card-foldable mt-3">
-    <div class="card-header">
-      ...
-    </div>
-    <div id="cardBodyOne" class="collapse card-body" aria-labelledby="cardOne" data-bs-parent="#accordionExample">
-      ...
-    </div>
-  </div>
-
-  <div class="card card-foldable mt-3">
-    <div class="card-header">
-        ...
-    </div>
-    <div id="cardBodyTwo" class="collapse card-body" aria-labelledby="cardTwo" data-bs-parent="#accordionExample">
-      ...
-    </div>
-  </div>
-
-</div>
-```


### PR DESCRIPTION
### Description
Boostrap5 has a new accordion component that does not use the card class anymore

<!-- Solution -->
switched all card classes in accordion to accordion

### Links
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1326?atlOrigin=eyJpIjoiOWI2ZGVkNDM3M2IzNGFlNmFhMTc2MGIzMzFhNGYzZjEiLCJwIjoiaiJ9)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/f5a5b883-cec1-434e-998e-679e68709b16/variables/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
