### PR TITLE
Uds 1494

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_blockquotes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_blockquotes.scss
@@ -17,6 +17,9 @@ blockquote {
     overflow-wrap: break-word;
     word-wrap: break-word;
     word-break: break-word;
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
+    -ms-hyphens: auto;
     hyphens: auto;
     hyphenate-limit-chars: 12 3 4;
   }

--- a/packages/unity-bootstrap-theme/src/scss/extends/_blockquotes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_blockquotes.scss
@@ -12,6 +12,14 @@ blockquote {
   font-weight: inherit;
   padding-left: 0;
   max-width: none;
+  p {
+    max-width: unset;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
+    hyphenate-limit-chars: 12 3 4;
+  }
 }
 
 // In an older version of this element, the quote glyph was applied as a
@@ -95,7 +103,6 @@ blockquote:before {
       width: 72px;
       height: 72px;
     }
-
     blockquote p:first-of-type:before {
       content: '\201C';
     }
@@ -164,8 +171,8 @@ blockquote:before {
       gap: $uds-size-spacing-4;
 
       img {
-        width: 120px;
-        height: 120px;
+        min-width: 120px;
+        min-height: 120px;
       }
     }
 


### PR DESCRIPTION
### Description

### Description of problem:
Blockquote component with image displays skewed image when text has long words (in WS2). In UDS, long words push text outside of containing div.

### Solution:
Add word breaks and hyphens on image blockquote paragraphs, and use min-width and min-height on blockquote larger images

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1494)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

Before:
![image](https://github.com/ASU/asu-unity-stack/assets/7406481/6b889a52-77d9-4327-9018-fd948396814b)
![image](https://github.com/ASU/asu-unity-stack/assets/7406481/aa15d0f8-57e1-4645-8d47-059d18adb2fb)
![image](https://github.com/ASU/asu-unity-stack/assets/7406481/e370ccc5-9e1a-4882-93cc-7dc38f2f699c)


After:
![image](https://github.com/ASU/asu-unity-stack/assets/7406481/0d3e17ec-c55d-45d1-9cb1-1aa9349c0216)
![image](https://github.com/ASU/asu-unity-stack/assets/7406481/f855334f-78df-4fc0-8c35-dab52e32a4dc)
![image](https://github.com/ASU/asu-unity-stack/assets/7406481/16926bc5-b530-4d05-8241-3258f25966c6)

