### PR TITLE
build: remove package with security issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,7 @@ spec:
                         withEnv(["GH_TOKEN=${RAW_GH_TOKEN_PSW}"]) {
                           // Must pass branch name "dev" and "PUSH" for script to deploy
                           // If branch!=="dev" build will be nested inside a folder
-                            sh "node ./scripts/deploy-gh-pages.js dev PUSH"
+                          sh "node ./scripts/deploy-gh-pages.js dev PUSH"
 
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,15 +115,13 @@ spec:
                     script {
                         echo '# Final, post-publish install and build to include just published pkgs...'
                         sh 'yarn install --frozen-lockfile'
-                        sh 'yarn build'
+                        sh 'yarn build-storybook'
 
                         withEnv(["GH_TOKEN=${RAW_GH_TOKEN_PSW}"]) {
-                            echo '# Prebuild Storybook static site as dry-run...'
-                            sh 'yarn deploy-storybook:dev'
-                            echo '# Compile templates and copy files for build deploy...'
-                            sh 'yarn gulp'
-                            echo '# Storybook static site final build and deploy...'
-                            sh 'yarn deploy-storybook --existing-output-dir=build'
+                          // Must pass branch name "dev" and "PUSH" for script to deploy
+                          // If branch!=="dev" build will be nested inside a folder
+                            sh "node ./scripts/deploy-gh-pages.js dev PUSH"
+
                         }
                     }
                 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,12 @@
 const gulp = require("gulp");
+const path = require("path");
+const glob = require("glob");
 const nunjucks = require("gulp-nunjucks");
 const clean = require("gulp-clean");
 const filter = require("gulp-filter");
+var fs = require('fs');
+var pkg = require('./package.json');
+const indexGenerator = require("./server/storybook-index-generator.js");
 
 copy = () => gulp.src(["./server/views/**/*"]).pipe(gulp.dest("./build/@asu"));
 
@@ -16,6 +21,16 @@ compile = () =>
     .pipe(nunjucks.compile())
     .pipe(gulp.dest("build"));
 
+index = (cb) => {
+  const packages = glob
+    .sync(path.join(process.cwd(), "packages/", '**/package.json'), {
+      ignore: '**/node_modules/**'
+    })
+    .map(file => JSON.parse(fs.readFileSync(file, 'utf8')));
+
+ fs.writeFile('build/index.html', indexGenerator(packages), cb);
+}
+
 cleanup = () =>
   gulp
     .src([
@@ -25,4 +40,4 @@ cleanup = () =>
     ])
     .pipe(clean());
 
-exports.default = gulp.series(copy, cname, compile, cleanup);
+exports.default = gulp.series(copy, cname, compile, index, cleanup);

--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,8 @@
       "options": {
         "cacheableOperations": [
           "prebuild",
-          "build"
+          "build",
+          "build-storybook"
         ]
       }
     }
@@ -30,6 +31,12 @@
       ],
       "outputs": [
         "{projectRoot}/dist"
+      ]
+    },
+    "build-storybook": {
+      "dependsOn": [
+        "build",
+        "^build-storybook"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lerna-clean": "lerna clean && rm -rf ./node_modules",
     "lint": "lerna run lint",
+    "build-storybook": "rm -rf ./build && lerna run build-storybook && gulp",
     "build-components-core": "lerna run --scope @asu/components-core build",
     "build-component-carousel": "lerna run --scope @asu/component-carousel build",
     "build": "lerna run --ignore @asu/components-core --ignore @asu/component-carousel build",
@@ -24,8 +25,6 @@
     "percy": "lerna run percy",
     "start": "node server/server.js",
     "stop": "node server/server.stop.js",
-    "deploy-storybook:dev": "storybook-to-ghpages --out=build --packages packages --monorepo-index-generator server/storybook-index-generator.js --source-branch=dev --ci --dry-run",
-    "deploy-storybook": "node ./scripts/deploy-check.js && storybook-to-ghpages --out=build --packages packages --monorepo-index-generator server/storybook-index-generator.js --source-branch=dev --ci",
     "prepare": "husky install",
     "commit": "cz",
     "check-element-changes": "node ./scripts/check-element-changes.js -d"
@@ -53,7 +52,6 @@
     "@commitlint/config-lerna-scopes": "^12.0.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "10.0.1",
-    "@storybook/storybook-deployer": "^2.8.16",
     "clean-webpack-plugin": "^3.0.0",
     "commitizen": "^4.2.3",
     "copy-webpack-plugin": "^8.1.1",
@@ -70,6 +68,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "gh-pages": "^6.0.0",
+    "glob": "^7.1.3",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-filter": "^7.0.0",

--- a/packages/app-degree-pages/package.json
+++ b/packages/app-degree-pages/package.json
@@ -37,7 +37,7 @@
     "build:stats": "webpack -c webpack/webpack.prod.js --profile --json=compilation-stats.json",
     "start:dev": "webpack-dashboard -- webpack serve -c webpack/webpack.dev.js",
     "storybook": "start-storybook -s ./dist -p 9010",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "jsdoc": "jsdoc -c jsdoc.config.js",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",

--- a/packages/app-rfi/package.json
+++ b/packages/app-rfi/package.json
@@ -33,7 +33,7 @@
     "build:stats": "webpack -c webpack/webpack.prod.js --profile --json=compilation-stats.json",
     "postbuild": "cp ./types/main.d.ts ./dist/main.d.ts",
     "storybook": "start-storybook -s ./dist -p 9020",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "jsdoc": "jsdoc -c jsdoc.config.js",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",

--- a/packages/app-webdir-ui/package.json
+++ b/packages/app-webdir-ui/package.json
@@ -32,7 +32,7 @@
     "build:stats": "webpack -c webpack/webpack.prod.js --profile --json=compilation-stats.json",
     "start:dev": "webpack-dashboard -- webpack serve -c webpack/webpack.dev.js",
     "storybook": "start-storybook -s ./dist -p 9030",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "jsdoc": "jsdoc -c jsdoc.config.js",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md -c jsdoc.config.js --files ./src/** > ./docs/README.props.md",

--- a/packages/component-carousel/package.json
+++ b/packages/component-carousel/package.json
@@ -33,7 +33,7 @@
     "test": "jest --config=./jest.config.js --passWithNoTests --silent --coverage",
     "start:dev": "webpack-dashboard -- webpack serve -c webpack/webpack.dev.js",
     "storybook": "start-storybook -s ./dist -p 9040",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "jsdoc": "jsdoc -c jsdoc.config.js",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",

--- a/packages/component-cookie-consent/package.json
+++ b/packages/component-cookie-consent/package.json
@@ -34,7 +34,7 @@
     "postbuild": "cp ./types/main.d.ts ./dist/main.d.ts",
     "start:dev": "webpack-dashboard -- webpack serve -c webpack/webpack.dev.js",
     "storybook": "start-storybook -s ./dist -p 9050",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src > ./docs/README.props.md",
     "postdocs": "node ../../scripts/process-readme-props.js"

--- a/packages/component-events/package.json
+++ b/packages/component-events/package.json
@@ -34,7 +34,7 @@
     "postbuild": "cp ./types/main.d.ts ./dist/main.d.ts",
     "start:dev": "webpack-dashboard -- webpack serve -c webpack/webpack.dev.js",
     "storybook": "start-storybook -s ./dist -p 9060",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "jsdoc": "jsdoc -c jsdoc.config.js",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",

--- a/packages/component-footer/package.json
+++ b/packages/component-footer/package.json
@@ -37,7 +37,7 @@
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",
     "postdocs": "node ../../scripts/process-readme-props.js",
-    "build-storybook": "build-storybook -s ./dist"
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name"
   },
   "dependencies": {
     "@asu/components-core": "^2.1.0",

--- a/packages/component-header/package.json
+++ b/packages/component-header/package.json
@@ -37,7 +37,7 @@
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",
     "postdocs": "node ../../scripts/process-readme-props.js",
-    "build-storybook": "build-storybook -s ./dist"
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name"
   },
   "peerDependencies": {
     "@asu/components-core": "^2.1.0",

--- a/packages/component-news/package.json
+++ b/packages/component-news/package.json
@@ -34,7 +34,7 @@
     "postbuild": "cp ./types/main.d.ts ./dist/main.d.ts",
     "start:dev": "webpack-dashboard -- webpack serve -c webpack/webpack.dev.js",
     "storybook": "start-storybook -s ./dist -p 9090",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "jsdoc": "jsdoc -c jsdoc.config.js",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",

--- a/packages/components-core/package.json
+++ b/packages/components-core/package.json
@@ -38,7 +38,7 @@
     "build:stats": "webpack -c webpack/webpack.prod.js --profile --json=compilation-stats.json",
     "storybook": "start-storybook -p 9100",
     "percy": "build-storybook -c ./.storybook/percy -o ./percy-storybook && export PERCY_TOKEN=$PERCY_TOKEN_COMPONENTS_CORE && percy storybook ./percy-storybook",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "jsdoc": "jsdoc -c jsdoc.config.js",
     "predocs": "mkdir -p ./docs",
     "docs": "jsdoc2md --no-cache -c jsdoc.config.js --files ./src/components > ./docs/README.props.md",

--- a/packages/unity-bootstrap-theme/package.json
+++ b/packages/unity-bootstrap-theme/package.json
@@ -20,7 +20,7 @@
     "build:dev": "rimraf ./dist && webpack --progress --bail && rimraf ./.tmp",
     "watch": "rimraf ./dist && webpack --watch && rimraf ./.tmp",
     "storybook": "start-storybook -p 9000",
-    "build-storybook": "build-storybook -s ./dist",
+    "build-storybook": "build-storybook -s ./dist -o ../../build/$npm_package_name",
     "lint": "yarn js-lint && yarn css-lint",
     "lint:fix": "yarn js-lint:fix && yarn css-lint:fix",
     "js-lint": "eslint \"**/*.js\"",

--- a/scripts/deploy-check.js
+++ b/scripts/deploy-check.js
@@ -7,5 +7,5 @@ if (!fs.existsSync(PATH_TO_CNAME)) {
   console.error('ERR: no CNAME file found, cancelling build');
   process.exit(1);
 } else {
-  console.log('CNAME file found or --dry-run flag added, continuing build');
+  console.log('CNAME file found, continuing build');
 }

--- a/scripts/deploy-gh-pages.js
+++ b/scripts/deploy-gh-pages.js
@@ -1,0 +1,39 @@
+var ghpages = require('gh-pages');
+
+// Jenkins file will call the file with branch name
+let BRANCH = process?.argv?.[2] || null;
+// Jenkins file will call the file with PUSH to trigger deploy to gh-pages
+let push = process?.argv?.[3] === "PUSH" ? true: false;
+
+const options = {
+  // default is the root (dev)
+  dest: ".",
+  push,
+  // ensures we delete the root directory except for the branch folder
+  remove: ["*", "!branch"]
+};
+
+if(BRANCH !== "dev"){
+  options.dest = `branch/${process.argv[2]}`;
+}
+
+console.log(options);
+
+require('./deploy-check');
+
+ghpages.publish('build', options, function(){
+
+  if(push){
+    console.log(`Published gh-pages branch: ${BRANCH}`);
+  }
+  else{
+    console.log(`
+Option to push was false!
+
+Output gh-pages to local directory "./node_modules/.cache/gh-pages".
+
+PUSH argument should only be used from jenkin, with the exception
+jenkins is down and the static site needs an immediate fix.
+  `);
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4545,17 +4545,6 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/storybook-deployer@^2.8.16":
-  version "2.8.16"
-  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.16.tgz#890abe4fd81b6fbc028dffb6314016f208aba6c2"
-  integrity sha512-DRQrjyLKaRLXMYo7SNUznyGabtOLJ0b9yfBKNVMu6PsUHJifGPabXuNXmRPZ6qvyhHUSKLQgeLaX8L3Og6uFUg==
-  dependencies:
-    git-url-parse "^12.0.0"
-    glob "^7.1.3"
-    parse-repo "^1.0.4"
-    shelljs "^0.8.1"
-    yargs "^15.0.0"
-
 "@storybook/telemetry@6.5.16":
   version "6.5.16"
   resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-6.5.16.tgz#b13c8133e02c28e37b7716c987e7414b1ddc5363"
@@ -6386,7 +6375,7 @@ async@^2.6.4:
   dependencies:
     lodash "^4.17.14"
 
-async@^3.2.3:
+async@^3.2.3, async@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
@@ -7972,6 +7961,11 @@ command-line-usage@^4.1.0:
     array-back "^2.0.0"
     table-layout "^0.4.2"
     typical "^2.6.1"
+
+commander@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
@@ -9597,6 +9591,11 @@ elliptic@^6.5.3:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+email-addresses@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-5.0.0.tgz#7ae9e7f58eef7d5e3e2c2c2d3ea49b78dc854fa6"
+  integrity sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==
+
 emittery@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
@@ -10846,6 +10845,20 @@ filelist@^1.0.4:
   dependencies:
     minimatch "^5.0.1"
 
+filename-reserved-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
+  integrity sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==
+
+filenamify@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.3.0.tgz#62391cb58f02b09971c9d4f9d63b3cf9aba03106"
+  integrity sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.1"
+    trim-repeated "^1.0.0"
+
 filesize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-7.0.0.tgz#9d4b3ce384ec7731a9e68c64ee29fb4934ad657d"
@@ -11260,7 +11273,7 @@ fs-extra@^10.0.0, fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.0.0, fs-extra@^11.1.0:
+fs-extra@^11.0.0, fs-extra@^11.1.0, fs-extra@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
   integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
@@ -11545,6 +11558,19 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gh-pages@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-6.0.0.tgz#3bb46ea13dc7cee306662db0d3f02bf05635cdc1"
+  integrity sha512-FXZWJRsvP/fK2HJGY+Di6FRNHvqFF6gOIELaopDjXXgjeOYSNURcuYwEO/6bwuq6koP5Lnkvnr5GViXzuOB89g==
+  dependencies:
+    async "^3.2.4"
+    commander "^11.0.0"
+    email-addresses "^5.0.0"
+    filenamify "^4.3.0"
+    find-cache-dir "^3.3.1"
+    fs-extra "^11.1.1"
+    globby "^6.1.0"
+
 git-log-parser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/git-log-parser/-/git-log-parser-1.2.0.tgz#2e6a4c1b13fc00028207ba795a7ac31667b9fd4a"
@@ -11584,14 +11610,6 @@ git-semver-tags@^4.1.1:
     meow "^8.0.0"
     semver "^6.0.0"
 
-git-up@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/git-up/-/git-up-6.0.0.tgz#dbd6e4eee270338be847a0601e6d0763c90b74db"
-  integrity sha512-6RUFSNd1c/D0xtGnyWN2sxza2bZtZ/EmI9448n6rCZruFwV/ezeEn2fJP7XnUQGwf0RAtd/mmUCbtH6JPYA2SA==
-  dependencies:
-    is-ssh "^1.4.0"
-    parse-url "^7.0.2"
-
 git-up@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/git-up/-/git-up-7.0.0.tgz#bace30786e36f56ea341b6f69adfd83286337467"
@@ -11606,13 +11624,6 @@ git-url-parse@13.1.0:
   integrity sha512-5FvPJP/70WkIprlUZ33bm4UAaFdjcLkJLpWft1BeZKqwR0uhhNGoKwlUaPtVb4LxCSQ++erHapRak9kWGj+FCA==
   dependencies:
     git-up "^7.0.0"
-
-git-url-parse@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-12.0.0.tgz#4ba70bc1e99138321c57e3765aaf7428e5abb793"
-  integrity sha512-I6LMWsxV87vysX1WfsoglXsXg6GjQRKq7+Dgiseo+h0skmp5Hp2rzmcEIRQot9CPA+uzU7x1x7jZdqvTFGnB+Q==
-  dependencies:
-    git-up "^6.0.0"
 
 gitconfiglocal@^1.0.0:
   version "1.0.0"
@@ -12929,7 +12940,7 @@ internal-slot@^1.0.3, internal-slot@^1.0.4, internal-slot@^1.0.5:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-interpret@^1.0.0, interpret@^1.4.0:
+interpret@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
@@ -16385,7 +16396,7 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
-normalize-url@^6.0.0, normalize-url@^6.0.1, normalize-url@^6.1.0:
+normalize-url@^6.0.0, normalize-url@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
@@ -17468,34 +17479,12 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==
 
-parse-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-5.0.0.tgz#f933152f3c6d34f4cf36cfc3d07b138ac113649d"
-  integrity sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==
-  dependencies:
-    protocols "^2.0.0"
-
 parse-path@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-7.0.0.tgz#605a2d58d0a749c8594405d8cc3a2bf76d16099b"
   integrity sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==
   dependencies:
     protocols "^2.0.0"
-
-parse-repo@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
-  integrity sha512-RdwYLh7cmxByP/BfeZX0QfIVfeNrH2fWgK1aLsGK+G6nCO4WTlCks4J7aW0O3Ap9BCPDF/e8rGTT50giQr10zg==
-
-parse-url@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-7.0.2.tgz#d21232417199b8d371c6aec0cedf1406fd6393f0"
-  integrity sha512-PqO4Z0eCiQ08Wj6QQmrmp5YTTxpYfONdOEamrtvK63AmzXpcavIVQubGHxOEwiIoDZFb8uDOoQFS0NCcjqIYQg==
-  dependencies:
-    is-ssh "^1.4.0"
-    normalize-url "^6.1.0"
-    parse-path "^5.0.0"
-    protocols "^2.0.1"
 
 parse-url@^8.1.0:
   version "8.1.0"
@@ -20328,15 +20317,6 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
-shelljs@^0.8.1:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
-  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -21221,6 +21201,13 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+strip-outer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
+  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
 strong-log-transformer@2.1.0, strong-log-transformer@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
@@ -21958,6 +21945,13 @@ trim-newlines@^4.0.2:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.1.1.tgz#28c88deb50ed10c7ba6dc2474421904a00139125"
   integrity sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==
+
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
+  integrity sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
 
 trim-trailing-lines@^1.0.0:
   version "1.1.4"
@@ -23539,7 +23533,7 @@ yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^15.0.0, yargs@^15.1.0, yargs@^15.4.1:
+yargs@^15.1.0, yargs@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
### Description
- Added npm package gh-pages which will deploy to gh-pages
- Added feature to allow nested static site in gh-pages (We are not using this feature at this time)

Simplified build: To build the complete static site locally
- `yarn install --frozen-lockfile` (--frozen-lockfile is used on Jenkins)
- `yarn build-storybook`
- `yarn start` (start a dev server)

Jenkins follows same pattern but runs a deploy script instead of `yarn start`
- ```node ./scripts/deploy-gh-pages.js dev PUSH```


Closed PR https://github.com/ASU/asu-unity-stack/pull/1173 (branch had history conflicts

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1390)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
