### PR TITLE
fix(_list.scss): fix Multi level OL and UL list-item doubling and padding squeeze

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
@@ -223,7 +223,7 @@ ol.uds-list {
         font-weight: bold;
         content: counter(
             listcounter
-        ); // Remove space as it messes with centering.
+        ); // Remove space because it messes with centering.
       }
     }
     &.uds-steplist-gold li:before {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
@@ -39,7 +39,8 @@
 
   ol,
   ul {
-    padding: 1rem 1.5rem 0rem;
+    padding: 1rem 0 0 1.5rem;
+    list-style: none;
   }
 }
 
@@ -150,7 +151,9 @@ ol.uds-list {
   counter-reset: listcounter;
 
   li ol {
-    padding: 1rem 1.5rem 0rem;
+    padding: 1rem 0 0 1.5rem;
+    list-style: none;
+    counter-reset: listcounter;
   }
 
   li:before {
@@ -219,7 +222,7 @@ ol.uds-list {
         font-size: 1.25rem;
         font-weight: bold;
         content: counter(
-          listcounter
+            listcounter
         ); // Remove space as it messes with centering.
       }
     }


### PR DESCRIPTION
Fix Multi level Ordered and Unordered Lists list-item doubling and padding squeeze


### Description of problem
Multi level Unordered and ordered lists have double bullet or double numbered list-items 
Multi level Ordered and Unordered Lists' right padding causing list items to squeeze to be super narrow on mobile screens

### Solution
`list-item:none;` where appropriate
remove right padding on nested list items
add `counter-reset: listcounter`; to `li ol`

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1483)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images
