### PR TITLE
WS2-1458: fix(unity-bootstrap-theme): fix video hero overlay height on mobile

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -422,6 +422,10 @@ div.uds-hero-lg {
       margin-bottom: $uds-size-spacing-4;
     }
   }
+
+  div.uds-hero-lg.uds-video-hero.has-btn-row .hero-overlay {
+    height: 100%;
+  }
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
### Description

On mobile, the Video hero overlay height is too tall, causing an odd area of darkness over the element below. This PR adds CSS to target the video heroes on the needed breakpoints to adjust the overlay height.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/WS2-1458)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
