### PR TITLE
fix(component-header): keep gold underline on open dropdown, remove …

### DIFF
--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.styles.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.styles.js
@@ -4,7 +4,7 @@ const NavItemWrapper = styled.li`
   position: relative;
   padding: 0;
   margin: 0 0.5rem 0 0;
-  &:hover > a:after {
+  &:has(.open-link) > a:after, &:hover > a:after {
     width: calc(100% + 24px);
   }
   > a {


### PR DESCRIPTION
…on close

### Description
Gold underline on dropdown menu has different behavior than unity-bootstrap-theme, this pr matches that unity behavior by altering css to keep gold underline


### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/component-header/index.html?path=/story/uds-asu-header--default)
- [UDS-1446](https://asudev.jira.com/browse/UDS-1446?atlOrigin=eyJpIjoiMjdiOTdlYjA0ODc0NGYyZTk5N2UzZmVjNmU4NjUxNTEiLCJwIjoiaiJ9)
- [Adobe mockup](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/02335e90-65c1-4245-8fc7-71b70322c4ff/specs/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [ ] Firefox
- [x] Edge

