### PR TITLE
fix(_form-fields.scss): added two style updates for validated form fields

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
@@ -205,6 +205,9 @@ form.uds-form {
       border-bottom: 8px solid $uds-color-font-dark-error;
       // BS4 input height led to border eating padding. Resolved in variable
       // overrides by setting input heights to auto.
+      &:focus {
+        border-bottom: 8px solid $uds-color-font-dark-error !important;
+      }
     }
     // Radios and checks individual labels shouldn't be colored.
     .form-check-input:invalid ~ .form-check-label {
@@ -218,6 +221,9 @@ form.uds-form {
       border-bottom: 8px solid $uds-color-font-dark-success;
       // BS4 input height led to border eating padding. Resolved in variable
       // overrides by setting input heights to auto.
+      &:focus {
+        border-bottom: 8px solid $uds-color-font-dark-success !important;
+      }
     }
     // Radios and checks individual labels shouldn't be colored.
     .form-check-input:valid ~ .form-check-label {


### PR DESCRIPTION
Forms – Client side validation fields - Focus state increases the border, causing jump

### Description

A couple client side validation fields got skipped when working on UDS-1474: 2.9.1:Forms – Focus state increases the border, causing jump, so this is to add the 8px bottom border to the remaining 2 field styles. (Note: This is already being done in WS2-1633)

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1482)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

