### PR TITLE
fix(unity-bootstrap-theme): fix form fields

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
@@ -60,9 +60,9 @@ form.uds-form {
   input:focus,
   textarea:focus,
   select:focus {
-    outline: none !important;
-    box-shadow: none !important;
-    border: 2px solid $uds-color-base-gray-7 !important;
+    outline: none!important;
+    box-shadow: 0 0 0 1px $uds-color-base-gray-7 !important;
+    border: 1px solid $uds-color-base-gray-7 !important;
     border-radius: none;
   }
 
@@ -246,6 +246,9 @@ form.uds-form {
     border-bottom: 8px solid $uds-color-font-dark-error;
     // BS4 input height led to border eating padding. Resolved in variable
     // overrides by setting input heights to auto.
+    &:focus {
+      border-bottom: 8px solid $uds-color-font-dark-error !important;
+    }
   }
   /* checks and radios */
   small.is-invalid,
@@ -283,6 +286,9 @@ form.uds-form {
     border-bottom: 8px solid $uds-color-font-dark-success;
     // BS4 input height led to border eating padding. Resolved in variable
     // overrides by setting input heights to auto.
+    &:focus {
+      border-bottom: 8px solid $uds-color-font-dark-success !important;
+    }
   }
   /* checks and radios */
   small.is-valid,
@@ -414,8 +420,11 @@ form.uds-form {
     textarea:focus,
     select:focus {
       background-color: $uds-color-base-gray-7;
-      border: 2px solid $uds-color-base-gray-1 !important;
       color: $uds-color-base-gray-1;
+      outline: none!important;
+      box-shadow: 0 0 0 1px $uds-color-base-gray-1 !important;
+      border: 1px solid $uds-color-base-gray-1 !important;
+      border-radius: none;
     }
 
     /* Dark Radios and Checkboxes */
@@ -477,9 +486,12 @@ form.uds-form {
     select.is-invalid {
       border-style: solid;
       border: 1px solid $uds-color-alerts-error;
-      border-bottom: 8px solid $uds-color-alerts-error;
+      border-bottom: 8px solid $uds-color-alerts-error !important;
       // BS4 input height led to border eating padding. Resolved in variable
       // overrides by setting input heights to auto.
+      &:focus {
+        border-bottom: 8px solid $uds-color-alerts-error !important;
+      }
     }
     .invalid-feedback {
       font-weight: bold;
@@ -501,6 +513,9 @@ form.uds-form {
       border-bottom: 8px solid $uds-color-base-green;
       // BS4 input height led to border eating padding. Resolved in variable
       // overrides by setting input heights to auto.
+      &:focus {
+        border-bottom: 8px solid $uds-color-base-green !important;
+      }
     }
     .valid-feedback {
       font-weight: bold;


### PR DESCRIPTION
fix form fields border that's causing jumping

### Description

**Description of problem**:
In Webforms, when a user focuses on a field, a 1px border is added. This changes the element height, and causes the content to jump.

**Solution:**
By replacing the added 1px border on the focus state with 1px of box-shadow of the same color, the jumpiness when clicking into the fields is eliminated.

While working on this, I encountered another issue with the success and alert fields, given both have an 8px bottom border. In order to retain the 8px bottom border, I had to create focus states of these individual styles.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1474)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
### Field focus state border causing jumpiness
![field-borders-growing](https://github.com/ASU/asu-unity-stack/assets/7406481/0efffff7-afde-4c33-9679-52da2e79404c)

### fixed field focus states
![field-borders-fixed](https://github.com/ASU/asu-unity-stack/assets/7406481/d2de63c9-83e2-4cbe-b564-2b12a3d97b19)
