### PR TITLE
fix(components-core): fix typo error in readme

### DIFF
--- a/packages/components-core/README.md
+++ b/packages/components-core/README.md
@@ -41,7 +41,7 @@ yarn test
 
 1. Make sure you are set up to use the private npm registry at registry.web.asu.edu. See instructures in the 'How to use private package registry' here: [README.md](../../README.md)
 2. Make sure to have included [FontAwesome](https://fontawesome.com/) on your project to allow icons to be shown
-3. `yarn add @asu/components-core@dev`
+3. `yarn add @asu/components-core`
 
 ## Use as a JS module in React app
 

--- a/packages/components-core/README.md
+++ b/packages/components-core/README.md
@@ -1,17 +1,20 @@
 # ASU Components Core
+
 ASU React Core Components.
 
 This component is the react implementation of some of the components of the Bootstrap 4 theme package.
 All of these components are listed [below](#examples---quick-links).
 
 ## Architecture details
+
 As this package is intended to be the react core components package, each of these components are built in isolation, thats mean that, each component, was thougth to be used in different scenarios in the same way.
 For each component there is a `.js` file, that contains the code of that component, a `.test.js` file, that has the unit test within that component. For this last file, we use [React testing library](https://testing-library.com/docs/react-testing-library/intro), that is use in combination with [Jest](https://jestjs.io/). This provide us a nice way to test all the components in terms of what that component paints in the DOM and what user sees. There might be another file on some component folder that contains some specific styling for that component(`.styles.js`). As you may noticed, we are using css in js to code the styles. For this, we make use of [styled-components](https://styled-components.com/) that has a great integration and support in the react ecosystem. The last file included, for each component, is the `.stories.js` one, that one, has the configuration for all the stories that are shown in [Storybook](https://storybook.js.org/) page.
 The initialization, for plain Javascript, of each component is the same as all the packages, so it can keep uniqueness between all of them. For this, we use two methods:
- - `createElement`: this is provided by React. It creates a new React element. Click to read more about [createElement](https://reactjs.org/docs/react-api.html#createelement) and [react without jsx](https://reactjs.org/docs/react-without-jsx.html).
- - `render`: this is provided by ReactDOM library. It is used to render the react element in the DOM. Click to read more about [render](https://reactjs.org/docs/react-dom.html).
-The way it works is: when the initializer function is called, this creates the element with the props provided and the react component.Then it is rendered on the DOM.
-We also have configured [Percy](https://percy.io/) to manage all the visual regression tests. The tests included can be found [here](./src/percyTests/testPage.percy.js). These tests runs on a test stage in the CI pipeline and then are pushed to the percy dashboard. More information about this integration can be found [here](../../tests/README.md#visual-regression-testing).
+
+- `createElement`: this is provided by React. It creates a new React element. Click to read more about [createElement](https://reactjs.org/docs/react-api.html#createelement) and [react without jsx](https://reactjs.org/docs/react-without-jsx.html).
+- `render`: this is provided by ReactDOM library. It is used to render the react element in the DOM. Click to read more about [render](https://reactjs.org/docs/react-dom.html).
+  The way it works is: when the initializer function is called, this creates the element with the props provided and the react component.Then it is rendered on the DOM.
+  We also have configured [Percy](https://percy.io/) to manage all the visual regression tests. The tests included can be found [here](./src/percyTests/testPage.percy.js). These tests runs on a test stage in the CI pipeline and then are pushed to the percy dashboard. More information about this integration can be found [here](../../tests/README.md#visual-regression-testing).
 
 ## Component props documentation
 
@@ -19,7 +22,7 @@ You can find a full list of props into the [docs/README.props.md](docs/README.pr
 
 ## CLI Commands
 
-``` bash
+```bash
 # add component-carousel
 yarn add @asu/components-core
 
@@ -38,7 +41,7 @@ yarn test
 
 1. Make sure you are set up to use the private npm registry at registry.web.asu.edu. See instructures in the 'How to use private package registry' here: [README.md](../../README.md)
 2. Make sure to have included [FontAwesome](https://fontawesome.com/) on your project to allow icons to be shown
-3. ```yarn add @asu/components-core@dev```
+3. `yarn add @asu/components-core@dev`
 
 ## Use as a JS module in React app
 
@@ -155,6 +158,7 @@ yarn test
 </script>
 
 ```
+
 ### Examples
 
 The folder [packages/components-core/examples](/packages/components-core/examples)
@@ -169,7 +173,7 @@ The folder [packages/components-core/examples](/packages/components-core/example
 - [Button](/packages/components-core/examples/button.html)
 - [Button Icon Only](/packages/components-core/examples/buttonIconOnly.html)
 - [Button Tag](/packages/components-core/examples/buttonTag.html)
-- [Card](/packages/components-core/examples/carg.html)
+- [Card](/packages/components-core/examples/card.html)
 - [Hero](/packages/components-core/examples/hero.html)
 - [Pagination](/packages/components-core/examples/pagination.html)
 - [Testimonial](/packages/components-core/examples/testimonial.html)
@@ -188,6 +192,7 @@ For example, if you want to use the `npm` package `lite-server` follow these ste
   (port number may be different)
 
 ## Future improvements
+
 All the requirements for this component were covered, so there is no need of any further enhancements at the moment this is being written.
 
 ## Tools


### PR DESCRIPTION
### Description

Typo error fixed

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1414)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes