### PR TITLE
fix(app-webdir-ui): fix rendered more hooks than during previous render

### DIFF
--- a/packages/app-webdir-ui/.storybook/preview.js
+++ b/packages/app-webdir-ui/.storybook/preview.js
@@ -56,7 +56,7 @@ export const decorators = [
     const [args, updateArgs] = useArgs();
   return <MemoryRouter>
         <Wrapper args={args} updateArgs={updateArgs}>
-          <Story />
+          {Story()}
         </Wrapper>
     </MemoryRouter>
   },


### PR DESCRIPTION
Need this fixed for presentation on Thursday. Was previously merged into #1175, but we don't want that effort blocking this getting into `dev`