### PR TITLE
style: inactive colors for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,8 @@
   "workbench.colorCustomizations": {
     "activityBar.background": "#000000",
     "titleBar.activeBackground": "#8C1D40",
-    "titleBar.activeForeground": "#FFC627"
+    "titleBar.activeForeground": "#FFC627",
+    "titleBar.inactiveBackground": "#8C1D40",
+    "titleBar.inactiveForeground": "#D0D0D0"
   }
 }


### PR DESCRIPTION
### Description

Update to help with context-switching. Background: UDS VSCode titleBar styles disappear when the window is inactive, unless defined like here. I've chosen to set the foreground text to a UDS-compatible gray when inactive so we retain a cue to inactivity while keeping the background of the titleBar a consistent maroon so the window is easily recognizable as a UDS window.
