### PR TITLE
fix(unity-bootstrap-theme): added background color to accordion-header

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -538,6 +538,7 @@ Cards - Table of Contents
   .accordion-header {
     padding: $uds-size-spacing-1;
     overflow: hidden;
+    background-color: $uds-color-base-white;
 
     &.accordion-header-icon {
       & .accordion-icon {


### PR DESCRIPTION
### Description
Added background color to accordion header

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1450?atlOrigin=eyJpIjoiMGIyYzRjMjdlNjIwNGQ3ZDhlZWFlNzUwMGJiZGI1MmMiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
