### PR TITLE
fix(multi-package): add arrow to select

### DIFF
--- a/packages/app-degree-pages/src/components/ListingPage/components/Filters/components/index.js
+++ b/packages/app-degree-pages/src/components/ListingPage/components/Filters/components/index.js
@@ -30,7 +30,7 @@ const SelectFormGroup = ({
   <div className="form-group">
     <label htmlFor={id}>{label}</label>
     <select
-      className="form-control"
+      className="form-select"
       id={id}
       data-testid={id}
       multiple={multiple}

--- a/packages/app-webdir-ui/src/SearchPage/components/sort.js
+++ b/packages/app-webdir-ui/src/SearchPage/components/sort.js
@@ -68,7 +68,7 @@ const SortPicker = ({ sort, onChange, customSortOptions }) => {
         <div className="form-group">
           <label htmlFor="sortBySelect">Sort by</label>
           <select
-            className="form-control"
+            className="form-select"
             id="sortBySelect"
             onChange={event => {
               updateSort(event.target.value);

--- a/packages/unity-bootstrap-theme/UPGRADE.md
+++ b/packages/unity-bootstrap-theme/UPGRADE.md
@@ -60,6 +60,9 @@ Most design components' markup changed little or not at all in this update. A fe
 
 **Accordions require the use of Javascript to function. If using Webspark, this has already been done for you. If using the Unity Bootstrap 5 theme in a standalone application, you will need to import the bundled bootstrap javascript file which is available in `@asu/unity-bootstrap-theme/dist/js/bootstrap.bundle.min.js`**
 
+#### Select Form Element
+- Select elements should use class `form-select` instead of `form-control`
+
 ### Update Unity design component tag attributes to comply with Bootstrap 5 conventions. Details follow:
 
 Regex of tag attribute changes:

--- a/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
@@ -27,7 +27,8 @@ form.uds-form {
   // color set in component's Bootstrap variable overrides.
 
   /* Input text */
-  .form-control {
+  .form-control,
+  .form-select {
     color: $uds-color-base-gray-7;
     border: 1px solid $uds-color-base-gray-5;
 

--- a/packages/unity-bootstrap-theme/stories/atoms/form-fields/form-fields.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/form-fields/form-fields.examples.stories.js
@@ -3049,7 +3049,7 @@ export const Selects = createStory(
       <label for="exampleFormControlSelect2">Example multiple select</label>
       <select
         multiple
-        className="form-control"
+        className="form-select"
         id="exampleFormControlSelect2"
         data-ga-input="select"
         data-ga-input-name="onclick"
@@ -3075,7 +3075,7 @@ export const Selects = createStory(
       </label>
       <select
         multiple
-        className="form-control is-invalid"
+        className="form-select is-invalid"
         id="exampleFormControlSelect4"
         aria-describedby="myInvalidSelectMsg"
         aria-required="true"
@@ -4185,7 +4185,7 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidValidatedForm
           </label>
           <select
             multiple
-            className="form-control"
+            className="form-select"
             id="exampleFormControlSelect2"
             aria-describedby="myInvalidSelectMsg"
             aria-required="true"
@@ -4676,7 +4676,7 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidNotYetValidat
             </label>
             <select
               multiple
-              className="form-control"
+              className="form-select"
               id="exampleFormControlSelect2"
             >
               <option>1</option>
@@ -5166,7 +5166,7 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidValidatedForm
             </label>
             <select
               multiple
-              className="form-control"
+              className="form-select"
               id="exampleFormControlSelect2"
               aria-describedby="myInvalidSelectMsg"
               aria-required="true"

--- a/packages/unity-bootstrap-theme/stories/atoms/form-fields/form-fields.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/form-fields/form-fields.examples.stories.js
@@ -2977,7 +2977,7 @@ export const Selects = createStory(
     <div className="form-group">
       <label for="exampleFormControlSelect1">Example select</label>
       <select
-        className="form-control"
+        className="form-select"
         id="exampleFormControlSelect1"
         data-ga-input="select"
         data-ga-input-name="onclick"
@@ -2998,7 +2998,7 @@ export const Selects = createStory(
         Example select with server-side validation
       </label>
       <select
-        className="form-control is-valid"
+        className="form-select is-valid"
         id="exampleFormControlSelect3"
         aria-describedby="myValidSelectMsg"
         data-ga-input="select"
@@ -3199,7 +3199,7 @@ export const KitchenSinkForm = createStory(
 
       <div className="form-group">
         <label for="exampleFormControlSelect1">Example select</label>
-        <select className="form-control" id="exampleFormControlSelect1">
+        <select className="form-select" id="exampleFormControlSelect1">
           <option>1</option>
           <option>2</option>
           <option>3</option>
@@ -3209,7 +3209,7 @@ export const KitchenSinkForm = createStory(
       </div>
       <div className="form-group">
         <label for="exampleFormControlSelect2">Example multiple select</label>
-        <select multiple className="form-control" id="exampleFormControlSelect2">
+        <select multiple className="form-select" id="exampleFormControlSelect2">
           <option>1</option>
           <option>2</option>
           <option>3</option>
@@ -3699,7 +3699,7 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidNotYetValidat
 
         <div className="form-group">
           <label for="exampleFormControlSelect1">Example select</label>
-          <select className="form-control" id="exampleFormControlSelect1">
+          <select className="form-select" id="exampleFormControlSelect1">
             <option>1</option>
             <option>2</option>
             <option>3</option>
@@ -3709,7 +3709,7 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidNotYetValidat
         </div>
         <div className="form-group">
           <label for="exampleFormControlSelect2">Example multiple select</label>
-          <select multiple className="form-control" id="exampleFormControlSelect2">
+          <select multiple className="form-select" id="exampleFormControlSelect2">
             <option>1</option>
             <option>2</option>
             <option>3</option>
@@ -4160,7 +4160,7 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidValidatedForm
         <div className="form-group">
           <label for="exampleFormControlSelect1">Example select</label>
           <select
-            className="form-control"
+            className="form-select"
             id="exampleFormControlSelect1"
             aria-describedby="myValidSelectMsg"
           >
@@ -4662,7 +4662,7 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidNotYetValidat
 
           <div className="form-group">
             <label for="exampleFormControlSelect1">Example select</label>
-            <select className="form-control" id="exampleFormControlSelect1">
+            <select className="form-select" id="exampleFormControlSelect1">
               <option>1</option>
               <option>2</option>
               <option>3</option>
@@ -5141,7 +5141,7 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidValidatedForm
           <div className="form-group">
             <label for="exampleFormControlSelect1">Example select</label>
             <select
-              className="form-control"
+              className="form-select"
               id="exampleFormControlSelect1"
               aria-describedby="myValidSelectMsg"
             >


### PR DESCRIPTION
### Description
Following bootstrap5, select elements should use form-select instead of form-control

### Links

- [Unity reference site - app-webdir-ui](https://unity.web.asu.edu/@asu/app-webdir-ui)
- [Unity reference site - app-degree-pages](https://unity.web.asu.edu/@asu/app-degree-pages)
- [Unity reference site - unity-bootstrap-theme](https://unity.web.asu.edu/@asu/unity-bootstrap-theme)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1424)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors