### PR TITLE
fix(app-degree-pages): fix Affording College section background image

### DIFF
--- a/packages/app-degree-pages/src/components/DetailPage/components/AffordingCollege/index.style.js
+++ b/packages/app-degree-pages/src/components/DetailPage/components/AffordingCollege/index.style.js
@@ -12,13 +12,12 @@ const Background = styled.div`
   background-position: center;
   background-size: contain;
   position: absolute;
-  width: 100vw;
-  height: 100%;
   top: 0;
   left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
+  transform: translateX(-50%);
+  width: 100vw;
+  max-width: 1920px;
+  height: 100%;
   z-index: -1;
 `;
 


### PR DESCRIPTION
set max width of affording college section to 1920px and adjust positioning

### Description

<!-- Description of problem -->
The topographical background image was staying at 100VW despite the max-width cap

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1341?atlOrigin=eyJpIjoiNzJiMzEyNzU2YTMxNDUwMDk3YzNlMDgyZTZkOTFmN2MiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge


