### PR TITLE
fix(app-webdir-ui): add webdir profiles for exclusion on rest endpoint

### DIFF
--- a/packages/app-webdir-ui/src/SearchResultsList/index.js
+++ b/packages/app-webdir-ui/src/SearchResultsList/index.js
@@ -4,9 +4,7 @@ import React, { useState, useEffect, useRef } from "react";
 
 import { trackGAEvent } from "../core/services/googleAnalytics";
 import {
-  performSearch,
-  anonFormatter,
-  filterOutResults,
+  performSearch
 } from "../helpers/search";
 import { SearchMessage } from "../SearchPage/components/SearchMessage";
 import { SearchResultsList } from "./index.styles";
@@ -96,11 +94,10 @@ const ASUSearchResultsList = ({
               return Object.keys(result).length > 1;
             });
           }
-          if (profilesToFilterOut) {
-            filteredResults = filterOutResults(res, profilesToFilterOut);
-          }
           const formattedResults = engine.formatter({
             results: filteredResults,
+            page,
+            itemsPerPage,
             cardSize,
             filters,
             appPathFolder: appPathFolder || engine.appPathFolder,
@@ -122,7 +119,7 @@ const ASUSearchResultsList = ({
             }
           }
           if (engine.method === "POST") {
-            setTotalResults(filters.peopleInDepts.length);
+            setTotalResults(filteredResults.length);
           } else {
             setTotalResults(formattedResults.page.total_results);
           }

--- a/packages/app-webdir-ui/src/SearchResultsList/index.js
+++ b/packages/app-webdir-ui/src/SearchResultsList/index.js
@@ -86,6 +86,7 @@ const ASUSearchResultsList = ({
         display,
         rankGroup,
         controller,
+        size: display?.profilesPerPage,
       })
         .then(res => {
           let filteredResults = res;
@@ -119,7 +120,7 @@ const ASUSearchResultsList = ({
             }
           }
           if (engine.method === "POST") {
-            setTotalResults(filteredResults.length);
+            setTotalResults(filteredResults[0]?.total_results); // Each result has the total_results property
           } else {
             setTotalResults(formattedResults.page.total_results);
           }

--- a/packages/app-webdir-ui/src/helpers/search.js
+++ b/packages/app-webdir-ui/src/helpers/search.js
@@ -360,18 +360,14 @@ export const engines = {
     resultsPerSummaryPage: 6,
     supportedSortTypes: ["_score_desc", "last_name_desc", "last_name_asc"],
     method: "POST",
-    formatter: ({ results, page, itemsPerPage, cardSize, filters, appPathFolder }) => {
-      const startIndex = (page - 1) * itemsPerPage;
-      const endIndex = startIndex + itemsPerPage;
-      const resultsToDisplay = results.slice(startIndex, endIndex);
-
-      return webDirDeptsFormatter({
+    formatter: ({ results, cardSize, filters, appPathFolder }) =>
+      webDirDeptsFormatter({
         engineName: engineNames.WEB_DIRECTORY_PEOPLE_AND_DEPS,
-        results: resultsToDisplay,
+        results,
         cardSize,
         filters,
         appPathFolder,
-      })},
+      }),
     needsTerm: false,
   },
 };
@@ -386,6 +382,7 @@ export const performSearch = function ({
   display,
   rankGroup,
   controller,
+  size,
 }) {
   async function search(resolve, reject) {
     const currentSort = engine.supportedSortTypes.includes(sort) ? sort : "";
@@ -466,8 +463,8 @@ export const performSearch = function ({
         "X-CSRF-Token": tokenResponse.data,
       };
       const data = {
-        "size": 500, // This is to retrieve all results and handle paging on the front end.
-        "page": 1, // This is to retrieve all results and handle paging on the front end.
+        "size": size,
+        "page": page,
         "sort-by": currentSort || "",
         "full_records": true,
         "profiles": filters.peopleInDepts,
@@ -482,20 +479,6 @@ export const performSearch = function ({
         // engine.inFlight = false;
         // engine.abortController = null;
         const { data } = res;
-        if (
-          engine.method === "POST" &&
-          (sort === "last_name_desc" || sort === "last_name_asc")
-        ) {
-          data.sort((a, b) =>
-            a.full_record.display_last_name.raw.localeCompare(
-              b.full_record.display_last_name.raw
-            )
-          );
-
-          if (sort === "last_name_desc") {
-            data.reverse();
-          }
-        }
         resolve(data);
       })
       .catch(err => {


### PR DESCRIPTION
### Description
The correct params and data were not being sent for the REST endpoint to properly filter out profiles in webdir

Added correct params.
This depends on having the correct login in place for the isearch repo. [Here](https://github.com/ASUWebPlatforms/asu-isearch/pull/542) is the pr for that

### Links

- [JIRA ticket](https://asudev.jira.com/browse/SCHWEB-1031?atlOrigin=eyJpIjoiZWY0MzAwMzJhYWFmNGJlNmE3ZDQ5MTkwZTNjZWU1NzgiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
