### PR TITLE
fix(components-core): updated accordion classnames to new BS5

### DIFF
--- a/packages/components-core/src/components/Accordion/AccordionCard/index.js
+++ b/packages/components-core/src/components/Accordion/AccordionCard/index.js
@@ -17,12 +17,12 @@ import { sanitizeDangerousMarkup } from "../../../core/utils/html-utils";
  */
 export const AccordionCard = ({ id, item, openCard, onClick }) => (
   <div
-    className={classNames("card", "card-foldable", "mt-3", {
-      [`card-${item.color}`]: item.color,
-      [`card-header-icon`]: item.content.icon,
+    className={classNames("accordion-item", "mt-3", {
+      [`accordion-item-${item.color}`]: item.color,
+      [`accordion-header-icon`]: item.content.icon,
     })}
   >
-    <div className="card-header">
+    <div className="accordion-header">
       <h4>
         <a
           data-testid="accordion-opener"
@@ -35,14 +35,14 @@ export const AccordionCard = ({ id, item, openCard, onClick }) => (
           onClick={e => onClick(e, id, item.content.header)}
         >
           {item.content.icon ? (
-            <span className="card-icon">
+            <span className="accordion-icon">
               <i
                 className={`${item.content.icon?.[0]} fa-${item.content.icon?.[1]} me-2`}
               />
               {item.content.header}
             </span>
           ) : (
-            item.content.header
+            item.content?.header
           )}
           <i className="fas fa-chevron-up" />
         </a>
@@ -50,7 +50,7 @@ export const AccordionCard = ({ id, item, openCard, onClick }) => (
     </div>
     <div
       id={`card-body-${id}`}
-      className={classNames("collapse", "card-body", {
+      className={classNames("collapse", "accordion-body", {
         [`show`]: id === openCard,
       })}
       // eslint-disable-next-line react/no-danger


### PR DESCRIPTION
BREAKING CHANGE: New BS5 theme is used

### Description

<!-- Description of problem -->
Updated classnames of accordion to new unity-bootstrap-theme classes.
This fixes the accordions used in app-degree-pages

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1369?atlOrigin=eyJpIjoiNWNjM2IyN2ZkOTU5NGRiNTg0ZmFmMDZmOGUxYjk1ZDMiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks
