### PR TITLE
WS2-1636: fix(unity-bootstrap-theme): fix anchor menu styles to match XD

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
@@ -67,6 +67,10 @@
       color: $uds-color-base-gray-7;
     }
 
+    &:focus {
+      box-shadow: 0px 0px 0px 2px $uds-color-base-gray-7 !important;
+    }
+
     svg {
       width: 2rem !important;
       margin-right: $uds-size-spacing-1;
@@ -99,6 +103,7 @@
     border-bottom: $uds-size-spacing-1 solid transparent;
     padding: $uds-size-spacing-3 $uds-size-spacing-2 $uds-size-spacing-2
       $uds-size-spacing-2;
+    margin-left: 8px;
 
     &:hover,
     &.active {


### PR DESCRIPTION
### Description

Currently, the Anchor Menu `:focus` and other small styles do not match the XD file, causing oddities when an item is in a focus state. This PR fixes anchor menu styles to match the XD specs in this regard.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1636)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox

### Images

<img width="528" alt="Screenshot 2023-07-28 at 1 38 00 PM" src="https://github.com/ASU/asu-unity-stack/assets/5995907/1850a185-f7f8-4b56-b18b-046d4d0bb5f6">

