### PR TITLE
fix(app-webdir-ui): added blankImage to photo service params

### DIFF
--- a/packages/app-webdir-ui/src/ProfileCard/index.js
+++ b/packages/app-webdir-ui/src/ProfileCard/index.js
@@ -41,7 +41,6 @@ const ProfileCard = ({ ...props }) => {
       <a href={props.profileURL} className="profile-img-container">
         <div
           className="profile-img-placeholder"
-          style={{ backgroundImage: `url(${props.anonImgURL})` }}
         >
           <img
             className="profile-img"

--- a/packages/app-webdir-ui/src/helpers/dataConverter.js
+++ b/packages/app-webdir-ui/src/helpers/dataConverter.js
@@ -240,6 +240,7 @@ const formatImageUrl = baseUrl => {
     AVAILABLE_IMG_SIZES.MEDIUM
   );
   url.searchParams.append(AVAILABLE_URL_PARAMS.BREAK, nearestHundredSeconds());
+  url.searchParams.append('blankImage2', 'true');
 
   return url.toString();
 };


### PR DESCRIPTION
### Description
the new photo service has added a blankImage2="true" option, this will add the anon image instead of returning a 404 for images that are not available 


### Links

- [JIRA ticket](https://asudev.jira.com/browse/SCHWEB-1020?atlOrigin=eyJpIjoiMTIzMzY4Mjg5OWYyNDRjZGI1MmU1M2Q3NzcyOTY2MDAiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge


