### PR TITLE
fix(unity-bootstrap-theme): update pagination css

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_pager.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_pager.scss
@@ -6,30 +6,37 @@
     // "%23" escapes "#" which does not work when the SVG is an inline value
     $fill-color: '%23' + str-slice('' + $fill-color, 2);
   }
-
-  $bg-icon: "data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' data-fa-i2svg=''>";
+  $svg-path: "<path fill='#{$fill-color}' d='M207.029 381.476L12.686 " +
+    "187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 " +
+    "24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 " +
+    "24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 " +
+    "33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'></path>";
+  $bg-icon: "data:image/svg+xml; utf8, " +
+    "<svg xmlns='http://www.w3.org/2000/svg' " +
+    "viewBox='0 0 448 512' " +
+    "data-fa-i2svg=''>#{$svg-path}</svg>";
 
   @if $direction == 'left' {
-    $bg-icon: $bg-icon +
-      "<path fill='#{$fill-color}' d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'></path></svg>";
+    transform: rotate(90deg);
   }
-
   @if $direction == 'right' {
-    $bg-icon: $bg-icon +
-      "<path fill='#{$fill-color}' d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'></path></svg>";
+    transform: rotate(270deg);
   }
 
   content: url($bg-icon);
 }
 
-a.page-link,
-a.page-link:visited {
-  border-radius: $uds-component-border-radius;
-  text-decoration: none;
-  font-weight: bold;
-  color: $uds-color-base-gray-7;
-  transition: 0.1s ease-out;
-  font-size: 14px;
+a.page-link {
+  &, &:visited {
+    border-radius: $uds-component-border-radius;
+    text-decoration: none;
+    font-weight: bold;
+    transition: 0.1s ease-out;
+    font-size: 14px;
+  }
+  .page-item:not(.active) &:not(:focus):visited {
+    color: $uds-color-base-gray-7;
+  }
 }
 a.page-link:hover {
   color: $uds-color-base-gray-7;
@@ -43,39 +50,34 @@ span.page-link {
     color: inherit;
   }
 }
-.page-item:last-child .page-link {
-  border-radius: $uds-component-border-radius;
-}
+.page-item:last-child .page-link,
 .page-item:first-child .page-link {
   border-radius: $uds-component-border-radius;
+  display: flex;
+}
+.page-item:last-child .page-link-icon:after,
+.page-item:first-child .page-link-icon:before {
+  align-self: center;
+  display: block;
+  font-size: inherit;
+  width: 1rem;
+  height: 1rem;
+
+  .disabled & {
+    opacity: 0.5;
+  }
 }
 .page-item:last-child .page-link-icon:after {
-  display: inline-block;
-  font-size: inherit;
   @include bg-arrow-icon('currentColor', right);
-  transform: rotate(270deg);
-  float: right;
-  height: 1rem;
-  width: 1rem;
-  margin-left: 0.25rem;
 }
 .page-item:first-child .page-link-icon:before {
-  display: inline-block;
-  font-size: inherit;
   @include bg-arrow-icon('currentColor', left);
-  transform: rotate(90deg);
-  float: left;
-  height: 1rem;
-  width: 1rem;
-  margin-right: 0.25rem;
-}
-.disabled .page-link-icon:before,
-.disabled .page-link-icon:after {
-  opacity: 0.5;
 }
 
 .pagination {
   overflow-x: auto;
+  padding: $pagination-padding-y $pagination-padding-x;
+  gap: 1rem;
   &.uds-bg-gray1 {
     background-color: $uds-color-base-gray-1;
 
@@ -137,8 +139,8 @@ span.page-link {
   }
 }
 @include media-breakpoint-down(md) {
-  .page-item {
-    margin: 0 0.2rem;
+  .pagination {
+    gap: .4rem;
   }
   a.page-link {
     font-size: 14px;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_pagination.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_pagination.scss
@@ -1,13 +1,13 @@
 .page-item {
-  margin: 0 $uds-size-spacing-1; // .5rem = 8px margin on each side, or 16px between each page-item
+  margin: 0;
   white-space: nowrap;
+  display: flex;
+  align-items: stretch;
 
   @media (max-width: 576px) {
-    margin: 0 .25rem;
     max-width: 34px;
   }
   &.elipses {
     max-width: 24px;
-    margin: 0 .15rem;
   }
 }

--- a/packages/unity-bootstrap-theme/stories/molecules/pagination/pagination.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/pagination/pagination.examples.stories.js
@@ -129,7 +129,7 @@ export const LargeNumbersComponent = createStory(
       <li className="page-item">
         <span className="page-link elipses">...</span>
       </li>
-      <li className="page-item elipses">
+      <li className="page-item">
         <a className="page-link" href="#">
           50
         </a>


### PR DESCRIPTION
### Description

Prev and Next hover background on pager is squashed

Adjusted CSS

Extras:
fixed bug in example

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-pagination-examples--disabled-and-active-states-component&args=header:false;footer:false;template:1)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1389)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/1af28db0-6c0f-4f44-b288-996e15054412/)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [ ] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images
![image](https://github.com/ASU/asu-unity-stack/assets/5209283/aec4857a-be83-4102-ae2d-4444c53096a8)
