### PR TITLE
build(.releaserc): added prerelease to testing config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,8 @@
     "dev",
     {
       "name": "testing",
-      "channel": "testing"
+      "channel": "testing",
+      "prerelease": true
     }
   ],
   "plugins": [


### PR DESCRIPTION
### Description
You can add a prerelease config to the semantic release config to label beta and alpha releases. This prevents errors when putting out test release packages so they don’t release with higher version numbers than the latest release


### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1451?atlOrigin=eyJpIjoiNDljYmU3NjRlNDFlNGI1Njk1YzExOTQ2ODJiM2M4ZGMiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

