### PR TITLE
fix(components-core): useEffect guards in cleanup function of TabbedP…

### DIFF
--- a/packages/components-core/src/components/TabbedPanels/index.js
+++ b/packages/components-core/src/components/TabbedPanels/index.js
@@ -67,7 +67,6 @@ const TabbedPanels = ({
   const [scrollableWidth, setScrollableWidth] = useState();
 
   useEffect(() => {
-    console.log("useEffect");
     const onScroll = () => {
       setScrollLeft(headerTabs.current.scrollLeft);
     };

--- a/packages/components-core/src/components/TabbedPanels/index.js
+++ b/packages/components-core/src/components/TabbedPanels/index.js
@@ -67,13 +67,18 @@ const TabbedPanels = ({
   const [scrollableWidth, setScrollableWidth] = useState();
 
   useEffect(() => {
+    console.log("useEffect");
     const onScroll = () => {
       setScrollLeft(headerTabs.current.scrollLeft);
     };
     headerTabs.current.addEventListener("scroll", onScroll);
     onScroll();
-    return () => headerTabs.current.removeEventListener("scroll", onScroll);
-  }, [scrollableWidth]);
+    return () => {
+      if (headerTabs.current) {
+        headerTabs.current.removeEventListener("scroll", onScroll);
+      }
+    };
+}, [scrollableWidth]);
 
   useEffect(() => {
     const onResize = () => {
@@ -83,7 +88,11 @@ const TabbedPanels = ({
     };
     window.addEventListener("resize", onResize);
     onResize();
-    return () => window.removeEventListener("resize", onResize);
+    return () => {
+      if (headerTabs.current) {
+        window.removeEventListener("resize", onResize);
+      }
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
…anels

Added checks for ref used to reference the TabbedPanels in cleanup function on unMount

### Description

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1506?atlOrigin=eyJpIjoiMDdlZWM0ZWNiMGI1NGEyN2I3NmY5MDVmZDhhM2VlODgiLCJwIjoiaiJ9

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
