### PR TITLE
fix(app-webdir-ui): make dept admin button display more exclusive

### DIFF
--- a/packages/app-webdir-ui/src/SearchPage/index.js
+++ b/packages/app-webdir-ui/src/SearchPage/index.js
@@ -18,6 +18,7 @@ function SearchPage({
   API_URL,
   searchApiVersion,
   loggedIn,
+  deptAdmin,
   profileURLBase,
   appPathFolder,
 }) {
@@ -147,7 +148,7 @@ function SearchPage({
             label="Edit my profile"
             href="/profile-edit"
           />
-          {loggedIn && (
+          {loggedIn && deptAdmin && (
             <Button
               color="gray"
               icon={["fas", "lock"]}
@@ -205,6 +206,7 @@ SearchPage.propTypes = {
   API_URL: PropTypes.string,
   searchApiVersion: PropTypes.string,
   loggedIn: PropTypes.bool,
+  deptAdmin: PropTypes.bool,
   profileURLBase: PropTypes.string,
   appPathFolder: PropTypes.string,
 };


### PR DESCRIPTION
UDS-1374

### Description

<!-- Description of problem -->
The Department Admin button displays for all logged-in users, which should not be the case. It should only show for those who have department admin privileges.
<!-- Solution -->
This PR is in conjunction with [ASUIS-1016](https://asudev.jira.com/browse/ASUIS-1016), which provides a new prop to be consumed by the React component. This PR adds a condition to the display of the block, based on the boolean value of the new prop, `deptAdmin`.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [https://asudev.jira.com/browse/UDS-1374](https://asudev.jira.com/browse/UDS-1374)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- (N/A) Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
