### PR TITLE
fix(asu-unity-stack): sitename position in header

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
-const express = require("express");
-const path = require("path");
-const nunjucks = require("nunjucks");
 const compression = require("compression");
+const express = require("express");
+const nunjucks = require("nunjucks");
+const path = require("path");
 
 const app = express();
 
@@ -50,7 +50,16 @@ app.get("/gtm-datalayer", function (req, res) {
 const server = require("http").createServer(app);
 const io = require("socket.io")(server);
 
-server.listen(3000);
+const PORT = 3000;
+const URL = `http://localhost:${PORT}`;
+
+server.listen(PORT, () => {
+  console.log("\nServer Details:");
+  console.log("------------------------------------");
+  console.log("| Server is running on port  |", PORT, " |");
+  console.log("| Access the application at  |", URL, " |");
+  console.log("------------------------------------");
+});
 
 io.on("connection", socketServer => {
   socketServer.on("npmStop", () => {

--- a/server/storybook-index-generator.js
+++ b/server/storybook-index-generator.js
@@ -73,57 +73,59 @@ module.exports = generateHTML = packages => `
       <div class="container-xl">
         <div class="row">
           <div id="header-main" class="col-12">
-            <nav class="navbar navbar-expand-xl" aria-label="Main">
+            <div class="navbar navbar-expand-xl" aria-label="Main">
+              <div class="container-fluid">
 
-              <a class="navbar-brand" href="#">
-                <img class="vert" src="./@asu/unity-bootstrap-theme/img/asu-logo/arizona-state-university-logo-vertical.png" alt="Arizona State University" />
-                <img class="horiz" src="./@asu/unity-bootstrap-theme/img/asu-logo/arizona-state-university-logo.png" alt="Arizona State University" />
-              </a>
+                <a class="navbar-brand" href="#">
+                  <img class="vert" src="./@asu/unity-bootstrap-theme/img/asu-logo/arizona-state-university-logo-vertical.png" alt="Arizona State University" />
+                  <img class="horiz" src="./@asu/unity-bootstrap-theme/img/asu-logo/arizona-state-university-logo.png" alt="Arizona State University" />
+                </a>
 
-              <button class="navbar-toggler collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#menubar" aria-controls="menubar" aria-expanded="false" aria-label="Toggle navigation">
-                <span title="Open mobile menu" class="fa fa-bars"></span>
-                <span title="Close mobile menu" class="fa-stack">
-                  <i class="fa fa-circle fa-stack-2x"></i>
-                  <i class="fa fa-times fa-stack-1x"></i>
-                </span>
-              </button>
+                <button class="navbar-toggler collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#menubar" aria-controls="menubar" aria-expanded="false" aria-label="Toggle navigation">
+                  <span title="Open mobile menu" class="fa fa-bars"></span>
+                  <span title="Close mobile menu" class="fa-stack">
+                    <i class="fa fa-circle fa-stack-2x"></i>
+                    <i class="fa fa-times fa-stack-1x"></i>
+                  </span>
+                </button>
 
-              <div class="navbar-container no-links">
+                <div class="navbar-container no-links">
 
-                <div class="title subdomain-name">
-                  Unity Design
-                </div>
-
-                <div class="collapse navbar-collapse w-100 justify-content-between" id="menubar">
-
-                  <!-- <form class="navbar-site-buttons form-inline">
-                    <a href="#" class="btn btn-md btn-maroon">CTA Button 1</a>
-                    <a href="#" class="btn btn-md btn-dark">CTA Button 2</a>
-                  </form> -->
-
-                  <div class="navbar-mobile-footer">
-                    <form class="form-inline navbar-mobile-search" action="https://search.asu.edu/search" method="get" name="gs">
-                      <input class="form-control" type="search" name="q" aria-label="Search" placeholder="Search ASU">
-                      <input name="site" value="default_collection" type="hidden">
-                      <input name="sort" value="date:D:L:d1" type="hidden">
-                      <input name="output" value="xml_no_dtd" type="hidden">
-                      <input name="ie" value="UTF-8" type="hidden">
-                      <input name="oe" value="UTF-8" type="hidden">
-                      <input name="client" value="asu_frontend" type="hidden">
-                      <input name="proxystylesheet" value="asu_frontend" type="hidden">
-                    </form>
-                    <div class="nav-grid">
-                      <a class="nav-link" href="https://asu.edu">ASU home</a>
-                      <a class="nav-link" href="https://my.asu.edu">My ASU</a>
-                      <a class="nav-link" href="https://asu.edu/about/colleges-and-schools">Colleges and schools</a>
-                      <a class="nav-link" href="https://weblogin.asu.edu/cgi-bin/login">Sign in</a>
-                    </div>
+                  <div class="title subdomain-name">
+                    <a data-ga-header="Subdomain name" href="#" title="Subdomain name home page">Unity Design</a>
                   </div>
 
+                  <div class="collapse navbar-collapse w-100 justify-content-between" id="menubar">
+
+                    <!-- <form class="navbar-site-buttons form-inline">
+                      <a href="#" class="btn btn-md btn-maroon">CTA Button 1</a>
+                      <a href="#" class="btn btn-md btn-dark">CTA Button 2</a>
+                    </form> -->
+
+                    <div class="navbar-mobile-footer">
+                      <form class="form-inline navbar-mobile-search" action="https://search.asu.edu/search" method="get" name="gs">
+                        <input class="form-control" type="search" name="q" aria-label="Search" placeholder="Search ASU">
+                        <input name="site" value="default_collection" type="hidden">
+                        <input name="sort" value="date:D:L:d1" type="hidden">
+                        <input name="output" value="xml_no_dtd" type="hidden">
+                        <input name="ie" value="UTF-8" type="hidden">
+                        <input name="oe" value="UTF-8" type="hidden">
+                        <input name="client" value="asu_frontend" type="hidden">
+                        <input name="proxystylesheet" value="asu_frontend" type="hidden">
+                      </form>
+                      <div class="nav-grid">
+                        <a class="nav-link" href="https://asu.edu">ASU home</a>
+                        <a class="nav-link" href="https://my.asu.edu">My ASU</a>
+                        <a class="nav-link" href="https://asu.edu/about/colleges-and-schools">Colleges and schools</a>
+                        <a class="nav-link" href="https://weblogin.asu.edu/cgi-bin/login">Sign in</a>
+                      </div>
+                    </div>
+
+                  </div>
                 </div>
               </div>
 
-            </nav>
+            </div>
           </div>
         </div>
       </div>

--- a/server/views/asuheader/index.njk
+++ b/server/views/asuheader/index.njk
@@ -196,151 +196,153 @@
                     id="header-main"
                   >
                     <div class="navbar navbar-expand-xl">
-                      <a
-                        class="navbar-brand"
-                        data-ga-header="asu logo"
-                        href="#"
-                      >
-                        <img
-                          alt="Arizona State University"
-                          class="vert"
-                          src="https://www.asu.edu/asuthemes/5.0/assets/arizona-state-university-logo-vertical.png"
-                        />
-                        <img
-                          alt="Arizona State University"
-                          class="horiz"
-                          src="https://www.asu.edu/asuthemes/5.0/assets/arizona-state-university-logo.png"
-                        />
-                      </a>
-                      <button
-                        aria-controls="menubar"
-                        aria-expanded="false"
-                        aria-label="Toggle navigation"
-                        class="navbar-toggler collapsed"
-                        data-ga-header="menu button label"
-                        data-ga-header-event="collapse"
-                        data-ga-header-type="click"
-                        data-bs-target="#menubar"
-                        data-bs-toggle="collapse"
-                        type="button"
-                      >
-                        <span
-                          alt=""
-                          class="fa fa-bars"
-                          title="Open mobile menu"
-                        ></span>
-                        <span
-                          class="fa-stack"
-                          title="Close mobile menu"
+                      <div class="container-fluid">
+                        <a
+                          class="navbar-brand"
+                          data-ga-header="asu logo"
+                          href="#"
                         >
-                          <i
-                            alt=""
-                            class="fa fa-circle fa-stack-2x"
-                          >
-                          </i>
-                          <i
-                            alt=""
-                            class="fa fa-times fa-stack-1x"
-                          ></i>
-                        </span>
-                      </button>
-                      <div class="navbar-container no-links">
-                        <div class="title subdomain-name">
-                          <a
-                            data-ga-header="Subdomain name"
-                            href="#"
-                            title="Subdomain name home page"
-                          >
-                            Unity Design
-                          </a>
-                        </div>
-                        <div
-                          class="collapse navbar-collapse w-100 justify-content-between"
-                          id="menubar"
+                          <img
+                            alt="Arizona State University"
+                            class="vert"
+                            src="https://www.asu.edu/asuthemes/5.0/assets/arizona-state-university-logo-vertical.png"
+                          />
+                          <img
+                            alt="Arizona State University"
+                            class="horiz"
+                            src="https://www.asu.edu/asuthemes/5.0/assets/arizona-state-university-logo.png"
+                          />
+                        </a>
+                        <button
+                          aria-controls="menubar"
+                          aria-expanded="false"
+                          aria-label="Toggle navigation"
+                          class="navbar-toggler collapsed"
+                          data-ga-header="menu button label"
+                          data-ga-header-event="collapse"
+                          data-ga-header-type="click"
+                          data-bs-target="#menubar"
+                          data-bs-toggle="collapse"
+                          type="button"
                         >
-                          <div class="navbar-mobile-footer pinned">
-                            <form
-                              action="https://search.asu.edu/search"
-                              class="form-inline navbar-mobile-search"
-                              method="get"
-                              name="gs"
+                          <span
+                            alt=""
+                            class="fa fa-bars"
+                            title="Open mobile menu"
+                          ></span>
+                          <span
+                            class="fa-stack"
+                            title="Close mobile menu"
+                          >
+                            <i
+                              alt=""
+                              class="fa fa-circle fa-stack-2x"
                             >
-                              <input
-                                aria-label="Search"
-                                class="form-control"
-                                name="q"
-                                placeholder="Search asu.edu"
-                                type="search"
-                              />
-                              <input
-                                name="site"
-                                type="hidden"
-                                value="default_collection"
-                              />
-                              <input
-                                name="sort"
-                                type="hidden"
-                                value="date:D:L:d1"
-                              />
-                              <input
-                                name="output"
-                                type="hidden"
-                                value="xml_no_dtd"
-                              />
-                              <input
-                                name="ie"
-                                type="hidden"
-                                value="UTF-8"
-                              />
-                              <input
-                                name="oe"
-                                type="hidden"
-                                value="UTF-8"
-                              />
-                              <input
-                                name="client"
-                                type="hidden"
-                                value="asu_frontend"
-                              />
-                              <input
-                                name="proxystylesheet"
-                                type="hidden"
-                                value="asu_frontend"
-                              />
-                            </form>
-                            <div class="nav-grid">
-                              <a
-                                class="nav-link"
-                                data-ga-header="asu home"
-                                data-ga-header-section="topbar"
-                                href="https://asu.edu"
+                            </i>
+                            <i
+                              alt=""
+                              class="fa fa-times fa-stack-1x"
+                            ></i>
+                          </span>
+                        </button>
+                        <div class="navbar-container no-links">
+                          <div class="title subdomain-name">
+                            <a
+                              data-ga-header="Subdomain name"
+                              href="#"
+                              title="Subdomain name home page"
+                            >
+                              Unity Design
+                            </a>
+                          </div>
+                          <div
+                            class="collapse navbar-collapse w-100 justify-content-between"
+                            id="menubar"
+                          >
+                            <div class="navbar-mobile-footer pinned">
+                              <form
+                                action="https://search.asu.edu/search"
+                                class="form-inline navbar-mobile-search"
+                                method="get"
+                                name="gs"
                               >
-                                ASU Home
-                              </a>
-                              <a
-                                class="nav-link"
-                                data-ga-header="my asu"
-                                data-ga-header-section="topbar"
-                                href="https://my.asu.edu"
-                              >
-                                My ASU
-                              </a>
-                              <a
-                                class="nav-link"
-                                data-ga-header="colleges and schools"
-                                data-ga-header-section="topbar"
-                                href="https://www.asu.edu/academics/colleges-schools"
-                              >
-                                Colleges and Schools
-                              </a>
-                              <a
-                                class="nav-link"
-                                data-ga-header="sign in"
-                                data-ga-header-section="topbar"
-                                href="https://weblogin.asu.edu/cgi-bin/login"
-                              >
-                                Sign In
-                              </a>
+                                <input
+                                  aria-label="Search"
+                                  class="form-control"
+                                  name="q"
+                                  placeholder="Search asu.edu"
+                                  type="search"
+                                />
+                                <input
+                                  name="site"
+                                  type="hidden"
+                                  value="default_collection"
+                                />
+                                <input
+                                  name="sort"
+                                  type="hidden"
+                                  value="date:D:L:d1"
+                                />
+                                <input
+                                  name="output"
+                                  type="hidden"
+                                  value="xml_no_dtd"
+                                />
+                                <input
+                                  name="ie"
+                                  type="hidden"
+                                  value="UTF-8"
+                                />
+                                <input
+                                  name="oe"
+                                  type="hidden"
+                                  value="UTF-8"
+                                />
+                                <input
+                                  name="client"
+                                  type="hidden"
+                                  value="asu_frontend"
+                                />
+                                <input
+                                  name="proxystylesheet"
+                                  type="hidden"
+                                  value="asu_frontend"
+                                />
+                              </form>
+                              <div class="nav-grid">
+                                <a
+                                  class="nav-link"
+                                  data-ga-header="asu home"
+                                  data-ga-header-section="topbar"
+                                  href="https://asu.edu"
+                                >
+                                  ASU Home
+                                </a>
+                                <a
+                                  class="nav-link"
+                                  data-ga-header="my asu"
+                                  data-ga-header-section="topbar"
+                                  href="https://my.asu.edu"
+                                >
+                                  My ASU
+                                </a>
+                                <a
+                                  class="nav-link"
+                                  data-ga-header="colleges and schools"
+                                  data-ga-header-section="topbar"
+                                  href="https://www.asu.edu/academics/colleges-schools"
+                                >
+                                  Colleges and Schools
+                                </a>
+                                <a
+                                  class="nav-link"
+                                  data-ga-header="sign in"
+                                  data-ga-header-section="topbar"
+                                  href="https://weblogin.asu.edu/cgi-bin/login"
+                                >
+                                  Sign In
+                                </a>
+                              </div>
                             </div>
                           </div>
                         </div>

--- a/server/views/gtm-datalayer/index.njk
+++ b/server/views/gtm-datalayer/index.njk
@@ -196,151 +196,153 @@
                     id="header-main"
                   >
                     <div class="navbar navbar-expand-xl">
-                      <a
-                        class="navbar-brand"
-                        data-ga-header="asu logo"
-                        href="#"
-                      >
-                        <img
-                          alt="Arizona State University"
-                          class="vert"
-                          src="https://www.asu.edu/asuthemes/5.0/assets/arizona-state-university-logo-vertical.png"
-                        />
-                        <img
-                          alt="Arizona State University"
-                          class="horiz"
-                          src="https://www.asu.edu/asuthemes/5.0/assets/arizona-state-university-logo.png"
-                        />
-                      </a>
-                      <button
-                        aria-controls="menubar"
-                        aria-expanded="false"
-                        aria-label="Toggle navigation"
-                        class="navbar-toggler collapsed"
-                        data-ga-header="menu button label"
-                        data-ga-header-event="collapse"
-                        data-ga-header-type="click"
-                        data-bs-target="#menubar"
-                        data-bs-toggle="collapse"
-                        type="button"
-                      >
-                        <span
-                          alt=""
-                          class="fa fa-bars"
-                          title="Open mobile menu"
-                        ></span>
-                        <span
-                          class="fa-stack"
-                          title="Close mobile menu"
+                      <div class="container-fluid">
+                        <a
+                          class="navbar-brand"
+                          data-ga-header="asu logo"
+                          href="#"
                         >
-                          <i
-                            alt=""
-                            class="fa fa-circle fa-stack-2x"
-                          >
-                          </i>
-                          <i
-                            alt=""
-                            class="fa fa-times fa-stack-1x"
-                          ></i>
-                        </span>
-                      </button>
-                      <div class="navbar-container no-links">
-                        <div class="title subdomain-name">
-                          <a
-                            data-ga-header="Subdomain name"
-                            href="#"
-                            title="Subdomain name home page"
-                          >
-                            Unity Design
-                          </a>
-                        </div>
-                        <div
-                          class="collapse navbar-collapse w-100 justify-content-between"
-                          id="menubar"
+                          <img
+                            alt="Arizona State University"
+                            class="vert"
+                            src="https://www.asu.edu/asuthemes/5.0/assets/arizona-state-university-logo-vertical.png"
+                          />
+                          <img
+                            alt="Arizona State University"
+                            class="horiz"
+                            src="https://www.asu.edu/asuthemes/5.0/assets/arizona-state-university-logo.png"
+                          />
+                        </a>
+                        <button
+                          aria-controls="menubar"
+                          aria-expanded="false"
+                          aria-label="Toggle navigation"
+                          class="navbar-toggler collapsed"
+                          data-ga-header="menu button label"
+                          data-ga-header-event="collapse"
+                          data-ga-header-type="click"
+                          data-bs-target="#menubar"
+                          data-bs-toggle="collapse"
+                          type="button"
                         >
-                          <div class="navbar-mobile-footer pinned">
-                            <form
-                              action="https://search.asu.edu/search"
-                              class="form-inline navbar-mobile-search"
-                              method="get"
-                              name="gs"
+                          <span
+                            alt=""
+                            class="fa fa-bars"
+                            title="Open mobile menu"
+                          ></span>
+                          <span
+                            class="fa-stack"
+                            title="Close mobile menu"
+                          >
+                            <i
+                              alt=""
+                              class="fa fa-circle fa-stack-2x"
                             >
-                              <input
-                                aria-label="Search"
-                                class="form-control"
-                                name="q"
-                                placeholder="Search asu.edu"
-                                type="search"
-                              />
-                              <input
-                                name="site"
-                                type="hidden"
-                                value="default_collection"
-                              />
-                              <input
-                                name="sort"
-                                type="hidden"
-                                value="date:D:L:d1"
-                              />
-                              <input
-                                name="output"
-                                type="hidden"
-                                value="xml_no_dtd"
-                              />
-                              <input
-                                name="ie"
-                                type="hidden"
-                                value="UTF-8"
-                              />
-                              <input
-                                name="oe"
-                                type="hidden"
-                                value="UTF-8"
-                              />
-                              <input
-                                name="client"
-                                type="hidden"
-                                value="asu_frontend"
-                              />
-                              <input
-                                name="proxystylesheet"
-                                type="hidden"
-                                value="asu_frontend"
-                              />
-                            </form>
-                            <div class="nav-grid">
-                              <a
-                                class="nav-link"
-                                data-ga-header="asu home"
-                                data-ga-header-section="topbar"
-                                href="https://asu.edu"
+                            </i>
+                            <i
+                              alt=""
+                              class="fa fa-times fa-stack-1x"
+                            ></i>
+                          </span>
+                        </button>
+                        <div class="navbar-container no-links">
+                          <div class="title subdomain-name">
+                            <a
+                              data-ga-header="Subdomain name"
+                              href="#"
+                              title="Subdomain name home page"
+                            >
+                              Unity Design
+                            </a>
+                          </div>
+                          <div
+                            class="collapse navbar-collapse w-100 justify-content-between"
+                            id="menubar"
+                          >
+                            <div class="navbar-mobile-footer pinned">
+                              <form
+                                action="https://search.asu.edu/search"
+                                class="form-inline navbar-mobile-search"
+                                method="get"
+                                name="gs"
                               >
-                                ASU Home
-                              </a>
-                              <a
-                                class="nav-link"
-                                data-ga-header="my asu"
-                                data-ga-header-section="topbar"
-                                href="https://my.asu.edu"
-                              >
-                                My ASU
-                              </a>
-                              <a
-                                class="nav-link"
-                                data-ga-header="colleges and schools"
-                                data-ga-header-section="topbar"
-                                href="https://www.asu.edu/academics/colleges-schools"
-                              >
-                                Colleges and Schools
-                              </a>
-                              <a
-                                class="nav-link"
-                                data-ga-header="sign in"
-                                data-ga-header-section="topbar"
-                                href="https://weblogin.asu.edu/cgi-bin/login"
-                              >
-                                Sign In
-                              </a>
+                                <input
+                                  aria-label="Search"
+                                  class="form-control"
+                                  name="q"
+                                  placeholder="Search asu.edu"
+                                  type="search"
+                                />
+                                <input
+                                  name="site"
+                                  type="hidden"
+                                  value="default_collection"
+                                />
+                                <input
+                                  name="sort"
+                                  type="hidden"
+                                  value="date:D:L:d1"
+                                />
+                                <input
+                                  name="output"
+                                  type="hidden"
+                                  value="xml_no_dtd"
+                                />
+                                <input
+                                  name="ie"
+                                  type="hidden"
+                                  value="UTF-8"
+                                />
+                                <input
+                                  name="oe"
+                                  type="hidden"
+                                  value="UTF-8"
+                                />
+                                <input
+                                  name="client"
+                                  type="hidden"
+                                  value="asu_frontend"
+                                />
+                                <input
+                                  name="proxystylesheet"
+                                  type="hidden"
+                                  value="asu_frontend"
+                                />
+                              </form>
+                              <div class="nav-grid">
+                                <a
+                                  class="nav-link"
+                                  data-ga-header="asu home"
+                                  data-ga-header-section="topbar"
+                                  href="https://asu.edu"
+                                >
+                                  ASU Home
+                                </a>
+                                <a
+                                  class="nav-link"
+                                  data-ga-header="my asu"
+                                  data-ga-header-section="topbar"
+                                  href="https://my.asu.edu"
+                                >
+                                  My ASU
+                                </a>
+                                <a
+                                  class="nav-link"
+                                  data-ga-header="colleges and schools"
+                                  data-ga-header-section="topbar"
+                                  href="https://www.asu.edu/academics/colleges-schools"
+                                >
+                                  Colleges and Schools
+                                </a>
+                                <a
+                                  class="nav-link"
+                                  data-ga-header="sign in"
+                                  data-ga-header-section="topbar"
+                                  href="https://weblogin.asu.edu/cgi-bin/login"
+                                >
+                                  Sign In
+                                </a>
+                              </div>
                             </div>
                           </div>
                         </div>


### PR DESCRIPTION
### Description

We had an error in HTML markup, I fixed that in all views of the monorepo index.
Also added a friendly output when you run `yarn start` command

There still seems to be a subtle difference between the index page and the others, which might be caused by some variation in our HTML. In the next steps, we should make some improvements to our templates to avoid code duplication, among other things.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1368)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<img width="802" alt="image" src="https://github.com/ASU/asu-unity-stack/assets/1083822/0f357457-c8c5-483f-a837-a0a0165bb3c8">
