### PR TITLE
fix(components-core): readMoreLink not required in ranking card

### DIFF
--- a/packages/components-core/src/components/RankingCard/index.js
+++ b/packages/components-core/src/components/RankingCard/index.js
@@ -102,20 +102,25 @@ const InfoLayerWrapper = ({ imageSize, body, heading, readMoreLink }) => {
           // eslint-disable-next-line react/no-danger
           <p dangerouslySetInnerHTML={sanitizeDangerousMarkup(body)} />
         )}
-        <a
-          href={readMoreLink}
-          aria-label="Read more"
-          onClick={() => {
-            trackGAEvent({
-              ...gaDefaultObject,
-              section: heading,
-              text: "read more",
-            });
-          }}
-        >
-          Read more
-          <span className="fas icon-small fa-arrow-right" aria-hidden="true" />
-        </a>
+        {readMoreLink && (
+          <a
+            href={readMoreLink}
+            aria-label="Read more"
+            onClick={() => {
+              trackGAEvent({
+                ...gaDefaultObject,
+                section: heading,
+                text: "read more",
+              });
+            }}
+          >
+            Read more
+            <span
+              className="fas icon-small fa-arrow-right"
+              aria-hidden="true"
+            />
+          </a>
+        )}
       </div>
     </div>
   );
@@ -125,7 +130,7 @@ InfoLayerWrapper.propTypes = {
   imageSize: PropTypes.oneOf(["small", "large"]),
   body: PropTypes.string.isRequired,
   heading: PropTypes.string.isRequired,
-  readMoreLink: PropTypes.string.isRequired,
+  readMoreLink: PropTypes.string,
 };
 
 export const RankingCard = ({
@@ -134,7 +139,7 @@ export const RankingCard = ({
   imageAlt,
   heading,
   body,
-  readMoreLink = "#",
+  readMoreLink = "",
   citation,
 }) => {
   return (
@@ -184,7 +189,7 @@ RankingCard.propTypes = {
   /**
    * Link for read more
    */
-  readMoreLink: PropTypes.string.isRequired,
+  readMoreLink: PropTypes.string,
   /**
    * Ranking card citation content (Required for small size only)
    */


### PR DESCRIPTION
Removed required prop readMoreLink and only render if there is one present

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/components-core/index.html?path=/story/uds-ranking-card--small)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1423?atlOrigin=eyJpIjoiMmE1Mjk1YTVjZjExNDliNWI1ZGI0MTFlMTFjMTUxODciLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge


