### PR TITLE
fix(app-degree-pages): adjust card columns

### DIFF
--- a/packages/app-degree-pages/src/components/DetailPage/components/AffordingCollege/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/components/AffordingCollege/index.js
@@ -17,7 +17,7 @@ function AffordingCollege() {
         <span className="highlight-gold">Affording college</span>
       </h2>
       <div className="mt-2 row">
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             icon={["fas", "calculator"]}
             title="Tuition estimator"
@@ -32,7 +32,7 @@ function AffordingCollege() {
             ]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             icon={["fas", "award"]}
             title="Scholarships"
@@ -47,7 +47,7 @@ function AffordingCollege() {
             ]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             icon={["fas", "hand-holding-usd"]}
             title="Financial aid"

--- a/packages/app-degree-pages/src/components/DetailPage/components/NextSteps/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/components/NextSteps/index.js
@@ -23,7 +23,7 @@ function NextSteps({ cards, defaultCards }) {
     >
       <h2>Next steps to attend ASU</h2>
       <div className="mt-2 row">
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             icon={cards?.learnMore?.icon ?? defaultCards.learnMore.icon}
             title={cards?.learnMore?.title ?? defaultCards.learnMore.title}
@@ -33,7 +33,7 @@ function NextSteps({ cards, defaultCards }) {
             ]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             icon={cards?.apply?.icon ?? defaultCards.apply.icon}
             title={cards?.apply?.title ?? defaultCards.apply.title}
@@ -43,7 +43,7 @@ function NextSteps({ cards, defaultCards }) {
             ]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             icon={cards?.visit?.icon ?? defaultCards.visit.icon}
             title={cards?.visit?.title ?? defaultCards.visit.title}

--- a/packages/app-degree-pages/src/components/DetailPage/components/WhyChooseAsu/index.js
+++ b/packages/app-degree-pages/src/components/DetailPage/components/WhyChooseAsu/index.js
@@ -29,7 +29,7 @@ const WhyChooseAsu = ({ sectionIntroText, cards, defaultCards }) => {
         dangerouslySetInnerHTML={sanitizeDangerousMarkup(sectionIntroText)}
       />
       <div className="mt-2 row">
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             image={cards?.faculty?.image?.url ?? defaultCards.faculty.image.url}
             imageAltText={
@@ -41,7 +41,7 @@ const WhyChooseAsu = ({ sectionIntroText, cards, defaultCards }) => {
             buttons={[cards?.faculty?.button ?? defaultCards.faculty.button]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             image={
               cards?.programs?.image?.url ?? defaultCards.programs.image.url
@@ -55,7 +55,7 @@ const WhyChooseAsu = ({ sectionIntroText, cards, defaultCards }) => {
             buttons={[cards?.programs?.button ?? defaultCards.programs.button]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             image={
               cards?.research?.image?.url ?? defaultCards.research.image.url
@@ -69,7 +69,7 @@ const WhyChooseAsu = ({ sectionIntroText, cards, defaultCards }) => {
             buttons={[cards?.research?.button ?? defaultCards.research.button]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             image={
               cards?.inclusion?.image?.url ?? defaultCards.inclusion.image.url
@@ -85,7 +85,7 @@ const WhyChooseAsu = ({ sectionIntroText, cards, defaultCards }) => {
             ]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             image={cards?.mentors?.image?.url ?? defaultCards.mentors.image.url}
             imageAltText={
@@ -97,7 +97,7 @@ const WhyChooseAsu = ({ sectionIntroText, cards, defaultCards }) => {
             buttons={[cards?.mentors?.button ?? defaultCards.mentors.button]}
           />
         </div>
-        <div className="mt-2 col-12 col-md-4">
+        <div className="mt-2 col-12 col-md-6 col-lg-4">
           <Card
             image={cards?.honors?.image?.url ?? defaultCards.honors.image.url}
             imageAltText={


### PR DESCRIPTION
### Description

Degree Pages – On some breakpoints, the buttons will overflow the card if content is too long.

### Links

- Unity reference site
  - [default-with-graduate-degree](https://unity.web.asu.edu/@asu/app-degree-pages/index.html?path=/story/program-detail-page--default-with-graduate-degree )
  - [with-content](https://unity.web.asu.edu/@asu/app-degree-pages/index.html?path=/story/program-detail-page--with-content)
  - [with-not-accept-new-students](https://unity.web.asu.edu/@asu/app-degree-pages/index.html?path=/story/program-detail-page--with-not-accept-new-students)
  - [with-video-and-market-text](https://unity.web.asu.edu/@asu/app-degree-pages/index.html?path=/story/program-detail-page--with-video-and-market-text)
  - [with-youtube-video](https://unity.web.asu.edu/@asu/app-degree-pages/index.html?path=/story/program-detail-page--with-youtube-video)
  - [with-no-global-opportunity](https://unity.web.asu.edu/@asu/app-degree-pages/index.html?path=/story/program-detail-page--with-no-global-opportunity)
- [JIRA ticket UDS-1405](https://asudev.jira.com/browse/UDS-1405)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
