### PR TITLE
fix(components-core): update README.md to trigger release for ws2-1634

### DIFF
--- a/packages/components-core/README.md
+++ b/packages/components-core/README.md
@@ -156,7 +156,6 @@ yarn test
     },
   });
 </script>
-
 ```
 
 ### Examples


### PR DESCRIPTION
### Description

trigger a release for `components-core` since the original ws2-1634 commit used the `refactor()` scope.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/WS2-1634)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

