### PR TITLE
Uds 1485 Fix package exports in UDS

### DIFF
--- a/packages/components-core/package.json
+++ b/packages/components-core/package.json
@@ -102,8 +102,10 @@
     "reactstrap": "^8.9.0"
   },
   "exports": {
-    "./dist/libCore.es.js": {
-      "default": "./src/index.js"
+    "./*": "./*",
+    ".": {
+      "import": "./dist/libCore.es.js",
+      "require": "./dist/libCore.cjs.js"
     }
   },
   "volta": {

--- a/packages/unity-bootstrap-theme/package.json
+++ b/packages/unity-bootstrap-theme/package.json
@@ -76,12 +76,6 @@
     "webpack-node-externals": "^3.0.0"
   },
   "exports": {
-    "./src/scss/unity-bootstrap-theme.bundle.scss": {
-      "browser": "./src/scss/unity-bootstrap-theme.bundle.scss",
-      "node": "./src/scss/unity-bootstrap-theme.bundle.scss",
-      "module": "./src/scss/unity-bootstrap-theme.bundle.scss",
-      "default": "./dist/css/unity-bootstrap-theme.bundle.css"
-    },
     "./js/global-header.js": {
       "module": "./src/js/storybook-global-header.js",
       "default": "./src/js/global-header.js"
@@ -90,18 +84,8 @@
       "module": "./src/js/storybook-data-layer.js",
       "default": "./src/js/data-layer.js"
     },
-    "./dist/css/unity-bootstrap-theme.bundle.css": {
-      "default": "./dist/css/unity-bootstrap-theme.bundle.css"
-    },
-    "./dist/css/unity-bootstrap-theme.css": {
-      "default": "./dist/css/unity-bootstrap-theme.css"
-    },
-    "./dist/css/unity-bootstrap-footer.css": {
-      "default": "./dist/css/unity-bootstrap-footer.css"
-    },
-    "./dist/css/unity-bootstrap-header.css": {
-      "default": "./dist/css/unity-bootstrap-header.css"
-    }
+    "./*": "./*",
+    ".": "./dist/css/unity-bootstrap-theme.bundle.css"
   },
   "peerDependencies": {
     "@fortawesome/fontawesome-free": "^5.15.3"

--- a/packages/unity-bootstrap-theme/webpack.config.js
+++ b/packages/unity-bootstrap-theme/webpack.config.js
@@ -140,7 +140,7 @@ const cssConfig = {
             loader: "css-loader",
             options: {
               // esModule: false,
-              sourceMap: false,
+              sourceMap: true,
               url: false,
               // modules: {
               //   namedExport: true,
@@ -154,17 +154,16 @@ const cssConfig = {
               postcssOptions: {
                 plugins: ["autoprefixer"],
               },
-              sourceMap: false,
+              sourceMap: true,
             },
           },
           {
             loader: "sass-loader",
             options: {
-              sourceMap: false,
+              sourceMap: true,
             },
           },
         ],
-        sideEffects: true,
       },
       {
         test: /\.(png|jpe?g|gif|svg)$/i,


### PR DESCRIPTION
### Description

When the ["exports"](https://nodejs.org/dist/latest-v18.x/docs/api/packages.html#exports) field is defined, only subpaths of the package listed in the exports are available. 

Adding pattern `"./*": "./*"` allows all files provided in the package can be imported

### Links

- [JIRA ticket UDS-1485](https://asudev.jira.com/browse/UDS-1485)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [x] No new console errors
- [ ] Accessibility checks
