### PR TITLE
fix(unity-bootstrap-theme): change className to class for Calendar Code

### DIFF
--- a/packages/unity-bootstrap-theme/stories/molecules/calendar/calendar.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/calendar/calendar.js
@@ -88,21 +88,21 @@ export const initCalendar = function () {
   const render = () => {
     const calendarContainer = document.getElementById('calendar');
     calendarContainer.innerHTML = `
-      <h2><span className="highlight-black">${months[state.month]} ${
+      <h2><span class="highlight-black">${months[state.month]} ${
       state.year
     }</span></h2>
-      <div className="calendar-grid">
-        <div className="heading desktop">
+      <div class="calendar-grid">
+        <div class="heading desktop">
           ${desktopDaysOfWeek.map((day) => `<p>${day}</p>`).join('')}
         </div>
-        <div className="heading mobile">
+        <div class="heading mobile">
           ${mobileDaysOfWeek.map((day) => `<p>${day}</p>`).join('')}
         </div>
-        <div className="body">
+        <div class="body">
           ${datesForGrid(state.year, state.month)
             .map(
               (date) =>
-                `<h3 id="${date.key}" className="calendar-item ${
+                `<h3 id="${date.key}" class="calendar-item ${
                   date.monthClass
                 }" ${
                   date.todayClass
@@ -111,7 +111,7 @@ export const initCalendar = function () {
                       )}"`
                     : ''
                 }>
-                  <span className="${date.todayClass ? date.todayClass : ''}">${
+                  <span class="${date.todayClass ? date.todayClass : ''}">${
                   date.date
                 }</span>
                 </h3>`
@@ -119,7 +119,7 @@ export const initCalendar = function () {
             .join('')}
         </div>
       </div>
-      <div className="calendar-nav">
+      <div class="calendar-nav">
         <button
           id="prev-month"
           aria-label="Previous month"
@@ -131,7 +131,7 @@ export const initCalendar = function () {
           data-ga-section="calendar"
           data-ga="left chevron"
         >
-          <span className="fas fa-angle-left"></span>
+          <span class="fas fa-angle-left"></span>
         </button>
         <button
           id="next-month"
@@ -144,7 +144,7 @@ export const initCalendar = function () {
           data-ga-section="calendar"
           data-ga="right chevron"
         >
-          <span className="fas fa-angle-right"></span>
+          <span class="fas fa-angle-right"></span>
         </button>
       </div>
   `;


### PR DESCRIPTION
### Description
Styles were not included because the code was written to look like a react component but isn't so className was not being converted

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1381)