### PR TITLE
fix(unity-bootstrap-theme): fix content img-txt overflow

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_image-text-block.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_image-text-block.scss
@@ -12,10 +12,6 @@
       flex-direction: row-reverse;
     }
 
-    @include media-breakpoint-up(xl) {
-      max-height: 540px;
-    }
-
     @media screen and (max-width: $uds-breakpoint-md) {
       flex-direction: column;
     }

--- a/packages/unity-bootstrap-theme/stories/molecules/image-background-with-cta/image-text-block/image-text-block.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/image-background-with-cta/image-text-block/image-text-block.templates.stories.js
@@ -1,5 +1,14 @@
 import { createComponent, createStory } from "../../../../helpers/wrapper.js";
 
+const ContentBlock = () => <p>
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae
+ab illo inventore veritatis et quasi architecto beatae vitae dicta
+sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
+aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos
+qui ratione voluptatem sequi nesciunt. Neque porro quisquam est.
+</p>;
+
 const extraOptions = {
   right: {
     name: "Right",
@@ -19,6 +28,11 @@ const extraOptions = {
         "gray-7-bg": "gray-7-bg",
       },
     },
+  },
+  extraContent: {
+    name: "Extra Content",
+    control: { type: "boolean" },
+    defaultValue: false,
   },
 };
 
@@ -51,14 +65,13 @@ export const ImageLeftOrRight = createStory(args => {
       <div className={`uds-image-text-block-text-container ${args.bgColor}`}>
         <h3>This is a heading</h3>
         <h4>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</h4>
-        <p>
-          Sed ut perspiciatis unde omnis iste natus error sit voluptatem
-          accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae
-          ab illo inventore veritatis et quasi architecto beatae vitae dicta
-          sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
-          aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos
-          qui ratione voluptatem sequi nesciunt. Neque porro quisquam est.
-        </p>
+        <ContentBlock/>
+        {
+          args.extraContent && <>
+          <ContentBlock/>
+          <ContentBlock/>
+          </>
+        }
         <div className="uds-buttons py-1">
           <a
             href="#"


### PR DESCRIPTION
### Description

Button overlap

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-content-sections-image-and-text-block-templates--image-left-or-right)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1478)
- [Unity Design Kit - inset-box (has example of 2 buttons](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/674ebe9d-bcfd-48c9-a3eb-37efe95f4f4a/)

- [Similar pattern - inset-box](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-content-sections-inset-box-examples--basic-example&args=header:false;footer:false;template:1)
  - Should we remove styles from inset-box (for the button group) and only use styles from [packages/unity-bootstrap-theme/src/scss/extends/_buttons.scss](https://github.com/ASU/asu-unity-stack/compare/uds-1386?expand=1#diff-5073d36ddc441dcc410438afbc9d47bf4365260e9f80250a7afbaf9a576b483a)


### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors
- [ ] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
