### PR TITLE
fix(app-webdir-ui): fix rendered more hooks than during previous render

### DIFF
--- a/packages/app-webdir-ui/.storybook/preview.js
+++ b/packages/app-webdir-ui/.storybook/preview.js
@@ -56,7 +56,7 @@ export const decorators = [
     const [args, updateArgs] = useArgs();
   return <MemoryRouter>
         <Wrapper args={args} updateArgs={updateArgs}>
-          <Story />
+          {Story()}
         </Wrapper>
     </MemoryRouter>
   },


### PR DESCRIPTION
@davidornelas11 This addresses an error I was seeing in Storybook where if you selected the Search Page story and it rendered, then  you select a different story, and then try to go back to the Search Page,  you get the error "Rendered more hooks than during previous render".

A search on that error turned up [this issue](https://github.com/storybookjs/storybook/issues/15223), and the fix in [this comment](https://github.com/storybookjs/storybook/issues/15223#issuecomment-1092837912) resolved the issue.

This PR implements that fix. Can you verify?