### PR TITLE
Uds 1531 - add props and code to Image component to match Bootstrap version

### DIFF
--- a/packages/components-core/src/components/Image/index.js
+++ b/packages/components-core/src/components/Image/index.js
@@ -48,17 +48,19 @@ export const Image = ({
     "uds-img-drop-shadow": dropShadow,
   });
 
-  const renderImage = () =>
+  const renderImage = (classes) => {
+    let combinedClasses = classes ? `${imageProps.className} ${classes}` : imageProps.className;
+  return (
     cardLink ? (
       <a href={cardLink}>
         {/* eslint-disable-next-line jsx-a11y/alt-text, react/jsx-props-no-spreading */}
-        <img {...imageProps} />
+        <img {...imageProps} className={combinedClasses} />
         <span className="visually-hidden">{title}</span>
       </a>
     ) : (
       // eslint-disable-next-line jsx-a11y/alt-text, react/jsx-props-no-spreading
-      <img {...imageProps} />
-    );
+      <img {...imageProps} className={combinedClasses} />
+    ))};
 
   const renderFigure = () => (
     <div className={borderAndDropShadowClasses}>
@@ -79,7 +81,7 @@ export const Image = ({
       {caption ? (
         renderFigure()
       ) : (
-        <div className={borderAndDropShadowClasses}>{renderImage()}</div>
+        renderImage(borderAndDropShadowClasses)
       )}
     </>
   );

--- a/packages/components-core/src/components/Image/index.js
+++ b/packages/components-core/src/components/Image/index.js
@@ -62,21 +62,25 @@ export const Image = ({
 
   const renderFigure = () => (
     <div className={borderAndDropShadowClasses}>
-    <figure className="figure uds-figure">
-      {renderImage()}
-      {caption && (
-        <figcaption className="figure-caption uds-figure-caption">
-          {captionTitle && <h3>{captionTitle}</h3>}
-          <span className="uds-caption-text">{caption}</span>
-        </figcaption>
-      )}
-    </figure>
+      <figure className="figure uds-figure">
+        {renderImage()}
+        {caption && (
+          <figcaption className="figure-caption uds-figure-caption">
+            {captionTitle && <h3>{captionTitle}</h3>}
+            <span className="uds-caption-text">{caption}</span>
+          </figcaption>
+        )}
+      </figure>
     </div>
   );
 
   return (
     <>
-      {caption ? renderFigure() : renderImage()}
+      {caption ? (
+        renderFigure()
+      ) : (
+        <div className={borderAndDropShadowClasses}>{renderImage()}</div>
+      )}
     </>
   );
 };

--- a/packages/components-core/src/components/Image/index.js
+++ b/packages/components-core/src/components/Image/index.js
@@ -61,6 +61,7 @@ export const Image = ({
     );
 
   const renderFigure = () => (
+    <div className={borderAndDropShadowClasses}>
     <figure className="figure uds-figure">
       {renderImage()}
       {caption && (
@@ -70,12 +71,13 @@ export const Image = ({
         </figcaption>
       )}
     </figure>
+    </div>
   );
 
   return (
-    <div className={borderAndDropShadowClasses}>
+    <>
       {caption ? renderFigure() : renderImage()}
-    </div>
+    </>
   );
 };
 

--- a/packages/components-core/src/components/Image/index.js
+++ b/packages/components-core/src/components/Image/index.js
@@ -1,6 +1,6 @@
+import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
-import classNames from "classnames";
 
 // eslint-disable-next-line import/no-cycle
 import { spreadClasses } from "../../../../../shared";
@@ -31,62 +31,50 @@ export const Image = ({
   border,
   dropShadow,
 }) => {
-  const imagePropsRequired = {
+  const imageProps = {
     src,
     alt,
     loading,
     decoding,
-    fetchpriority: fetchPriority, // due to a bug in react, we need to use this attribute in lowercase instead of fetchPriority
-  };
-  // TODO: Will the border and dropShadow props be true or false, or will they be strings?
-  const borderAndDropShadowClasses = classNames("uds-img",{
-    "borderless": !border,
-    "uds-img-drop-shadow": dropShadow,
-  });
-
-  const imagePropsOptional = {
+    fetchpriority: fetchPriority, // React attribute bug workaround
     ...(cssClasses?.length > 0 && { className: spreadClasses(cssClasses) }),
     ...(dataTestId && { "data-testid": dataTestId }),
     ...(width && { width }),
     ...(height && { height }),
   };
 
-  const imageProps = Object.assign(imagePropsRequired, imagePropsOptional);
+  const borderAndDropShadowClasses = classNames("uds-img", {
+    "borderless": !border,
+    "uds-img-drop-shadow": dropShadow,
+  });
 
-  function addCardLink(cardLink) {
-    return (
+  const renderImage = () =>
+    cardLink ? (
       <a href={cardLink}>
         {/* eslint-disable-next-line jsx-a11y/alt-text, react/jsx-props-no-spreading */}
         <img {...imageProps} />
         <span className="visually-hidden">{title}</span>
       </a>
+    ) : (
+      // eslint-disable-next-line jsx-a11y/alt-text, react/jsx-props-no-spreading
+      <img {...imageProps} />
     );
-  }
-  // eslint-disable-next-line jsx-a11y/alt-text, react/jsx-props-no-spreading
+
+  const renderFigure = () => (
+    <figure className="figure uds-figure">
+      {renderImage()}
+      {caption && (
+        <figcaption className="figure-caption uds-figure-caption">
+          {captionTitle && <h3>{captionTitle}</h3>}
+          <span className="uds-caption-text">{caption}</span>
+        </figcaption>
+      )}
+    </figure>
+  );
+
   return (
-    <div className={borderAndDropShadowClasses} >
-      {caption ? (
-        <figure className="figure uds-figure">
-          {cardLink ? (
-            addCardLink(cardLink)
-          ) : (
-            <img {...imageProps} />
-          )}
-          {caption && <figcaption
-          className="figure-caption uds-figure-caption">
-            {captionTitle && <h3>{captionTitle}</h3>}
-            <span className="uds-caption-text">{caption}</span>
-            </figcaption>
-            }
-        </figure>
-      ) : (
-        cardLink ? (
-          addCardLink(cardLink)
-        ) : (
-          <img {...imageProps} />
-        )
-        )
-      }
+    <div className={borderAndDropShadowClasses}>
+      {caption ? renderFigure() : renderImage()}
     </div>
   );
 };
@@ -127,4 +115,8 @@ Image.propTypes = {
   dataTestId: PropTypes.string,
   cardLink: PropTypes.string,
   title: PropTypes.string,
+  caption: PropTypes.string,
+  captionTitle: PropTypes.string,
+  border: PropTypes.bool,
+  dropShadow: PropTypes.bool,
 };

--- a/packages/components-core/src/components/Image/index.js
+++ b/packages/components-core/src/components/Image/index.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
+import classNames from "classnames";
 
 // eslint-disable-next-line import/no-cycle
 import { spreadClasses } from "../../../../../shared";
@@ -25,6 +26,10 @@ export const Image = ({
   height,
   cardLink,
   title,
+  caption,
+  captionTitle,
+  border,
+  dropShadow,
 }) => {
   const imagePropsRequired = {
     src,
@@ -33,6 +38,11 @@ export const Image = ({
     decoding,
     fetchpriority: fetchPriority, // due to a bug in react, we need to use this attribute in lowercase instead of fetchPriority
   };
+  // TODO: Will the border and dropShadow props be true or false, or will they be strings?
+  const borderAndDropShadowClasses = classNames("uds-img",{
+    "borderless": !border,
+    "uds-img-drop-shadow": dropShadow,
+  });
 
   const imagePropsOptional = {
     ...(cssClasses?.length > 0 && { className: spreadClasses(cssClasses) }),
@@ -43,7 +53,7 @@ export const Image = ({
 
   const imageProps = Object.assign(imagePropsRequired, imagePropsOptional);
 
-  if (cardLink) {
+  function addCardLink(cardLink) {
     return (
       <a href={cardLink}>
         {/* eslint-disable-next-line jsx-a11y/alt-text, react/jsx-props-no-spreading */}
@@ -53,7 +63,32 @@ export const Image = ({
     );
   }
   // eslint-disable-next-line jsx-a11y/alt-text, react/jsx-props-no-spreading
-  return <img {...imageProps} />;
+  return (
+    <div className={borderAndDropShadowClasses} >
+      {caption ? (
+        <figure className="figure uds-figure">
+          {cardLink ? (
+            addCardLink(cardLink)
+          ) : (
+            <img {...imageProps} />
+          )}
+          {caption && <figcaption
+          className="figure-caption uds-figure-caption">
+            {captionTitle && <h3>{captionTitle}</h3>}
+            <span className="uds-caption-text">{caption}</span>
+            </figcaption>
+            }
+        </figure>
+      ) : (
+        cardLink ? (
+          addCardLink(cardLink)
+        ) : (
+          <img {...imageProps} />
+        )
+        )
+      }
+    </div>
+  );
 };
 
 Image.propTypes = {

--- a/packages/components-core/src/components/Image/index.stories.js
+++ b/packages/components-core/src/components/Image/index.stories.js
@@ -18,10 +18,37 @@ export default {
 
 const Template = args => <Image {...args} />;
 
-export const Default = Template.bind({});
-Default.args = {
+export const imageWithNoCaption = Template.bind({});
+imageWithNoCaption.args = {
   src: "https://source.unsplash.com/WLUHO9A_xik/800x600",
   alt: "Placeholder image",
+  border: true,
+};
+
+export const imageWithNoCaptionBorderless = Template.bind({});
+imageWithNoCaptionBorderless.args = {
+  src: "https://source.unsplash.com/WLUHO9A_xik/800x600",
+  alt: "Placeholder image",
+  border: false,
+};
+
+export const imageWithCaption = Template.bind({});
+imageWithCaption.args = {
+  src: "https://source.unsplash.com/WLUHO9A_xik/800x600",
+  alt: "Placeholder image",
+  caption: "This is a caption",
+  captionTitle: "Caption title",
+  border: true,
+};
+
+export const imageWithCaptionAndDropshadow = Template.bind({});
+imageWithCaptionAndDropshadow .args = {
+  src: "https://source.unsplash.com/WLUHO9A_xik/800x600",
+  alt: "Placeholder image",
+  caption: "This is a caption",
+  captionTitle: "Caption title",
+  dropShadow: true,
+  border: true,
 };
 
 const GridTemplate = args => {

--- a/packages/components-core/src/components/Image/index.stories.js
+++ b/packages/components-core/src/components/Image/index.stories.js
@@ -42,7 +42,7 @@ imageWithCaption.args = {
 };
 
 export const imageWithCaptionAndDropshadow = Template.bind({});
-imageWithCaptionAndDropshadow .args = {
+imageWithCaptionAndDropshadow.args = {
   src: "https://source.unsplash.com/WLUHO9A_xik/800x600",
   alt: "Placeholder image",
   caption: "This is a caption",

--- a/packages/components-core/src/components/TabbedPanels/index.js
+++ b/packages/components-core/src/components/TabbedPanels/index.js
@@ -77,7 +77,7 @@ const TabbedPanels = ({
         headerTabs.current.removeEventListener("scroll", onScroll);
       }
     };
-}, [scrollableWidth]);
+  }, [scrollableWidth]);
 
   useEffect(() => {
     const onResize = () => {
@@ -91,7 +91,7 @@ const TabbedPanels = ({
       if (headerTabs.current) {
         window.removeEventListener("resize", onResize);
       }
-    }
+    };
   }, []);
 
   useEffect(() => {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -364,11 +364,11 @@ Cards - Table of Contents
 }
 
 .card-story:not(.card.card-foldable)
-  > div:first-of-type:not(.card-image-content) {
+  > div:first-of-type:not(.card-image-content, .uds-img) {
   padding-top: 16px;
 }
 
-.card-story > div:first-of-type:not(.card-image-content) {
+.card-story > div:first-of-type:not(.card-image-content, .uds-img) {
   padding: 16px;
   flex-grow: 1;
 }

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -509,7 +509,7 @@ Cards - Table of Contents
   height: auto;
   max-width: 40%;
   aspect-ratio: 2/3;
-  max-height: 400px;
+  max-height: 100%;
 }
 
 .card-event.card-horizontal .card-header {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -509,7 +509,7 @@ Cards - Table of Contents
   height: auto;
   max-width: 40%;
   aspect-ratio: 2/3;
-  max-height: 100%;
+  max-height: 400px;
 }
 
 .card-event.card-horizontal .card-header {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_images.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_images.scss
@@ -33,11 +33,15 @@
       background: $uds-color-background-white 0% 0% no-repeat padding-box;
       padding: 0.75rem;
       font-size: $uds-size-font-tiny;
+
+      h3, .h3 {
+        color: $uds-color-base-gray-7;
+      }
     }
     .uds-caption-text {
       display: block;
       max-width: 700px;
-      color: $uds-color-base-gray-5;
+      color: $uds-color-base-gray-7;
     }
   }
 

--- a/packages/unity-bootstrap-theme/src/scss/extends/_images.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_images.scss
@@ -4,7 +4,7 @@
   opacity: 1;
   margin-bottom: $uds-size-spacing-0;
   max-width: 900px;
-  img {
+  img, &:is(img) {
     border: 1px solid $uds-color-base-gray-3;
     width: 100%;
   }
@@ -32,11 +32,11 @@
       border-top: none;
       opacity: 1;
       background: $uds-color-background-white 0% 0% no-repeat padding-box;
-      padding: 0.75rem;
+      padding: 2rem;
       font-size: $uds-size-font-tiny;
-
       h3, .h3 {
         color: $uds-color-base-gray-7;
+        margin: 0 0 1rem 0;
       }
     }
     .uds-caption-text {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_images.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_images.scss
@@ -12,6 +12,7 @@
   &.borderless {
     img {
       border-color: transparent;
+      border: 0px;
     }
     .uds-figure {
       .uds-figure-caption {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_ranking-cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_ranking-cards.scss
@@ -105,7 +105,7 @@
   }
 
   &.large-image {
-    > img {
+    img {
       z-index: 0;
       position: absolute;
       top: 50%;


### PR DESCRIPTION
### Description
Add props to match the multiple versions of Image component used in unity-bootstrap-theme.
https://github.com/ASUWebPlatforms/webspark-ci/pull/214 is dependent on this pr


### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/components-core/index.html?path=/story/uds-image--default)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1531?atlOrigin=eyJpIjoiNzg5YTUxYTVjNTE1NDgxZmJkNzg0MjNmNzkzNmZhYTMiLCJwIjoiaiJ9)


### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

