### PR TITLE
fix(app-webdir-ui): limit results to 100 pages

### DIFF
--- a/packages/app-webdir-ui/src/SearchResultsList/index.js
+++ b/packages/app-webdir-ui/src/SearchResultsList/index.js
@@ -207,7 +207,7 @@ const ASUSearchResultsList = ({
               type="default"
               background="white"
               currentPage={currentPage}
-              totalPages={Math.ceil(totalResults / itemsPerPage)}
+              totalPages={Math.ceil(totalResults / itemsPerPage) > 100 ? 100 : Math.ceil(totalResults / itemsPerPage)}
               onChange={(e, action) => onPageChange(action)}
               showFirstButton
               showLastButton


### PR DESCRIPTION
SCHWEB-1043

### Description

<!-- Description of problem -->
Elastic App Search limits results to 100, and it is not configurable. So, we need to limit our results accordingly.
<!-- Solution -->
I have made it so that the pager for search results caps out at 100.
### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/SCHWEB-1078)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
