### PR TITLE
fix(components-core): change TabbedPanels props 

### DIFF
--- a/packages/app-webdir-ui/src/FacultyRankComponent/index.js
+++ b/packages/app-webdir-ui/src/FacultyRankComponent/index.js
@@ -40,7 +40,7 @@ export const FacultyRankTabPanels = ({
   tempFilters["deptIds"] = deptIds.split(",");
 
   return (
-    <TabbedPanels onTabChange={() => true} id="faculty-rank-tabs">
+    <TabbedPanels onTabChange={() => true}>
       <Tab id="faculty" title="Faculty">
         <ASUSearchResultsList
           engine={enginesWithParams[searchTypeEngineMap[searchType]]}

--- a/packages/app-webdir-ui/src/SearchPage/index.js
+++ b/packages/app-webdir-ui/src/SearchPage/index.js
@@ -160,7 +160,6 @@ function SearchPage({
       </div>
       <TabbedPanels
         initialTab={searchParams.get(searchTabsId)}
-        id={searchTabsId}
         onTabChange={tab => goToTab(tab)}
       >
         <Tab id={tabIds.all} title="All ASU Search">

--- a/packages/app-webdir-ui/src/SearchPage/index.js
+++ b/packages/app-webdir-ui/src/SearchPage/index.js
@@ -158,7 +158,11 @@ function SearchPage({
           )}
         </div>
       </div>
-      <TabbedPanels id={searchTabsId} onTabChange={() => true}>
+      <TabbedPanels
+        initialTab={searchParams.get(searchTabsId)}
+        id={searchTabsId}
+        onTabChange={tab => goToTab(tab)}
+      >
         <Tab id={tabIds.all} title="All ASU Search">
           {preSearchOrContent(
             <AllTab

--- a/packages/app-webdir-ui/src/WebDirectoryComponent/index.js
+++ b/packages/app-webdir-ui/src/WebDirectoryComponent/index.js
@@ -54,7 +54,7 @@ function WebDirectory({
         display?.defaultSort
       )
     ) {
-      return defaultCMSOptions[display.defaultSort];
+      return defaultCMSOptions[display?.defaultSort];
     }
     return "last_name_asc"; // defaults to last_name_asc if no default sort is set in CMS
   }
@@ -137,12 +137,12 @@ function WebDirectory({
             <ASUSearchResultsList
               engine={enginesWithParams[searchTypeEngineMap[searchType]]}
               itemsPerPage={
-                parseInt(display.profilesPerPage, 10) || RES_PER_PAGE
+                parseInt(display?.profilesPerPage, 10) || RES_PER_PAGE
               }
               sort={sort}
-              hidePaginator={display.usePager !== "1"}
+              hidePaginator={display?.usePager !== "1"}
               filters={requestFilters}
-              profilesToFilterOut={display.doNotDisplayProfiles}
+              profilesToFilterOut={display?.doNotDisplayProfiles}
               display={display}
               appPathFolder={appPathFolder}
             />

--- a/packages/components-core/src/components/TabbedPanels/components/NavControls.js
+++ b/packages/components-core/src/components/TabbedPanels/components/NavControls.js
@@ -3,32 +3,36 @@ import React from "react";
 
 import { NavControlButtons } from "./NavControls.styles";
 
-const NavControls = ({ clickPrev, clickNext }) => {
+const NavControls = ({ hidePrev, hideNext, clickPrev, clickNext }) => {
   return (
     <NavControlButtons>
-      <button
-        className="scroll-control-prev"
-        type="button"
-        onClick={clickPrev}
-        tabIndex={-1}
-      >
-        <span className="carousel-control-prev-icon" aria-hidden="true" />
-        <span className="visually-hidden">Previous</span>
-      </button>
-      <button
-        className="scroll-control-next"
-        type="button"
-        onClick={clickNext}
-        tabIndex={-1}
-      >
-        <span className="carousel-control-next-icon" aria-hidden="true" />
-        <span className="visually-hidden">Next</span>
-      </button>
+      {!hidePrev && <button
+          className="scroll-control-prev"
+          type="button"
+          onClick={clickPrev}
+          tabIndex={-1}
+        >
+          <span className="carousel-control-prev-icon" aria-hidden="true" />
+          <span className="visually-hidden">Previous</span>
+        </button>
+      }
+      {!hideNext && <button
+          className="scroll-control-next"
+          type="button"
+          onClick={clickNext}
+          tabIndex={-1}
+        >
+          <span className="carousel-control-next-icon" aria-hidden="true" />
+          <span className="visually-hidden">Next</span>
+        </button>
+  }
     </NavControlButtons>
   );
 };
 
 NavControls.propTypes = {
+  hidePrev: PropTypes.bool,
+  hideNext: PropTypes.bool,
   clickPrev: PropTypes.func.isRequired,
   clickNext: PropTypes.func.isRequired,
 };

--- a/packages/components-core/src/components/TabbedPanels/components/TabHeader.js
+++ b/packages/components-core/src/components/TabbedPanels/components/TabHeader.js
@@ -1,15 +1,34 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { forwardRef, useRef, useImperativeHandle } from "react";
 
-const TabHeader = ({
-  id,
-  selected,
-  title,
-  selectTab,
-  leftKeyPressed,
-  rightKeyPressed,
-  icon,
-}) => {
+const TabHeader = forwardRef(function TabHeader(props, ref) {
+  const {
+    id,
+    selected,
+    title,
+    selectTab,
+    leftKeyPressed,
+    rightKeyPressed,
+    icon,
+  } = props;
+
+  const inputRef = useRef(null);
+
+  useImperativeHandle(
+    ref,
+    () => {
+      return {
+        focus() {
+          inputRef.current.focus();
+        },
+        scrollIntoView() {
+          inputRef.current.scrollIntoView();
+        }
+      };
+    },
+    []
+  );
+
   const func = e => {
     if (e.keyCode === 37) {
       leftKeyPressed();
@@ -19,6 +38,7 @@ const TabHeader = ({
   };
   return (
     <a
+      ref={inputRef}
       className={`nav-item nav-link ${selected ? "active" : ""}`}
       id={id}
       href={`#nav-${id}`}
@@ -32,7 +52,7 @@ const TabHeader = ({
       {title} {icon && <i className={`${icon?.[0]} fa-${icon?.[1]} me-1`} />}
     </a>
   );
-};
+});
 
 TabHeader.propTypes = {
   id: PropTypes.string.isRequired,

--- a/packages/components-core/src/components/TabbedPanels/components/TabHeader.js
+++ b/packages/components-core/src/components/TabbedPanels/components/TabHeader.js
@@ -22,8 +22,16 @@ const TabHeader = forwardRef(function TabHeader(props, ref) {
           inputRef.current.focus();
         },
         scrollIntoView() {
-          inputRef.current.scrollIntoView();
-        }
+          const middle =
+            inputRef.current.offsetWidth / 2 + inputRef.current.offsetLeft;
+          const targetMiddle =
+            inputRef.current.offsetParent.scrollLeft +
+            inputRef.current.offsetParent.offsetWidth / 2;
+
+          inputRef.current.offsetParent.scrollBy({
+            left: middle - targetMiddle,
+          });
+        },
       };
     },
     []
@@ -31,8 +39,10 @@ const TabHeader = forwardRef(function TabHeader(props, ref) {
 
   const func = e => {
     if (e.keyCode === 37) {
+      e.preventDefault();
       leftKeyPressed();
     } else if (e.keyCode === 39) {
+      e.preventDefault();
       rightKeyPressed();
     }
   };

--- a/packages/components-core/src/components/TabbedPanels/index.js
+++ b/packages/components-core/src/components/TabbedPanels/index.js
@@ -194,7 +194,7 @@ const TabbedPanels = ({ initialTab, children, bgColor, onTabChange = () => {} })
 };
 
 TabbedPanels.propTypes = {
-  id: PropTypes.string,
+  initialTab: PropTypes.string,
   children: PropTypes.arrayOf(PropTypes.element).isRequired,
   bgColor: PropTypes.string,
   onTabChange: PropTypes.func,

--- a/packages/components-core/src/components/TabbedPanels/index.js
+++ b/packages/components-core/src/components/TabbedPanels/index.js
@@ -49,10 +49,7 @@ const TabbedPanels = ({
   onTabChange = () => {},
 }) => {
   const childrenArray = React.Children.toArray(children);
-  const selectedChild =
-    childrenArray.find(element => initialTab === element.props.id) ||
-    childrenArray[0];
-  const [activeTabID, setActiveTabID] = useState(selectedChild.props.id);
+  const [activeTabID, setActiveTabID] = useState(initialTab);
   const headerTabs = useRef(null);
   const [headerTabItems, setHeaderTabItems] = useRefs();
   const tabbedPanels = useRef(null);
@@ -83,11 +80,15 @@ const TabbedPanels = ({
   }, []);
 
   useEffect(() => {
-    headerTabItems.current[activeTabID].focus();
-    headerTabItems.current[activeTabID].scrollIntoView();
+    headerTabItems.current[activeTabID]?.focus();
+    headerTabItems.current[activeTabID]?.scrollIntoView();
 
     onTabChange(activeTabID);
   }, [activeTabID]);
+
+  useEffect(() => {
+    setActiveTabID(initialTab);
+  }, [initialTab]);
 
   const [backgroundColor] = useState(bgColor || "");
   const [randId] = useState(Math.floor(Math.random() * 1000 + 1));

--- a/packages/components-core/src/components/TabbedPanels/index.js
+++ b/packages/components-core/src/components/TabbedPanels/index.js
@@ -45,14 +45,13 @@ Tab.propTypes = {
 const TabbedPanels = ({
   initialTab,
   children,
-  bgColor,
+  bgColor = '',
   onTabChange = () => {},
 }) => {
   const childrenArray = React.Children.toArray(children);
   const [activeTabID, setActiveTabID] = useState(initialTab);
   const headerTabs = useRef(null);
   const [headerTabItems, setHeaderTabItems] = useRefs();
-  const tabbedPanels = useRef(null);
 
   const updateTabParam = tab => {
     setActiveTabID(tab);
@@ -90,10 +89,6 @@ const TabbedPanels = ({
     setActiveTabID(initialTab);
   }, [initialTab]);
 
-  const [backgroundColor] = useState(bgColor || "");
-  const [randId] = useState(Math.floor(Math.random() * 1000 + 1));
-  const TabbedPanelsId = `tabbed-panels-${randId}`;
-  const NavTabsId = `nav-tabs-${randId}`;
 
   const trackArrowsEvent = text => {
     trackGAEvent({
@@ -118,7 +113,7 @@ const TabbedPanels = ({
 
   const tabs = childrenArray.map(el => {
     return React.cloneElement(el, {
-      bgColor: backgroundColor,
+      bgColor,
       selected: activeTabID === el.props.id,
     });
   });
@@ -145,19 +140,14 @@ const TabbedPanels = ({
   };
 
   let navClasses = "uds-tabbed-panels";
-  if (backgroundColor === "bg-dark") {
+  if (bgColor === "bg-dark") {
     navClasses += " uds-tabbed-panels-dark";
   }
 
   return (
-    <div className={backgroundColor} ref={tabbedPanels}>
-      <nav className={navClasses} id={TabbedPanelsId}>
-        <div
-          className="nav nav-tabs"
-          id={NavTabsId}
-          role="tablist"
-          ref={headerTabs}
-        >
+    <div className={bgColor}>
+      <nav className={navClasses}>
+        <div className="nav nav-tabs" role="tablist" ref={headerTabs}>
           {childrenArray.map((child, index) => {
             return (
               <TabHeader

--- a/packages/components-core/src/components/TabbedPanels/index.js
+++ b/packages/components-core/src/components/TabbedPanels/index.js
@@ -42,10 +42,16 @@ Tab.propTypes = {
   ]),
 };
 
-const TabbedPanels = ({ initialTab, children, bgColor, onTabChange = () => {} }) => {
+const TabbedPanels = ({
+  initialTab,
+  children,
+  bgColor,
+  onTabChange = () => {},
+}) => {
   const childrenArray = React.Children.toArray(children);
   const selectedChild =
-    childrenArray.find(({props}) => initialTab === props.id) || childrenArray[0];
+    childrenArray.find(element => initialTab === element.props.id) ||
+    childrenArray[0];
   const [activeTabID, setActiveTabID] = useState(selectedChild.props.id);
   const headerTabs = useRef(null);
   const [headerTabItems, setHeaderTabItems] = useRefs();


### PR DESCRIPTION
### Description

refreshing TabbedPanels with BS5
Removed `app-webdir-ui` logic from `components-core:TabbedPanels`

use `app-webdir-ui/examples/index.html?search-tabs=web_dir_faculty_staff&q=test` to test url parameters
- params should fill in search and select 2nd tab

### Links

- [@asu/components-core](https://unity.web.asu.edu/@asu/components-core/index.html?path=/story/uds-tabbedpanels--default)
- [@asu/app-webdir-ui](https://unity.web.asu.edu/@asu/app-webdir-ui/?path=/story/organisms-search-page-templates--search-page-example)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1412)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/674f1d96-f175-442a-8087-25cf3924e219/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
