### PR TITLE
fix(unity-bootstrap-theme): add opacity rule for <hr/> elements

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_dividers.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_dividers.scss
@@ -3,6 +3,7 @@ hr {
   height: 1px;
   margin: $uds-size-spacing-6 0;
   background-color: $uds-color-base-gray-3;
+  opacity: 1;
 
   &.copy-divider {
     height: $uds-size-spacing-1;
@@ -10,4 +11,3 @@ hr {
     max-width: $uds-size-spacing-32;
   }
 }
-


### PR DESCRIPTION
### Description

The BS5 version includes a `reboot.scss` file that contains a CSS rule adding an opacity of 0.25 to `<hr />` elements. It should be removed.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1383)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

![image](https://github.com/ASU/asu-unity-stack/assets/1083822/e8b38759-835c-482a-bdf4-2f54dade2d1d)
