### PR TITLE
WS2-1649: fix(unity-bootstrap-theme): revert the removal of carousel image borders

### DIFF
--- a/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
+++ b/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
@@ -425,11 +425,6 @@ $uds-color-brand-gold: #ffc627; // ASU Gold brand color
   &.image-gallery,
   &.image-carousel {
     margin: auto;
-    @mixin li-inactive-border {
-      li:not(.glide__slide--active) img {
-        border: 0;
-      }
-    }
 
     &[role="figure"],
     figure.uds-figure {
@@ -440,10 +435,6 @@ $uds-color-brand-gold: #ffc627; // ASU Gold brand color
         color: $uds-color-base-gray-7;
         max-width: 100%;
       }
-
-      @include li-inactive-border;
     }
-
-    @include li-inactive-border;
   }
 }


### PR DESCRIPTION
### Description

Currently, in carousels, the images of the non-active items have their borders removed. This causes wired visuals when using images where the lack of a border is obvious. The XD does contain borders, and there is no explanation why the borders are being removed for these situations.

This PR restores the borders for the images.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1649)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
