### PR TITLE
fix(unity-bootstrap-theme): video hero gray overlay fix

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -477,11 +477,12 @@ div.uds-hero-lg {
 
       &.uds-video-hero video {
         display: block;
-        height: auto;
+        height: 100%;
         left: 0;
         position: absolute;
         top: 0;
         width: 100%;
+        object-fit: cover;
       }
 
       .video-hero-controls {


### PR DESCRIPTION
fix Video gray overlay if Video aspect ratio is too wide

### Description

### Description of problem:
Video Hero can show gray area from overlay if Video aspect ratio is too wide

### Solution
add styles to video element
```
height: 100%;
object-fit: cover;
```
note: ticket WS2-1796 after UDS reconciled in Renovation theme

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1487)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] No new console errors

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

### Before
![image](https://github.com/ASU/asu-unity-stack/assets/7406481/fd14f0af-cdf1-4528-bf84-ae341ab7a08c)


### After
<img width="1033" alt="image" src="https://github.com/ASU/asu-unity-stack/assets/7406481/94ca485e-a662-4b1b-82d8-d5b10a56cfed">

