### PR TITLE
fix(unity-bootstrap-theme): show modal close button in smaller view

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_modals.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_modals.scss
@@ -2,16 +2,16 @@
   align-items: center;
   // Use rgba instead of opacity because opacity will affect children
   background-color: $uds-modal-overlay-background-color;
-  bottom: 0;
   display: none;
   justify-content: center;
   left: 0;
   opacity: 0;
-  padding: 0 32px;
+  padding: 4rem 2rem;
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 999;
+  z-index: 1030;
+  min-height: 100vh;
 
   &.open {
     animation: fadeIn $uds-time-transition-base ease-out forwards; // .4s


### PR DESCRIPTION
### Description
Modal Close button is hidden in mobile view
### Solution
Adjust CSS to allow space above popup
Modal should have higher z-index than Header

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-0000)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] ~Add/updated examples~
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<img width="932" alt="image" src="https://github.com/ASU/asu-unity-stack/assets/5209283/9e63a55c-3bd2-489c-a4dc-2df0c9b0c221">