### PR TITLE
fix(app-webdir-ui): pagination and results now account for filtered p…

### DIFF
--- a/packages/app-webdir-ui/src/WebDirectoryComponent/index.js
+++ b/packages/app-webdir-ui/src/WebDirectoryComponent/index.js
@@ -33,8 +33,16 @@ function WebDirectory({
       tempFilters["deptIds"] = deptIds.split(",");
       return tempFilters;
     }
-    tempFilters["peopleInDepts"] = ids
+    const profilesToFilterOut = display?.doNotDisplayProfiles
+      ?.split(",")
+      ?.map(asurite => asurite.toLowerCase());
+
+      tempFilters["peopleInDepts"] = ids
       .split(",")
+      .filter(person => {
+        const [asurite,] = person.split(":");
+        return !profilesToFilterOut.includes(asurite.toLowerCase());
+      })
       .filter(id => id.includes(":"))
       .map(pair => pair.split(":"))
       .map(pair => {

--- a/packages/app-webdir-ui/src/WebDirectoryComponent/index.stories.js
+++ b/packages/app-webdir-ui/src/WebDirectoryComponent/index.stories.js
@@ -98,7 +98,7 @@ export const webDirectoryExampleDepartmentsAndPeople = createStory(
       <div className="uds-content-align">
         <WebDirectory
           searchType="people_departments"
-          ids=",tgrandli:1344,mcrow:1343,jcunnin8:1358,ccherrer:1358,csmudde:1358"
+          ids="mcrow:1343,ccherrer:1358,csmudde:1358"
           API_URL="https://test-asu-isearch.ws.asu.edu"
           searchApiVersion="/api/v1/"
           display={display}


### PR DESCRIPTION
…rofiles

### Description
Error where the pagination and displayed people were not taking into account the user-supplied profiles to filter out is now fixed

<!-- Description of problem -->
<!-- Solution -->

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/app-webdir-ui/index.html?path=/story/organisms-web-directory-templates--web-directory-example-departments-and-people)
- [JIRA ticket](https://asudev.jira.com/browse/SCHWEB-1031?atlOrigin=eyJpIjoiMjUxYTA0ZDYwZmE4NDA5YWE5YmM4MzMzZGRhN2RlYjgiLCJwIjoiaiJ9)
### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge


