### PR TITLE
SCHWEB-1128: fix(app-webdir-ui): fix zero value EID in path problem

### DIFF
--- a/packages/app-webdir-ui/src/helpers/dataConverter.js
+++ b/packages/app-webdir-ui/src/helpers/dataConverter.js
@@ -277,7 +277,7 @@ export const staffConverter = ({
 
   // We use EID if it's available, otherwise we use the asurite_id.
   const profileURLBase = options.profileURLBase ?? "";
-  const asuriteEID = filledDatum.eid.raw
+  const asuriteEID = filledDatum.eid.raw && filledDatum.eid.raw !== '0'
     ? filledDatum.eid.raw.toString()
     : filledDatum.asurite_id.raw.toString();
   if (appPathFolder) {
@@ -334,7 +334,7 @@ export const studentsConverter = ({
   if (appPathFolder) {
     anonImg = `${appPathFolder}/img/anon.png`;
   }
-  const asuriteEID = filledDatum.eid.raw
+  const asuriteEID = filledDatum.eid.raw && filledDatum.eid.raw !== '0'
     ? filledDatum.eid.raw.toString()
     : filledDatum.asurite_id.raw.toString();
 


### PR DESCRIPTION
SCHWEB-1128

### Description
Because some profiles do not have an EID, and the database doesn't allow NULL values on that field, any profile without an EID is supposedly accessable at the path `/profile/0`. However, since there are multiple profiles with this problem, only one is accessible at that path. To mitigate this, I have made changes on the CMS side, but I also felt it would be good to check for zero-value EIDs on the component side, and if the EID has a value of 0 to fall back to creating the path for the profile by using the asurite ID instead (thus yielding a path like `/profile/djmahone` instead.
<!-- Description of problem -->
<!-- Solution -->

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/SCHWEB-1128)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] No new console errors
- [x] Accessibility checks
