### PR TITLE
fix(unity-bootstrap-theme): added mt-3 class on accordion stories and…

### DIFF
--- a/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.examples.stories.js
@@ -4,7 +4,7 @@ import { googleAnalytics as initFunc } from "@asu/unity-bootstrap-theme/js/data-
 
 export const FoldableCardDefaultOpen = createStory(
   <div className="accordion">
-  <div className="accordion-item">
+  <div className="accordion-item mt-3">
     <div className="accordion-header">
       <h3>
         <a
@@ -59,7 +59,7 @@ FoldableCardDefaultOpen.args = {
 
 export const ColorAccents = createStory(
   <div className="accordion" id="accordionExample">
-    <div className="card accordion-item mt-3">
+    <div className="accordion-item mt-3">
       <div className="accordion-header">
         <h4>
           <a
@@ -109,7 +109,7 @@ export const ColorAccents = createStory(
     </div>
     {/* end .card */}
 
-    <div className="card accordion-item mt-3 accordion-item-maroon">
+    <div className="accordion-item mt-3 accordion-item-maroon">
       <div className="accordion-header">
         <h4>
           <a
@@ -160,7 +160,7 @@ export const ColorAccents = createStory(
     </div>
     {/* end .card */}
 
-    <div className="card accordion-item mt-3 accordion-item-gray">
+    <div className="accordion-item mt-3 accordion-item-gray">
       <div className="accordion-header">
         <h4>
           <a
@@ -207,7 +207,7 @@ export const ColorAccents = createStory(
     </div>
     {/* end .card */}
 
-    <div className="card accordion-item mt-3 accordion-item-dark">
+    <div className="accordion-item mt-3 accordion-item-dark">
       <div className="accordion-header">
         <h4>
           <a
@@ -262,7 +262,7 @@ export const ColorAccents = createStory(
 
 export const IncludedIcons = createStory(
   <div className="accordion" id="accordionExample">
-    <div className="card accordion-item mt-3">
+    <div className="accordion-item mt-3">
       <div className="accordion-header accordion-header-icon">
         <h4>
           <a
@@ -315,7 +315,7 @@ export const IncludedIcons = createStory(
     </div>
     {/* end .card */}
 
-    <div className="card accordion-item mt-3 accordion-item-maroon">
+    <div className="accordion-item mt-3 accordion-item-maroon">
       <div className="accordion-header accordion-header-icon">
         <h4>
           <a
@@ -378,7 +378,7 @@ export const DisableFold = createStory(
       <div className="col-md-7">
         {/* Component start */}
         <div className="accordion" id="accordionExample">
-        <div className="card accordion-item desktop-disable-lg">
+        <div className="accordion-item desktop-disable-lg">
           <div className="accordion-header">
             <h4>
               <a
@@ -426,7 +426,7 @@ export const DisableFold = createStory(
       <div className="col-md-7">
         {/* Component start */}
         <div className="accordion" id="accordionExample">
-        <div className="card accordion-item desktop-disable-xl">
+        <div className="accordion-item desktop-disable-xl">
           <div className="accordion-header">
             <h4>
               <a

--- a/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.templates.stories.js
@@ -8,7 +8,7 @@ const FoldableCardElement = (
   bodyID = null
 ) => (
   <div className="accordion">
-    <div className="card accordion-item">
+    <div className="accordion-item mt-3">
       <div className="accordion-header">
         <h3>
           <a


### PR DESCRIPTION
… removed card class

### Description

<!-- Description of problem -->
Accordion stories needed mt-3 class added to enforce spacing between accordion items. 
`.card` class was removed from accordion-item as well since it is not needed

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1391?atlOrigin=eyJpIjoiODYwNDZiNTg2MWJlNDdhZGJlZDc5YmY4MTZjYjYxOWMiLCJwIjoiaiJ9)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/f5a5b883-cec1-434e-998e-679e68709b16/specs/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge