### PR TITLE
fix(component-header): fixed aria-owns and id attrs for submenus

### DIFF
--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/DropdownItem/index.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/DropdownItem/index.js
@@ -30,6 +30,7 @@ const DropdownItem = ({ dropdownName, items, buttons, classes, listId }) => {
   const isMega = items?.length > 2;
   const dropdownRef = useRef(null);
   const [alignedRight, setAlignedRight] = useState(false);
+  const MULTIPLE_SUBMENUS = items?.length > 1;
 
   useEffect(() => {
     if (window && dropdownRef.current) {
@@ -91,12 +92,12 @@ const DropdownItem = ({ dropdownName, items, buttons, classes, listId }) => {
       // @ts-ignore
       breakpoint={breakpoint}
     >
-      <div className="dropdown-container">
+      <div id={MULTIPLE_SUBMENUS ? listId : null } className="dropdown-container">
         {items?.map((item, index0) => {
           const genKey = idGenerator(`dropdown-item-${index0}-`);
           const key = genKey.next().value;
           return (
-            <ul id={listId} key={key}>
+            <ul id={MULTIPLE_SUBMENUS ? `${listId}-${key}` : listId} key={key}>
               {item.map((link, index) => renderItem(link, index))}
             </ul>
           );


### PR DESCRIPTION
fixed aria-owns and id attrs for submenus

### Description
Submenus in main header dropdown menus had same id which also affected aria-owns of parent control element

<!-- Description of problem -->
<!-- Solution -->

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/component-header/index.html?path=/story/uds-asu-header--default)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1346?atlOrigin=eyJpIjoiMTM0ZDJmOTc4NzZhNGEwMzhkM2JiOGEzMmFjZDIyZTciLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

