### PR TITLE
fix(app-degree-pages): keep focus on anchor menu

### DIFF
--- a/packages/app-degree-pages/src/core/components/OnThisPageAnchorMenu/index.js
+++ b/packages/app-degree-pages/src/core/components/OnThisPageAnchorMenu/index.js
@@ -38,7 +38,7 @@ function OnThisPageAnchorMenu({ anchorMenu }) {
     <AnchorMenu
       items={anchorList}
       firstElementId={anchorList[0]?.targetIdName}
-      focusFirstFocusableElement
+      focusFirstFocusableElement={false}
     />
   );
 }

--- a/packages/app-degree-pages/src/core/components/OnThisPageAnchorMenu/index.test.js
+++ b/packages/app-degree-pages/src/core/components/OnThisPageAnchorMenu/index.test.js
@@ -36,7 +36,7 @@ describe("#OnThisPageAnchorMenu", () => {
         firstElementId: expect.stringContaining(
           progDetailSectionIds.affordingCollege.targetIdName
         ),
-        focusFirstFocusableElement: true,
+        focusFirstFocusableElement: false,
       }),
       expect.anything()
     );


### PR DESCRIPTION
### Description

On Degree pages, the focus border does not remain visible
remove the property to move focus to content

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/app-degree-pages/?path=/story/program-detail-page--with-content)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1433)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/8f348a6b-fb44-439d-b739-07ec4886101d/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
