### PR TITLE
refactor(unity-bootstrap-theme): fixed Hero stories images

### DIFF
--- a/packages/unity-bootstrap-theme/stories/molecules/heroes/heroes.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/heroes/heroes.examples.stories.js
@@ -5,6 +5,7 @@ import {
 } from "../../../helpers/wrapper.js";
 import { initVideo as initFunc } from "./heroes-video";
 import stockVideo from "../../atoms/video/stock-video-person-drawing.mp4";
+import exampleImage from "../cards/example-image.jpg";
 
 export default createComponent("Heroes", "Molecules", "Examples");
 
@@ -13,7 +14,7 @@ export const HeroMedium = createStory(
     <div className="hero-overlay"></div>
     <img
       className="hero"
-      src="https://source.unsplash.com/random/2560x512"
+      src={exampleImage}
       alt="Sample placeholder image."
       width="2560"
       height="512"
@@ -76,7 +77,7 @@ export const HeroLarge = createStory(
       <div className="hero-overlay"></div>
       <img
         className="hero"
-        src="https://source.unsplash.com/random/2560x512"
+        src={exampleImage}
         alt="Sample placeholder image."
         width="2560"
         height="512"
@@ -123,7 +124,7 @@ export const StoryHeroLarge = createStory(
     <section className="uds-story-hero uds-story-hero-lg entry-header">
       <img
         className="hero"
-        src="https://source.unsplash.com/random/2560x512"
+        src={exampleImage}
         alt="Sample placeholder image."
         width="2560"
         height="512"
@@ -205,7 +206,7 @@ export const HeroVideo = createStory(
         <div className="hero-overlay"></div>
         <img
           className="hero"
-          src="https://source.unsplash.com/random/2560x512"
+          src={exampleImage}
           alt="Sample placeholder image."
           width="2560"
           height="512"

--- a/packages/unity-bootstrap-theme/stories/molecules/heroes/heroes.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/heroes/heroes.templates.stories.js
@@ -4,6 +4,7 @@ import {
   layoutNames,
 } from "../../../helpers/wrapper.js";
 import { googleAnalytics as initFunc } from "@asu/unity-bootstrap-theme/js/data-layer.js";
+import exampleImage from "../cards/example-image.jpg";
 
 const extraOptions = {
   size: {
@@ -35,7 +36,7 @@ export const HeroSmallOneButton = createStory(
         <div className="hero-overlay"></div>
         <img
           className="hero"
-          src="https://source.unsplash.com/random/2560x512"
+          src={exampleImage}
           alt="Sample placeholder image."
           width="2560"
           height="512"
@@ -82,7 +83,7 @@ export const HeroSmallTwoButtons = createStory(
         <div className="hero-overlay"></div>
         <img
           className="hero"
-          src="https://source.unsplash.com/random/2560x512"
+          src={exampleImage}
           alt="Sample placeholder image."
           width="2560"
           height="512"
@@ -144,7 +145,7 @@ export const StoryHero = createStory(
   <section className="uds-story-hero">
     <img
       className="hero"
-      src="https://source.unsplash.com/random/2560x512"
+      src={exampleImage}
       alt="Sample placeholder image."
       width="2560"
       height="512"


### PR DESCRIPTION
### Description
Hero stories had unsplash image that was removed

<!-- Solution -->
Replaced with static image

### Links
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1388?atlOrigin=eyJpIjoiYTUyOGViMDVmODg2NDViZDgyM2IxZDY3OWE3MmZiMjgiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
