### PR TITLE
WS2-1644: fix(unity-bootstrap-theme): set a max-width on donut chart text

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_charts-and-graphs.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_charts-and-graphs.scss
@@ -20,6 +20,7 @@
 
   span {
     font: normal normal bold 1.125rem Arial;
+    max-width: 60%;
   }
 
   @include media-breakpoint-down(md) {


### PR DESCRIPTION
### Description

Currently, the text on Donut charts can expand beyond the chart width and is hidden underneath when doing so. This PR adds a simple max-width on Donut Chart text to remain visible.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1644)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
