### PR TITLE
fix(unity-bootstrap-theme): remove duplicate container rules

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/_end-style.scss
+++ b/packages/unity-bootstrap-theme/src/scss/_end-style.scss
@@ -1,0 +1,52 @@
+
+@mixin end_styles() {
+/* -----------------------------------------------------
+Container/ row / column padding adjustments for mobile.
+
+Bootstrap doesn't natively provide a way to alter the behavior
+its native grid elements based on a media query. This overrides
+that behavior at screens <= 575px. (The small breakpoint.)
+
+Should be included after @import scss/grid. Registered here for clarity.
+------------------------------------------------------- */
+
+  @include media-breakpoint-down(md) {
+    .container,
+    .container-fluid,
+    .container-xl,
+    .container-lg,
+    .container-md,
+    .container-sm {
+      padding-left: 2rem;
+      padding-right: 2rem;
+    }
+  }
+}
+
+
+//
+// This File should be included ONE time at the end of compiled code and bundles.
+
+// To include once, just do so normally. The styles are only excluded if
+//   this variable ($add_end_styles) is explicitly set to false
+//   @import 'end-style';
+
+// To include at the end of a bundle:
+//   $add_end_styles: false;
+//   @import 'unity-bootstrap-theme'; (file also imports 'end-style')
+//   @import 'unity-bootstrap-header'; (file also imports 'end-style')
+
+//   $add_end_styles: true;
+//   @import 'unity-bootstrap-footer'; (file also imports 'end-style')
+
+//
+//
+@if variable-exists($name: "add_end_styles") {
+  @if $add_end_styles == true {
+    @include end_styles();
+  }
+}
+@else {
+  @include end_styles();
+}
+$add_end_styles: false;

--- a/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-footer.scss
+++ b/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-footer.scss
@@ -8,24 +8,4 @@
 // @import "unity-bootstrap-theme-extends";
 @import 'extends/globalfooter';
 
-/* -----------------------------------------------------
-Container/ row / column padding adjustments for mobile.
-
-Bootstrap doesn't natively provide a way to alter the behavior
-its native grid elements based on a media query. This overrides
-that behavior at screens <= 575px. (The small breakpoint.)
-
-Should be included after @import scss/grid. Registered here for clarity.
------------------------------------------------------- */
-
-@include media-breakpoint-down(md) {
-  .container,
-  .container-fluid,
-  .container-xl,
-  .container-lg,
-  .container-md,
-  .container-sm {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
+@import 'end-style';

--- a/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-header.scss
+++ b/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-header.scss
@@ -8,24 +8,4 @@
 // @import "unity-bootstrap-theme-extends";
 @import 'extends/global-header';
 
-/* -----------------------------------------------------
-Container/ row / column padding adjustments for mobile.
-
-Bootstrap doesn't natively provide a way to alter the behavior
-its native grid elements based on a media query. This overrides
-that behavior at screens <= 575px. (The small breakpoint.)
-
-Should be included after @import scss/grid. Registered here for clarity.
------------------------------------------------------- */
-
-@include media-breakpoint-down(md) {
-  .container,
-  .container-fluid,
-  .container-xl,
-  .container-lg,
-  .container-md,
-  .container-sm {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
+@import 'end-style';

--- a/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.bundle.scss
+++ b/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.bundle.scss
@@ -1,3 +1,7 @@
+$add_end_styles: false;
 @import 'unity-bootstrap-theme';
 @import 'unity-bootstrap-header';
 @import 'unity-bootstrap-footer';
+
+$add_end_styles: true;
+@import 'end-style';

--- a/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.scss
+++ b/packages/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.scss
@@ -7,24 +7,4 @@
 // css Bootstrap doesn't have variables for
 @import "unity-bootstrap-theme-extends";
 
-/* -----------------------------------------------------
-Container/ row / column padding adjustments for mobile.
-
-Bootstrap doesn't natively provide a way to alter the behavior
-its native grid elements based on a media query. This overrides
-that behavior at screens <= 575px. (The small breakpoint.)
-
-Should be included after @import scss/grid. Registered here for clarity.
------------------------------------------------------- */
-
-@include media-breakpoint-down(md) {
-  .container,
-  .container-fluid,
-  .container-xl,
-  .container-lg,
-  .container-md,
-  .container-sm {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
+@import 'end-style';


### PR DESCRIPTION
### Description

```@include media-breakpoint-down(md) {
  .container,
  .container-fluid,
  .container-xl,
  .container-lg,
  .container-md,
  .container-sm {
    padding-left: 2rem;
    padding-right: 2rem;
  }
}
```

was being added 3 times inside bundle.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1512)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes

### Images

no changes to these files:
- `unity-bootstrap-theme/dist3/css/unity-bootstrap-theme.css`
- `unity-bootstrap-theme/dist3/css/unity-bootstrap-footer.css`
- `unity-bootstrap-theme/dist3/css/unity-bootstrap-header.css`

Unminified compare of output for:
- `unity-bootstrap-theme/dist3/css/unity-bootstrap-theme.bundle.css`
<img width="1038" alt="image" src="https://github.com/ASU/asu-unity-stack/assets/5209283/4d12a987-80eb-410f-bfac-bd472eceef78">

