### PR TITLE
fix(app-webdir-ui): added proper margin/display to profile photo title

### DIFF
--- a/packages/app-webdir-ui/src/ProfileCard/index.styles.js
+++ b/packages/app-webdir-ui/src/ProfileCard/index.styles.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 const ProfileCardLayout = styled.div`
   padding: 4px;
   .person-name {
+    display: block;
     font-weight: bold;
   }
 `;


### PR DESCRIPTION
### Description
Added correct display of block to person profile in webdir to mimic [unity-bootstrap-theme implementation](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-person-profile-templates--person-profile-template&globals=outline:true)


### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-person-profile-templates--person-profile-template&globals=outline:true)
- [JIRA ticket](https://asudev.jira.com/browse/SCHWEB-1108?atlOrigin=eyJpIjoiY2I5MDI2M2M5MWMxNGI5OTg3NWMwNDk4OTNlYzZhNjUiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge


