### PR TITLE
fix(app-webdir-ui): remove alpha filter option from faculty rank

### DIFF
--- a/packages/app-webdir-ui/docs/README.props.md
+++ b/packages/app-webdir-ui/docs/README.props.md
@@ -13,7 +13,7 @@
 <dt><a href="#SearchPage">SearchPage(props)</a> ⇒ <code>JSX.Element</code></dt>
 <dd><p>React component for the ASU search page.</p>
 </dd>
-<dt><a href="#ASUSearchResultsList">ASUSearchResultsList(term, sort, type, engine, titleText, showSearchMessage, seeAllResultsText, itemsPerPage, onExpandClick, GASource, setPromotedResult, hidePaginator, registerResults, filters, loggedIn, profilesToFilterOut, display, appPathFolder, localSection, rankGroup, icon)</a> ⇒ <code>JSX.Element</code></dt>
+<dt><a href="#ASUSearchResultsList">ASUSearchResultsList(props, term, sort, type, engine, titleText, showSearchMessage, seeAllResultsText, itemsPerPage, onExpandClick, GASource, setPromotedResult, hidePaginator, registerResults, filters, loggedIn, profilesToFilterOut, display, appPathFolder, localSection, rankGroup, icon)</a> ⇒ <code>JSX.Element</code></dt>
 <dd><p>React component for displaying search results.</p>
 </dd>
 <dt><a href="#WebDirectory">WebDirectory(props)</a> ⇒ <code>JSX.Element</code></dt>
@@ -132,7 +132,7 @@ React component for the ASU search page.
 
 <a name="ASUSearchResultsList"></a>
 
-## ASUSearchResultsList(term, sort, type, engine, titleText, showSearchMessage, seeAllResultsText, itemsPerPage, onExpandClick, GASource, setPromotedResult, hidePaginator, registerResults, filters, loggedIn, profilesToFilterOut, display, appPathFolder, localSection, rankGroup, icon) ⇒ <code>JSX.Element</code>
+## ASUSearchResultsList(props, term, sort, type, engine, titleText, showSearchMessage, seeAllResultsText, itemsPerPage, onExpandClick, GASource, setPromotedResult, hidePaginator, registerResults, filters, loggedIn, profilesToFilterOut, display, appPathFolder, localSection, rankGroup, icon) ⇒ <code>JSX.Element</code>
 React component for displaying search results.
 
 **Kind**: global function  
@@ -140,6 +140,7 @@ React component for displaying search results.
 
 | Param | Type | Description |
 | --- | --- | --- |
+| props | <code>Object</code> | The props for configuring the ASUSearchResultsList component. |
 | term | <code>string</code> | The search term. |
 | sort | <code>string</code> | The sorting option. |
 | type | <code>string</code> | The type of results must be 'micro', 'preview', or 'full'. |

--- a/packages/app-webdir-ui/src/FacultyRankComponent/index.js
+++ b/packages/app-webdir-ui/src/FacultyRankComponent/index.js
@@ -38,7 +38,6 @@ const filtersData = {
  * @property {string} filters.expertise - Expertise filter.
  * @property {string} filters.title - Title filter.
  * @property {string} filters.campuses - Campuses filter.
- * @property {string} alphaFilter - Whether to enable the alpha filter.
  */
 
 const FacultyRankTabPanels = ({
@@ -50,7 +49,6 @@ const FacultyRankTabPanels = ({
   display,
   profileURLBase,
   searchType,
-  alphaFilter,
 }) => {
   const [requestFilters, setRequestFilters] = useState({});
   const [tabChange, setTabChange] = useState(null);
@@ -90,45 +88,6 @@ const FacultyRankTabPanels = ({
           id={`faculty-${rankGroup}`}
           title={filtersData[rankGroup]}
         >
-          {alphaFilter === "true" && (
-            <FilterComponent
-              filterLabel="Filter by last initial"
-              choices={[
-                "A",
-                "B",
-                "C",
-                "D",
-                "E",
-                "F",
-                "G",
-                "H",
-                "I",
-                "J",
-                "K",
-                "L",
-                "M",
-                "N",
-                "O",
-                "P",
-                "Q",
-                "R",
-                "S",
-                "T",
-                "U",
-                "V",
-                "W",
-                "X",
-                "Y",
-                "Z",
-              ]}
-              onChoose={filterLetter =>
-                setRequestFilters({ ...requestFilters, lastInit: filterLetter })
-              }
-              resetFilters={() =>
-                setRequestFilters({ ...requestFilters, lastInit: "" })
-              }
-            />
-          )}
           <ASUSearchResultsList
             engine={enginesWithParams[searchTypeEngineMap[searchType]]}
             itemsPerPage={parseInt(display.profilesPerPage, 10) || RES_PER_PAGE}
@@ -166,7 +125,6 @@ FacultyRankTabPanels.propTypes = {
     title: PropTypes.string,
     campuses: PropTypes.string,
   }),
-  alphaFilter: PropTypes.string,
 };
 
 export default FacultyRankTabPanels;

--- a/packages/app-webdir-ui/src/FacultyRankComponent/index.stories.js
+++ b/packages/app-webdir-ui/src/FacultyRankComponent/index.stories.js
@@ -1,0 +1,55 @@
+import React from "react";
+
+import {
+  createComponent,
+  createStory,
+  layoutNames,
+} from "../../../unity-bootstrap-theme/helpers/wrapper";
+import { WebDirectory } from "../WebDirectoryComponent/index";
+
+export default createComponent("Web Directory", "Organisms", "Templates");
+
+const display = {
+  defaultSort: "last_name",
+  doNotDisplayProfiles: "",
+  profilesPerPage: "10",
+  usePager: "1",
+};
+const filters = {
+  employee: "",
+  expertise: "",
+  title: "",
+  campuses: "",
+};
+/* For testing filters...
+const filters = {
+  employee: "Faculty,Administative",
+  expertise: "Big Data,Connected Learning",
+  title: "Professor",
+  campuses: "TEMPE,POLY",
+};
+*/
+
+export const facultyRankWebDirectory = createStory(
+  ({ ...args }) => {
+    return (
+      <div className="uds-content-align">
+        <WebDirectory
+          searchType="faculty_rank"
+          deptIds="1535"
+          API_URL="https://live-asu-isearch.ws.asu.edu/"
+          searchApiVersion="api/v1/"
+          filters={filters}
+          display={display}
+          // alphaFilter={args.alphaFilter}
+          // appPathFolder="/my/custom/path/to/component/root/example"
+        />
+      </div>
+    );
+  },
+  { supportedTemplates: [layoutNames.FULL_WIDTH] }
+);
+
+facultyRankWebDirectory.args = {
+  template: 0,
+};

--- a/packages/app-webdir-ui/src/SearchResultsList/index.js
+++ b/packages/app-webdir-ui/src/SearchResultsList/index.js
@@ -3,9 +3,7 @@ import PropTypes from "prop-types";
 import React, { useState, useEffect, useRef } from "react";
 
 import { trackGAEvent } from "../../../../shared";
-import {
-  performSearch
-} from "../helpers/search";
+import { performSearch } from "../helpers/search";
 import { SearchMessage } from "../SearchPage/components/SearchMessage";
 import { SearchResultsList } from "./index.styles";
 
@@ -91,7 +89,7 @@ const ASUSearchResultsList = ({
         restClientTag,
       })
         .then(res => {
-          let filteredResults = res;
+          const filteredResults = res;
           if (sort === "employee_weight" && engine?.name === "people_in_dept") {
             filteredResults.results = filteredResults.results.filter(result => {
               return Object.keys(result).length > 1;

--- a/packages/app-webdir-ui/src/WebDirectoryComponent/index.stories.js
+++ b/packages/app-webdir-ui/src/WebDirectoryComponent/index.stories.js
@@ -114,27 +114,3 @@ export const webDirectoryExampleDepartmentsAndPeople = createStory(
 webDirectoryExampleDepartmentsAndPeople.args = {
   template: 0,
 };
-
-export const facultyRankWebDirectory = createStory(
-  ({ ...args }) => {
-    return (
-      <div className="uds-content-align">
-        <WebDirectory
-          searchType="faculty_rank"
-          deptIds="1535"
-          API_URL="https://live-asu-isearch.ws.asu.edu/"
-          searchApiVersion="api/v1/"
-          filters={filters}
-          display={display}
-          alphaFilter={args.alphaFilter}
-          // appPathFolder="/my/custom/path/to/component/root/example"
-        />
-      </div>
-    );
-  },
-  { supportedTemplates: [layoutNames.FULL_WIDTH] }
-);
-
-facultyRankWebDirectory.args = {
-  template: 0,
-};

--- a/packages/app-webdir-ui/src/helpers/dataConverter.js
+++ b/packages/app-webdir-ui/src/helpers/dataConverter.js
@@ -277,9 +277,10 @@ export const staffConverter = ({
 
   // We use EID if it's available, otherwise we use the asurite_id.
   const profileURLBase = options.profileURLBase ?? "";
-  const asuriteEID = filledDatum.eid.raw && filledDatum.eid.raw !== '0'
-    ? filledDatum.eid.raw.toString()
-    : filledDatum.asurite_id.raw.toString();
+  const asuriteEID =
+    filledDatum.eid.raw && filledDatum.eid.raw !== "0"
+      ? filledDatum.eid.raw.toString()
+      : filledDatum.asurite_id.raw.toString();
   if (appPathFolder) {
     anonImg = `${appPathFolder}/img/anon.png`;
   }
@@ -334,9 +335,10 @@ export const studentsConverter = ({
   if (appPathFolder) {
     anonImg = `${appPathFolder}/img/anon.png`;
   }
-  const asuriteEID = filledDatum.eid.raw && filledDatum.eid.raw !== '0'
-    ? filledDatum.eid.raw.toString()
-    : filledDatum.asurite_id.raw.toString();
+  const asuriteEID =
+    filledDatum.eid.raw && filledDatum.eid.raw !== "0"
+      ? filledDatum.eid.raw.toString()
+      : filledDatum.asurite_id.raw.toString();
 
   const imgURLProp = formatImageUrl(filledDatum.photo_url.raw);
 


### PR DESCRIPTION
### Description

Faculty Rank Web Directory listings should not include the `alphaFilter` option.

Removed `alphaFilter` from Faculty Rank component. Moved story for that component into its folder to better manage variation on the configs (by not showing alpha filter controls).

Note: Some automated code cleanup is included here. I've left it in as valid, but if any of it looks problematic or suggests I have out of date linting rules, let me know.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/SCHWEB-1145)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks
