### PR TITLE
fix(unity-bootstrap-theme): update blockquote image size in breakpoint

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_blockquotes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_blockquotes.scss
@@ -164,8 +164,8 @@ blockquote:before {
       gap: $uds-size-spacing-4;
 
       img {
-        width: 180px;
-        height: 180px;
+        width: 120px;
+        height: 120px;
       }
     }
 


### PR DESCRIPTION
NOT TO BE MERGED UNTIL ORIGINAL WS2 FIX IS CONFIRMED.

### Description

With blockquote images, on different breakpoints the image will skew, then disappear, then reappear set to the left in some use cases.

Solution: Adjusting images styles in the blockquote component for different resolutions.

(Note, this PR is derived from https://github.com/ASUWebPlatforms/webspark-ci/pull/53 doesn't regress and to address this edge case)

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1640)
