### PR TITLE
WS2-1634: fix(app-degree-pages): add check to the anchorMenu for false values

### DIFF
--- a/packages/app-degree-pages/src/core/components/OnThisPageAnchorMenu/index.js
+++ b/packages/app-degree-pages/src/core/components/OnThisPageAnchorMenu/index.js
@@ -15,11 +15,6 @@ import { anchorMenuPropType, progDetailSectionIds } from "../../models";
  * @returns {JSX.Element}
  */
 function OnThisPageAnchorMenu({ anchorMenu }) {
-  // Check if all keys in anchorMenu are false
-  if (Object.values(anchorMenu).every(value => value === false)) {
-    return null;
-  }
-
   // clean up those targetIdNames bad formatted
   /** @type {AnchorMenuItem[]} */
   const externalAnchors = anchorMenu?.externalAnchors?.map(anchorItem => {

--- a/packages/app-degree-pages/src/core/components/OnThisPageAnchorMenu/index.js
+++ b/packages/app-degree-pages/src/core/components/OnThisPageAnchorMenu/index.js
@@ -15,6 +15,11 @@ import { anchorMenuPropType, progDetailSectionIds } from "../../models";
  * @returns {JSX.Element}
  */
 function OnThisPageAnchorMenu({ anchorMenu }) {
+  // Check if all keys in anchorMenu are false
+  if (Object.values(anchorMenu).every(value => value === false)) {
+    return null;
+  }
+
   // clean up those targetIdNames bad formatted
   /** @type {AnchorMenuItem[]} */
   const externalAnchors = anchorMenu?.externalAnchors?.map(anchorItem => {

--- a/packages/components-core/src/components/AnchorMenu/index.js
+++ b/packages/components-core/src/components/AnchorMenu/index.js
@@ -181,71 +181,73 @@ export const AnchorMenu = ({
   };
 
   return (
-    <AnchorMenuWrapper
-      // @ts-ignore
-      requiresAltMenuSpacing={state.hasAltMenuSpacing}
-      ref={anchorMenuRef}
-      className={classNames(
-        "uds-anchor-menu",
-        "uds-anchor-menu-expanded-lg",
-        "mb-4",
-        {
-          [`sticky`]: state.sticky,
-          [`with-header`]: state.hasHeader,
-        }
-      )}
-      style={state.showMenu ? { borderBottom: 0 } : {}}
-    >
-      <div className={`${state.containerClass} uds-anchor-menu-wrapper`}>
-        {isSmallDevice ? (
-          <button
-            className={classNames("mobile-menu-toggler", {
-              [`show-menu`]: state.showMenu,
-            })}
-            type="button"
-            onClick={() => {
-              trackMobileDropdownEvent();
-              handleMenuVisibility();
-            }}
-            data-bs-toggle="collapse"
-            data-bs-target="#collapseAnchorMenu"
-            aria-controls="collapseAnchorMenu"
-          >
-            <h4>
-              {menuTitle}:<i className="fas fa-chevron-down" />
-            </h4>
-          </button>
-        ) : (
-          <h4>{menuTitle}:</h4>
+    items?.length > 0 && (
+      <AnchorMenuWrapper
+        // @ts-ignore
+        requiresAltMenuSpacing={state.hasAltMenuSpacing}
+        ref={anchorMenuRef}
+        className={classNames(
+          "uds-anchor-menu",
+          "uds-anchor-menu-expanded-lg",
+          "mb-4",
+          {
+            [`sticky`]: state.sticky,
+            [`with-header`]: state.hasHeader,
+          }
         )}
+        style={state.showMenu ? { borderBottom: 0 } : {}}
+      >
+        <div className={`${state.containerClass} uds-anchor-menu-wrapper`}>
+          {isSmallDevice ? (
+            <button
+              className={classNames("mobile-menu-toggler", {
+                [`show-menu`]: state.showMenu,
+              })}
+              type="button"
+              onClick={() => {
+                trackMobileDropdownEvent();
+                handleMenuVisibility();
+              }}
+              data-bs-toggle="collapse"
+              data-bs-target="#collapseAnchorMenu"
+              aria-controls="collapseAnchorMenu"
+            >
+              <h4>
+                {menuTitle}:<i className="fas fa-chevron-down" />
+              </h4>
+            </button>
+          ) : (
+            <h4>{menuTitle}:</h4>
+          )}
 
-        <div
-          data-testid="anchor-menu-container"
-          id="collapseAnchorMenu"
-          className={classNames("card", "card-body", "collapse", {
-            [`show`]: state.showMenu,
-          })}
-        >
-          <nav data-testid="anchor-menu" className="nav" aria-label={menuTitle}>
-            {items?.map(item => (
-              // Use this package button
-              // @ts-ignore
-              <Button
-                data-testid={`anchor-item-${item.targetIdName}`}
-                key={item.targetIdName}
-                classes={classNames("nav-link", {
-                  [`active`]: state.activeContainer === item.targetIdName,
-                }).split(" ")}
-                ariaLabel={item.text}
-                label={item.text}
-                icon={item.icon}
-                onClick={() => handleClickLink(item.targetIdName)}
-              />
-            ))}
-          </nav>
+          <div
+            data-testid="anchor-menu-container"
+            id="collapseAnchorMenu"
+            className={classNames("card", "card-body", "collapse", {
+              [`show`]: state.showMenu,
+            })}
+          >
+            <nav data-testid="anchor-menu" className="nav" aria-label={menuTitle}>
+              {items?.map(item => (
+                // Use this package button
+                // @ts-ignore
+                <Button
+                  data-testid={`anchor-item-${item.targetIdName}`}
+                  key={item.targetIdName}
+                  classes={classNames("nav-link", {
+                    [`active`]: state.activeContainer === item.targetIdName,
+                  }).split(" ")}
+                  ariaLabel={item.text}
+                  label={item.text}
+                  icon={item.icon}
+                  onClick={() => handleClickLink(item.targetIdName)}
+                />
+              ))}
+            </nav>
+          </div>
         </div>
-      </div>
-    </AnchorMenuWrapper>
+      </AnchorMenuWrapper>
+    )
   );
 };
 


### PR DESCRIPTION
### Description

Currently, the Anchor Menu on the degree pages renders by default with no items. In this state, there is a bug where if you scroll down the page, then scroll back up the page, the menu will then disappear completely.

This PR adds a check to the `OnThisPageAnchorMenu` component to see if all values from the `anchorMenu` prop are false. If true, the component returns `null`.

This really may not be the best place to put this logic, or returning null for a component might just be a terrible idea. The end goal is to prevent the component from rendering at all if all the initial `anchorMenu` values are false. Please suggest changes as needed.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/WS2-1634)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
