### PR TITLE
Uds 1469 - footer p.h5 to div.h5

### DIFF
--- a/packages/component-footer/src/components/ColumnSection/index.js
+++ b/packages/component-footer/src/components/ColumnSection/index.js
@@ -25,7 +25,7 @@ const ColumnSection = ({ columnIndex, column: { title, links } }) => {
           tabIndex={0}
           data-bs-toggle="collapse"
         >
-          <p className="h5">
+          <div className="h5">
             <a
               id={`footlink-header-${columnIndex}`}
               className="collapsed"
@@ -35,7 +35,7 @@ const ColumnSection = ({ columnIndex, column: { title, links } }) => {
               {title}
               <FontAwesomeIcon icon={faChevronUp} />
             </a>
-          </p>
+          </div>
         </div>
         <div
           id={`footlink-${columnIndex}`}

--- a/packages/component-footer/src/components/Contact/index.js
+++ b/packages/component-footer/src/components/Contact/index.js
@@ -18,7 +18,7 @@ const Contact = ({
       <div className="container" id="footer-columns">
         <div className="row" data-testid="columns-container">
           <div className="col-xl-3" id="info-column">
-            <p className="h5">{title}</p>
+            <div className="h5">{title}</div>
             {contactLink && (
               <p className="contact-link">
                 <a href={contactLink}>Contact Us</a>

--- a/packages/unity-bootstrap-theme/stories/organisms/global-footer/global-footer.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/organisms/global-footer/global-footer.templates.stories.js
@@ -491,9 +491,9 @@ export const OneColumn = (
       <div className="container" id="footer-columns">
         <div className="row">
           <div className="col-xl-3" id="info-column">
-            <p className="h5">
+            <div className="h5">
               Complete Name of College, School or Unit Title Should Go Here
-            </p>
+            </div>
             <p className="contact-link">
               <a href="#">Contact Us</a>
             </p>
@@ -661,9 +661,9 @@ export const OneColumnNoLogoOrSocial = (
       <div className="container" id="footer-columns">
         <div className="row">
           <div className="col-xl-3" id="info-column">
-            <p className="h5">
+            <div className="h5">
               Complete Name of College, School or Unit Title Should Go Here
-            </p>
+            </div>
             <p className="contact-link">
               <a href="#">Contact Us</a>
             </p>
@@ -921,9 +921,9 @@ export const TwoColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl-3" id="info-column">
-              <p className="h5">
+              <div className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </p>
+              </div>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -937,7 +937,7 @@ export const TwoColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -950,7 +950,7 @@ export const TwoColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-two"
@@ -1225,9 +1225,9 @@ export const ThreeColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl" id="info-column">
-              <p className="h5">
+              <div className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </p>
+              </div>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -1241,7 +1241,7 @@ export const ThreeColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -1254,7 +1254,7 @@ export const ThreeColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-two"
@@ -1284,7 +1284,7 @@ export const ThreeColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-three"
                       className="collapsed"
@@ -1297,7 +1297,7 @@ export const ThreeColumns = (
                       Student Information
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-three"
@@ -1577,9 +1577,9 @@ export const FourColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl" id="info-column">
-              <p className="h5">
+              <div className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </p>
+              </div>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -1593,7 +1593,7 @@ export const FourColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -1606,7 +1606,7 @@ export const FourColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-two"
@@ -1636,7 +1636,7 @@ export const FourColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-three"
                       className="collapsed"
@@ -1649,7 +1649,7 @@ export const FourColumns = (
                       Student Information
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-three"
@@ -1684,7 +1684,7 @@ export const FourColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-four"
                       className="collapsed"
@@ -1697,7 +1697,7 @@ export const FourColumns = (
                       Column Number Four
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-four"
@@ -1977,9 +1977,9 @@ export const FiveColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl" id="info-column">
-              <p className="h5">
+              <div className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </p>
+              </div>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -1993,7 +1993,7 @@ export const FiveColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -2006,7 +2006,7 @@ export const FiveColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-two"
@@ -2036,7 +2036,7 @@ export const FiveColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-three"
                       className="collapsed"
@@ -2049,7 +2049,7 @@ export const FiveColumns = (
                       Student Information
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-three"
@@ -2084,7 +2084,7 @@ export const FiveColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-four"
                       className="collapsed"
@@ -2097,7 +2097,7 @@ export const FiveColumns = (
                       Column Number Four
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-four"
@@ -2132,7 +2132,7 @@ export const FiveColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-five"
                       className="collapsed"
@@ -2145,7 +2145,7 @@ export const FiveColumns = (
                       Mambo Number Five
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-five"
@@ -2425,9 +2425,9 @@ export const SixColumns = (
         <div className="container" id="footer-columns">
           <div className="row">
             <div className="col-xl" id="info-column">
-              <p className="h5">
+              <div className="h5">
                 Complete Name of College, School or Unit Title Should Go Here
-              </p>
+              </div>
               <p className="contact-link">
                 <a href="#">Contact Us</a>
               </p>
@@ -2441,7 +2441,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-two"
                       className="collapsed"
@@ -2454,7 +2454,7 @@ export const SixColumns = (
                       Second Column
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-two"
@@ -2484,7 +2484,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-three"
                       className="collapsed"
@@ -2497,7 +2497,7 @@ export const SixColumns = (
                       Student Information
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-three"
@@ -2532,7 +2532,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-four"
                       className="collapsed"
@@ -2545,7 +2545,7 @@ export const SixColumns = (
                       Column Number Four
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-four"
@@ -2580,7 +2580,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-five"
                       className="collapsed"
@@ -2593,7 +2593,7 @@ export const SixColumns = (
                       Mambo Number Five
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-five"
@@ -2628,7 +2628,7 @@ export const SixColumns = (
             <div className="col-xl flex-footer">
               <div className="card accordion-item desktop-disable-xl">
                 <div className="accordion-header">
-                  <p className="h5">
+                  <div className="h5">
                     <a
                       id="footlink-header-six"
                       className="collapsed"
@@ -2641,7 +2641,7 @@ export const SixColumns = (
                       The Zen Master and the Hot Dog Vendor
                       <span className="fas fa-chevron-up"></span>
                     </a>
-                  </p>
+                  </div>
                 </div>
                 <div
                   id="footlink-six"


### PR DESCRIPTION
### Description

Change footer p.h5 tag to div.h5 since p tag has min-width

### Links

- [component-footer](https://unity.web.asu.edu/@asu/component-footer/index.html?path=/story/uds-asu-footer--one-column-no-logo)
- [unity-bootstrap-theme](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/organisms-global-footer-examples--one-column-no-logo-or-social-example)
- [JIRA ticket UDS-1469](https://asudev.jira.com/browse/UDS-1469)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
