### PR TITLE
refactor(component-footer): update Footer Site Name Tag from h5 to p.h5

### DIFF
--- a/packages/component-footer/src/components/ColumnSection/index.js
+++ b/packages/component-footer/src/components/ColumnSection/index.js
@@ -25,7 +25,7 @@ const ColumnSection = ({ columnIndex, column: { title, links } }) => {
           tabIndex={0}
           data-bs-toggle="collapse"
         >
-          <h5>
+          <p className="h5">
             <a
               id={`footlink-header-${columnIndex}`}
               className="collapsed"
@@ -35,7 +35,7 @@ const ColumnSection = ({ columnIndex, column: { title, links } }) => {
               {title}
               <FontAwesomeIcon icon={faChevronUp} />
             </a>
-          </h5>
+          </p>
         </div>
         <div
           id={`footlink-${columnIndex}`}

--- a/packages/component-footer/src/components/Contact/index.js
+++ b/packages/component-footer/src/components/Contact/index.js
@@ -18,7 +18,7 @@ const Contact = ({
       <div className="container" id="footer-columns">
         <div className="row" data-testid="columns-container">
           <div className="col-xl-3" id="info-column">
-            <h5>{title}</h5>
+            <p className="h5">{title}</p>
             {contactLink && (
               <p className="contact-link">
                 <a href={contactLink}>Contact Us</a>

--- a/packages/unity-bootstrap-theme/stories/organisms/global-footer/global-footer.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/organisms/global-footer/global-footer.templates.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
-import endorsedLogo from "./ASU_UniversityTechOffice_2_Horiz_RGB_White_150ppi.png";
+
 import innovationLockup from "./200420-GlobalFooter-No1InnovationLockup.png";
+import endorsedLogo from "./ASU_UniversityTechOffice_2_Horiz_RGB_White_150ppi.png";
 
 export const GlobalElementsOnly = (
   <footer
@@ -936,7 +937,7 @@ export const TwoColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -949,7 +950,7 @@ export const TwoColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-two"
@@ -1240,7 +1241,7 @@ export const ThreeColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -1253,7 +1254,7 @@ export const ThreeColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-two"
@@ -1283,7 +1284,7 @@ export const ThreeColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-three"
                       className="collapsed"
@@ -1296,7 +1297,7 @@ export const ThreeColumns = (
                       Student Information
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-three"
@@ -1592,7 +1593,7 @@ export const FourColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -1605,7 +1606,7 @@ export const FourColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-two"
@@ -1635,7 +1636,7 @@ export const FourColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-three"
                       className="collapsed"
@@ -1648,7 +1649,7 @@ export const FourColumns = (
                       Student Information
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-three"
@@ -1683,7 +1684,7 @@ export const FourColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-four"
                       className="collapsed"
@@ -1696,7 +1697,7 @@ export const FourColumns = (
                       Column Number Four
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-four"
@@ -1992,7 +1993,7 @@ export const FiveColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -2005,7 +2006,7 @@ export const FiveColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-two"
@@ -2035,7 +2036,7 @@ export const FiveColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-three"
                       className="collapsed"
@@ -2048,7 +2049,7 @@ export const FiveColumns = (
                       Student Information
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-three"
@@ -2083,7 +2084,7 @@ export const FiveColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-four"
                       className="collapsed"
@@ -2096,7 +2097,7 @@ export const FiveColumns = (
                       Column Number Four
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-four"
@@ -2131,7 +2132,7 @@ export const FiveColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-five"
                       className="collapsed"
@@ -2144,7 +2145,7 @@ export const FiveColumns = (
                       Mambo Number Five
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-five"
@@ -2440,7 +2441,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -2453,7 +2454,7 @@ export const SixColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-two"
@@ -2483,7 +2484,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-three"
                       className="collapsed"
@@ -2496,7 +2497,7 @@ export const SixColumns = (
                       Student Information
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-three"
@@ -2531,7 +2532,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-four"
                       className="collapsed"
@@ -2544,7 +2545,7 @@ export const SixColumns = (
                       Column Number Four
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-four"
@@ -2579,7 +2580,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-five"
                       className="collapsed"
@@ -2592,7 +2593,7 @@ export const SixColumns = (
                       Mambo Number Five
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-five"
@@ -2627,7 +2628,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <h5>
+                  <p className="h5">
                     <a
                       id="footlink-header-six"
                       className="collapsed"
@@ -2640,7 +2641,7 @@ export const SixColumns = (
                       The Zen Master and the Hot Dog Vendor
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </h5>
+                  </p>
                 </div>
                 <div
                   id="footlink-six"

--- a/packages/unity-bootstrap-theme/stories/organisms/global-footer/global-footer.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/organisms/global-footer/global-footer.templates.stories.js
@@ -490,9 +490,9 @@ export const OneColumn = (
       <div className="container" id="footer-columns">
         <div className="row">
           <div className="col-xl-3" id="info-column">
-            <h5>
+            <p className="h5">
               Complete Name of College, School or Unit Title Should Go Here
-            </h5>
+            </p>
             <p className="contact-link">
               <a href="#">Contact Us</a>
             </p>
@@ -660,9 +660,9 @@ export const OneColumnNoLogoOrSocial = (
       <div className="container" id="footer-columns">
         <div className="row">
           <div className="col-xl-3" id="info-column">
-            <h5>
+            <p className="h5">
               Complete Name of College, School or Unit Title Should Go Here
-            </h5>
+            </p>
             <p className="contact-link">
               <a href="#">Contact Us</a>
             </p>
@@ -920,9 +920,9 @@ export const TwoColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl-3" id="info-column">
-              <h5>
+              <p className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </h5>
+              </p>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -1224,9 +1224,9 @@ export const ThreeColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl" id="info-column">
-              <h5>
+              <p className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </h5>
+              </p>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -1576,9 +1576,9 @@ export const FourColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl" id="info-column">
-              <h5>
+              <p className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </h5>
+              </p>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -1976,9 +1976,9 @@ export const FiveColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl" id="info-column">
-              <h5>
+              <p className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </h5>
+              </p>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -2424,9 +2424,9 @@ export const SixColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl" id="info-column">
-              <h5>
+              <p className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </h5>
+              </p>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>


### PR DESCRIPTION
### Description

SEO best practice to not skip heading levels. As an example, we have pages with an H1, H2, and H3. Without an H4, the headings automatically skip a level when it has the H5 in the footer.

### Solution

Swapping the `<h5>` footer site name with `<p class="h5">`

### Links
- [Unity reference site - component-footer](https://unity.web.asu.edu/@asu/component-footer/index.html?path=/story/uds-asu-footer--three-columns)
- [Unity reference site - unity-bootstrap-theme](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/organisms-global-footer-examples--three-columns-example&args=template:0;header:false;footer:false)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1305)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge
