### PR TITLE
build: set gh-pages debug environment variable in js.

### DIFF
--- a/scripts/deploy-gh-pages.js
+++ b/scripts/deploy-gh-pages.js
@@ -29,6 +29,7 @@ if(typeof process?.env?.GH_TOKEN !== "undefined") {
   console.log("Added GH_TOKEN Option");
 }
 
+process.env.NODE_DEBUG = "gh-pages";
 
 require('./deploy-check');
 


### PR DESCRIPTION
### Description

We need to get a look at gh-pages failure to deploy. Set debug in script. Doing this way to avoid overhead of DevOps review as would be required by setting environ variable in Jenkinsfile.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1390)
