### PR TITLE
fix(unity-bootstrap-theme): nested containers failsafe, include conta…

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/_end-style.scss
+++ b/packages/unity-bootstrap-theme/src/scss/_end-style.scss
@@ -1,0 +1,93 @@
+
+/* -----------------------------------------------------
+Container/ row / column padding adjustments for mobile.
+
+Bootstrap doesn't natively provide a way to alter the behavior
+its native grid elements based on a media query. This overrides
+that behavior at screens <= 575px. (The small breakpoint.)
+
+Should be included after @import scss/grid. Registered here for clarity.
+------------------------------------------------------ */
+@mixin end_styles() {
+
+  @include media-breakpoint-down(md) {
+    .container,
+    .container-fluid,
+    .container-xl,
+    .container-lg,
+    .container-md,
+    .container-sm {
+      padding-left: 2rem;
+      padding-right: 2rem;
+    }
+  }
+
+
+  .container .container,
+  .container .container-sm,
+  .container .container-md,
+  .container .container-lg,
+  .container .container-xl,
+  .container .container-fluid,
+  .container-sm .container,
+  .container-sm .container-sm,
+  .container-sm .container-md,
+  .container-sm .container-lg,
+  .container-sm .container-xl,
+  .container-sm .container-fluid,
+  .container-md .container,
+  .container-md .container-sm,
+  .container-md .container-md,
+  .container-md .container-lg,
+  .container-md .container-xl,
+  .container-md .container-fluid,
+  .container-lg .container,
+  .container-lg .container-sm,
+  .container-lg .container-md,
+  .container-lg .container-lg,
+  .container-lg .container-xl,
+  .container-lg .container-fluid,
+  .container-xl .container,
+  .container-xl .container-sm,
+  .container-xl .container-md,
+  .container-xl .container-lg,
+  .container-xl .container-xl,
+  .container-xl .container-fluid,
+  .container-fluid .container,
+  .container-fluid .container-sm,
+  .container-fluid .container-md,
+  .container-fluid .container-lg,
+  .container-fluid .container-xl,
+  .container-fluid .container-fluid {
+    /* Avoid nested containers, this rule is meant as a backup */
+      padding-left: 0;
+      padding-right: 0;
+  }
+}
+
+
+/*
+This File should be included ONE time at the end of compiled code and bundles.
+
+To include once, just do so normally. The styles are only excluded if
+  this variable ($add_end_styles) is explicitly set to false
+  @import 'end-style';
+
+To include at the end of a bundle:
+  $add_end_styles: false;
+  @import 'unity-bootstrap-theme'; (file also imports 'end-style')
+  @import 'unity-bootstrap-header'; (file also imports 'end-style')
+
+  $add_end_styles: true;
+  @import 'unity-bootstrap-footer'; (file also imports 'end-style')
+
+*/
+@if variable-exists($name: "add_end_styles") {
+  @if $add_end_styles == true {
+    @include end_styles();
+  }
+}
+@else {
+  @include end_styles();
+}
+$add_end_styles: false;

--- a/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-footer.scss
+++ b/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-footer.scss
@@ -8,24 +8,4 @@
 // @import "unity-bootstrap-theme-extends";
 @import 'extends/globalfooter';
 
-/* -----------------------------------------------------
-Container/ row / column padding adjustments for mobile.
-
-Bootstrap doesn't natively provide a way to alter the behavior
-its native grid elements based on a media query. This overrides
-that behavior at screens <= 575px. (The small breakpoint.)
-
-Should be included after @import scss/grid. Registered here for clarity.
------------------------------------------------------- */
-
-@include media-breakpoint-down(md) {
-  .container,
-  .container-fluid,
-  .container-xl,
-  .container-lg,
-  .container-md,
-  .container-sm {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
+@import 'end-style';

--- a/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-header.scss
+++ b/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-header.scss
@@ -8,24 +8,4 @@
 // @import "unity-bootstrap-theme-extends";
 @import 'extends/global-header';
 
-/* -----------------------------------------------------
-Container/ row / column padding adjustments for mobile.
-
-Bootstrap doesn't natively provide a way to alter the behavior
-its native grid elements based on a media query. This overrides
-that behavior at screens <= 575px. (The small breakpoint.)
-
-Should be included after @import scss/grid. Registered here for clarity.
------------------------------------------------------- */
-
-@include media-breakpoint-down(md) {
-  .container,
-  .container-fluid,
-  .container-xl,
-  .container-lg,
-  .container-md,
-  .container-sm {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
+@import 'end-style';

--- a/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.bundle.scss
+++ b/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.bundle.scss
@@ -1,3 +1,7 @@
+$add_end_styles: false;
 @import 'unity-bootstrap-theme';
 @import 'unity-bootstrap-header';
 @import 'unity-bootstrap-footer';
+
+$add_end_styles: true;
+@import 'end-style';

--- a/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.scss
+++ b/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.scss
@@ -7,24 +7,4 @@
 // css Bootstrap doesn't have variables for
 @import "unity-bootstrap-theme-extends";
 
-/* -----------------------------------------------------
-Container/ row / column padding adjustments for mobile.
-
-Bootstrap doesn't natively provide a way to alter the behavior
-its native grid elements based on a media query. This overrides
-that behavior at screens <= 575px. (The small breakpoint.)
-
-Should be included after @import scss/grid. Registered here for clarity.
------------------------------------------------------- */
-
-@include media-breakpoint-down(md) {
-  .container,
-  .container-fluid,
-  .container-xl,
-  .container-lg,
-  .container-md,
-  .container-sm {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
+@import 'end-style';


### PR DESCRIPTION
nested containers failsafe, include container end styles only once

### Description
button issue on mobile was caused by nested container padding
https://chs.asu.edu/bachelors-degrees/majorinfo/ECEXERBS/undergrad/false/91407

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1230)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [ ] No new console errors
- [ ] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

![image](https://github.com/ASU/asu-unity-stack/assets/5209283/ed99a94c-d58d-4c37-b504-0260891256b3)

![image](https://github.com/ASU/asu-unity-stack/assets/5209283/7f2f2f02-7de8-4e3e-9bc6-3c69b5c35d74)
