### PR TITLE
fix(components-core): align anchor menu with its content

### DIFF
--- a/packages/app-degree-pages/README.md
+++ b/packages/app-degree-pages/README.md
@@ -7,7 +7,6 @@ ASU Web Standards-based implementation of the Degree page component
 
 ### Document reference
 
-
 [ux-doc-link]:https://xd.adobe.com/view/03081953-57ea-498f-a7f1-771c92c4dbed-565b/?fullscreen
 
 You can find the UX document [here][ux-doc-link]
@@ -69,7 +68,6 @@ You can find the UX document [here][ux-doc-link]
 </td>
 </tr>
 </table>
-
 
 
 

--- a/packages/components-core/src/components/AnchorMenu/index.js
+++ b/packages/components-core/src/components/AnchorMenu/index.js
@@ -36,10 +36,11 @@ export const AnchorMenu = ({
   const isSmallDevice = useMediaQuery("(max-width: 991px)");
   const [state, setState] = useState({
     hasHeader: false,
-    hasDegreeContainer: false,
+    hasAltMenuSpacing: false,
     containerClass: "container-xl",
     activeContainer: "",
     showMenu: false,
+    sticky: false,
   });
   const headerHeight = isSmallDevice ? 110 : 142;
 
@@ -88,8 +89,8 @@ export const AnchorMenu = ({
     debounce(handleWindowScroll, timeout);
   };
 
-  // Set any ASU Header on the document
-  const getHasHeader = () => {
+  // Is ASU Header on the document
+  const isHeader = () => {
     const pageHeader =
       document.getElementById("asu-header") ||
       document.getElementById("headerContainer") ||
@@ -97,9 +98,9 @@ export const AnchorMenu = ({
     return (!!pageHeader);
   };
 
+  // Is element present which requires different spacing for the ASU Header
   // Sets prop for styled-component to change anchor menu style
-  // based on if it requires different spacing for the ASU Header
-  const getHasDegreeContainer = () => {
+  const isAltMenuSpacing = () => {
     const degreeDetailPageContainer = document.getElementById(
       "degreeDetailPageContainer"
     );
@@ -131,8 +132,8 @@ export const AnchorMenu = ({
   useEffect(() => {
     const firstElement = document.getElementById(firstElementId) || null;
     const newState = {
-      hasHeader: getHasHeader(),
-      hasDegreeContainer: getHasDegreeContainer(),
+      hasHeader: isHeader(),
+      hasAltMenuSpacing: isAltMenuSpacing(),
       containerClass: getContainerClass(firstElement),
     };
     setState(prevState => ({
@@ -182,19 +183,25 @@ export const AnchorMenu = ({
   return (
     <AnchorMenuWrapper
       // @ts-ignore
-      requiresAltMenuSpacing={state.hasDegreeContainer}
+      requiresAltMenuSpacing={state.hasAltMenuSpacing}
       ref={anchorMenuRef}
-      className={`uds-anchor-menu uds-anchor-menu-expanded-lg ${state.sticky ? "sticky" : ""} ${
-        state.hasHeader ? "with-header " : ""
-      }mb-4`}
+      className={classNames(
+        "uds-anchor-menu",
+        "uds-anchor-menu-expanded-lg",
+        "mb-4",
+        {
+          [`sticky`]: state.sticky,
+          [`with-header`]: state.hasHeader,
+        }
+      )}
       style={state.showMenu ? { borderBottom: 0 } : {}}
     >
       <div className={`${state.containerClass} uds-anchor-menu-wrapper`}>
         {isSmallDevice ? (
           <button
-            className={`${
-              state.showMenu ? "show-menu " : ""
-            }mobile-menu-toggler`}
+            className={classNames("mobile-menu-toggler", {
+              [`show-menu`]: state.showMenu,
+            })}
             type="button"
             onClick={() => {
               trackMobileDropdownEvent();
@@ -226,10 +233,9 @@ export const AnchorMenu = ({
               <Button
                 data-testid={`anchor-item-${item.targetIdName}`}
                 key={item.targetIdName}
-                classes={[
-                  "nav-link",
-                  `${state.activeContainer === item.targetIdName ? "active" : ""}`,
-                ]}
+                classes={classNames("nav-link", {
+                  [`active`]: state.activeContainer === item.targetIdName,
+                }).split(" ")}
                 ariaLabel={item.text}
                 label={item.text}
                 icon={item.icon}

--- a/packages/components-core/src/core/utils/timers.js
+++ b/packages/components-core/src/core/utils/timers.js
@@ -1,0 +1,32 @@
+// @ts-check
+
+/**
+ *
+ * @param {function} callback
+ * @param {number} time
+ * throttle calls a function at intervals of a specified amount of time while the user is carrying out an event.
+ */
+
+let throttleTimer = false;
+const throttle = (callback, time) => {
+  if (throttleTimer) return;
+  throttleTimer = true;
+  setTimeout(() => {
+    callback();
+    throttleTimer = false;
+  }, time);
+};
+
+/**
+ *
+ * @param {function} callback
+ * @param {number} time
+ * debounce calls a function when a user hasn’t carried out an event in a specific amount of time
+ */
+let debounceTimer;
+const debounce = (callback, time) => {
+  window.clearTimeout(debounceTimer);
+  debounceTimer = window.setTimeout(callback, time);
+};
+
+export { throttle, debounce };


### PR DESCRIPTION
### Description

Issue of the problem found on app-degree-pages, which uses components-core anchor menu.
The anchor menu hard codes the container-xl

### Solution

The component will look at the content of the first item and align with those containers found or will default to container-xl
Also added some performance to avoid re-rendering:
- optimized functions with multi state updates to only update state once
- moved sticky to state, bad practice to use a ref when we can use a state
- added throttle and debounce functions to limit scroll events

Alternate solution would be to add a prop for container

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/components-core/iframe.html?args=&id=uds-anchormenu--default&viewMode=story)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1435)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/8f348a6b-fb44-439d-b739-07ec4886101d/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] No new console errors
- [ ] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
