### PR TITLE
fix(unity-bootstrap-theme): updated anchor-menu js to match webspark

### DIFF
--- a/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.js
@@ -15,7 +15,8 @@ function initializeAnchorMenu () {
   let isNavbarAttached = false;  // Flag to track if navbar is attached to header
   const body = document.body;
 
-  // These values are for the drupal admin toolbars. They are not present in the storybook.
+  // These values are for optionally present Drupal admin toolbars. They
+  // are not present in Storybook and not required in implementations.
   let toolbarBar = document.getElementById('toolbar-bar');
   let toolbarItemAdministrationTray = document.getElementById('toolbar-item-administration-tray');
 
@@ -32,7 +33,7 @@ function initializeAnchorMenu () {
   }
 
   /*
-    bootstrap needs to be loaded as a variable in order for this to work.
+    Bootstrap needs to be loaded as a variable in order for this to work.
     An alternative is to remove this and add the data-bs-spy="scroll" data-bs-target="#uds-anchor-menu nav" attributes to the body tag
     See https://getbootstrap.com/docs/5.3/components/scrollspy/ for more info
   */

--- a/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.js
@@ -1,62 +1,78 @@
-export const initializeAnchorMenu = () => {
-  const globalHeader = document.getElementById('asu-header');
+const bootstrap = require('bootstrap');
+
+function initializeAnchorMenu () {
+  const HEADER_IDS = ['asu-header', 'asuHeader'];
+
+  const globalHeaderId = HEADER_IDS.find((id) => document.getElementById(id));
+  const globalHeader = document.getElementById(globalHeaderId);
   const navbar = document.getElementById('uds-anchor-menu');
+  const navbarOriginalParent = navbar.parentNode;
+  const navbarOriginalNextSibling = navbar.nextSibling;
   const anchors = navbar.getElementsByClassName('nav-link');
-  const navbarInitialPosition = navbar.offsetTop;
+  const navbarInitialPosition = navbar.getBoundingClientRect().bottom;
   const anchorTargets = new Map();
   let previousScrollPosition = window.scrollY;
-  // Cache the anchor target elements by mapping them as a key/pair so don't have to
-  // parse the dom on every scroll event
+  let isNavbarAttached = false;  // Flag to track if navbar is attached to header
+  const body = document.body;
+
+  // These values are for the drupal admin toolbars. They are not present in the storybook.
+  let toolbarBar = document.getElementById('toolbar-bar');
+  let toolbarItemAdministrationTray = document.getElementById('toolbar-item-administration-tray');
+
+  let toolbarBarHeight = toolbarBar ? toolbarBar.offsetHeight : 0;
+  let toolbarItemAdministrationTrayHeight = toolbarItemAdministrationTray ? toolbarItemAdministrationTray.offsetHeight : 0;
+
+  let combinedToolbarHeightOffset = toolbarBarHeight + toolbarItemAdministrationTrayHeight;
+
+  // Cache the anchor target elements
   for (let anchor of anchors) {
     const targetId = anchor.getAttribute('href').replace('#', '');
     const target = document.getElementById(targetId);
     anchorTargets.set(anchor, target);
   }
 
-  window.onscroll = function () {
-    const navbarY = navbar.getBoundingClientRect().top;
-    const headerHeight = globalHeader.offsetHeight;
+  /*
+    bootstrap needs to be loaded as a variable in order for this to work.
+    An alternative is to remove this and add the data-bs-spy="scroll" data-bs-target="#uds-anchor-menu nav" attributes to the body tag
+    See https://getbootstrap.com/docs/5.3/components/scrollspy/ for more info
+  */
+  const scrollSpy = new bootstrap.ScrollSpy(body, {
+    target: '#uds-anchor-menu nav',
+    rootMargin: '20%'
+  });
 
-    // If scrolling DOWN
+  window.addEventListener("scroll", function () {
+    const navbarY = navbar.getBoundingClientRect().top;
+    const headerHeight = globalHeader.classList.contains("scrolled") ?  globalHeader.offsetHeight - 32 : globalHeader.offsetHeight; // 32 is the set height of the gray toolbar above the global header.
+
+    // If scrolling DOWN and navbar touches the globalHeader
     if (
       window.scrollY > previousScrollPosition &&
-      !navbar.classList.contains('uds-anchor-menu-sticky')
-    ) {
-      if (navbarY > 0 && navbarY < headerHeight) {
-        globalHeader.style.top = -(headerHeight - navbarY) + 'px';
-      } else if (navbarY <= 0) {
-        globalHeader.style.top = -globalHeader.offsetHeight + 'px';
-        navbar.classList.add('uds-anchor-menu-sticky');
+      navbarY > 0 && navbarY < headerHeight
+      ) {
+        if (!isNavbarAttached) {
+          // Attach navbar to globalHeader
+          globalHeader.appendChild(navbar);
+          isNavbarAttached = true;
+          navbar.classList.add('uds-anchor-menu-attached');
+        }
+        previousScrollPosition = window.scrollY;
       }
-    }
 
-    // If scrolling UP
+    // If scrolling UP and past the initial navbar position
     if (
       window.scrollY < previousScrollPosition &&
-      window.scrollY < navbarInitialPosition
+      (window.scrollY - navbarInitialPosition < (navbarInitialPosition - combinedToolbarHeightOffset) || window.scrollY === 0) && isNavbarAttached
     ) {
-      navbar.classList.remove('uds-anchor-menu-sticky');
-      if (globalHeader.getBoundingClientRect().top < 0) {
-        const offset = globalHeader.getBoundingClientRect().top + navbarY;
-        globalHeader.style.top = (offset < 0 ? offset : 0) + 'px';
-      }
-    }
-
-    for (let [anchor, target] of anchorTargets) {
-      const offsets = navbar.offsetHeight;
-
-      if (
-        target.getBoundingClientRect().top < offsets &&
-        target.getBoundingClientRect().top + target.offsetHeight > offsets
-      ) {
-        anchor.classList.add('active');
-      } else {
-        anchor.classList.remove('active');
-      }
+        // Detach navbar and return to original position
+        navbarOriginalParent.insertBefore(navbar, navbarOriginalNextSibling);
+        isNavbarAttached = false;
+        navbar.classList.remove('uds-anchor-menu-attached');
+        previousScrollPosition = window.scrollY;
     }
 
     previousScrollPosition = window.scrollY;
-  };
+  }, { passive: true });
 
   // Set click event of anchors
   for (let [anchor, anchorTarget] of anchorTargets) {
@@ -91,3 +107,5 @@ export const initializeAnchorMenu = () => {
     });
   }
 };
+
+export { initializeAnchorMenu };


### PR DESCRIPTION
Update anchor menu logic to match [webspark pr](https://github.com/ASUWebPlatforms/webspark-ci/commit/60509bbf5c10c3d1cbea876a63f8454975a1cbb2)


### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/atoms-anchor-menu--anchor-menu)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1560?atlOrigin=eyJpIjoiOWYzNTRjMTlmMmQ1NDE2N2FiNjAyOTIxNmQxZDFmMTIiLCJwIjoiaiJ9)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

