### PR TITLE
fix(unity-bootstrap-theme): btn to wrap

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_buttons.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_buttons.scss
@@ -84,6 +84,19 @@
   background-color: $gray-1;
 }
 
+
+.uds-buttons {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1.5rem;
+  row-gap: 1rem;
+    .btn {
+      display: inline;
+      margin: 0;
+    }
+}
+
 // Remove background changing hover effects from all buttons
 @each $color, $value in $theme-colors {
   .btn-#{$color} {
@@ -110,6 +123,10 @@ a.text-gold:visited:not(.btn) {
 0 to SM breakpoint included
 --------------------------------------------------------------*/
 @include media-breakpoint-down(sm) {
+  .uds-buttons {
+    column-gap: 1rem;
+  }
+
   .btn {
     &.btn-responsive {
       @include btn-md;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_image-text-block.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_image-text-block.scss
@@ -12,6 +12,10 @@
       flex-direction: row-reverse;
     }
 
+    @include media-breakpoint-up(xl) {
+      max-height: 540px;
+    }
+
     @media screen and (max-width: $uds-breakpoint-md) {
       flex-direction: column;
     }

--- a/packages/unity-bootstrap-theme/src/scss/extends/_image-text-block.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_image-text-block.scss
@@ -12,10 +12,6 @@
       flex-direction: row-reverse;
     }
 
-    @include media-breakpoint-up(md) {
-      max-height: 540px;
-    }
-
     @media screen and (max-width: $uds-breakpoint-md) {
       flex-direction: column;
     }

--- a/packages/unity-bootstrap-theme/stories/molecules/image-background-with-cta/image-text-block/image-text-block.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/image-background-with-cta/image-text-block/image-text-block.templates.stories.js
@@ -59,27 +59,23 @@ export const ImageLeftOrRight = createStory(args => {
           aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos
           qui ratione voluptatem sequi nesciunt. Neque porro quisquam est.
         </p>
-        <div className="row">
-          <div className="col-12 col-md-6 py-1">
-            <a
-              href="#"
-              className={`btn ${
-                args.bgColor === "gray-7-bg" ? "btn-gold" : "btn-dark"
-              }`}
-            >
-              Button link here
-            </a>
-          </div>
-          <div className="col-12 col-md-6 py-1">
-            <a
-              href="#"
-              className={`btn ${
-                args.bgColor === "gray-7-bg" ? "btn-gold" : "btn-dark"
-              }`}
-            >
-              Button link here
-            </a>
-          </div>
+        <div className="uds-buttons py-1">
+          <a
+            href="#"
+            className={`btn ${
+              args.bgColor === "gray-7-bg" ? "btn-gold" : "btn-dark"
+            }`}
+          >
+            Button link here
+          </a>
+          <a
+            href="#"
+            className={`btn ${
+              args.bgColor === "gray-7-bg" ? "btn-gold" : "btn-dark"
+            }`}
+          >
+            Button link here
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Description

Button overlap

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-content-sections-image-and-text-block-templates--image-left-or-right)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1386)
- [Unity Design Kit - inset-box (has example of 2 buttons](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/674ebe9d-bcfd-48c9-a3eb-37efe95f4f4a/)

- [Similar pattern - inset-box](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-content-sections-inset-box-examples--basic-example&args=header:false;footer:false;template:1)
  - Should we remove styles from inset-box (for the button group) and only use styles from [packages/unity-bootstrap-theme/src/scss/extends/_buttons.scss](https://github.com/ASU/asu-unity-stack/compare/uds-1386?expand=1#diff-5073d36ddc441dcc410438afbc9d47bf4365260e9f80250a7afbaf9a576b483a)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [x] No new console errors
- [ ] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
