### PR TITLE
fix(app-rfi): phone field styles issues

### DIFF
--- a/packages/app-rfi/src/components/AsuRfi/index.css
+++ b/packages/app-rfi/src/components/AsuRfi/index.css
@@ -62,6 +62,9 @@ form.uds-form.uds-rfi
   -webkit-box-shadow: 0 !important;
   box-shadow: none !important;
 }
+form.uds-form.uds-rfi .rfi-phone-form-group .rfi-phone-input-dropdown {
+  margin: 0;
+}
 form.uds-form.uds-rfi .rfi-phone-form-group .rfi-phone-input-dropdown:focus {
   border: 2px solid #191919 !important;
   outline: 0;

--- a/packages/app-rfi/src/components/controls/RfiPhone.js
+++ b/packages/app-rfi/src/components/controls/RfiPhone.js
@@ -42,7 +42,6 @@ const RfiPhone = ({
                 required: required,
               }}
               {...field}
-              className="form-control"
               placeholder={helperText}
               country={values.Country ? values.Country.toLowerCase() : "us"}
               preferredCountries={["us"]}


### PR DESCRIPTION
### Description

RFI component: phone form field styles issues

### Solution
 Remove extra class wrapped around phone input element

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/app-rfi/index.html?path=/story/uds-asurfi--rfi-test-mode)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1331)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
