### PR TITLE
fix(component-header): selected prop only on top level navTree items

### DIFF
--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
@@ -11,6 +11,7 @@ import { NavTreePropTypes } from "../../../../core/models/app-prop-types";
 import { DropdownItem } from "../DropdownItem";
 import { NavItemWrapper } from "./index.styles";
 
+// TODO: why did we stop using this class and should we remove
 const DROPDOWN_CONTAINER_CLASS = "dropdown-container";
 
 export const DROPDOWNS_GA_EVENTS = {
@@ -123,8 +124,6 @@ const NavItem = ({ link, setItemOpened, itemOpened }) => {
     }
   };
 
-  const activeChild = link.items?.flat().find(({ selected }) => selected);
-
   return (
     <NavItemWrapper
       // @ts-ignore
@@ -140,7 +139,7 @@ const NavItem = ({ link, setItemOpened, itemOpened }) => {
         aria-expanded={() => "true"} // eslint-disable-line no-nested-ternary
         aria-owns={link.items ? `dropdown-${link.id}` : null}
         className={`${link.class ? link.class : ""}${
-          activeChild || link.selected ? " nav-item-selected" : ""
+          link.selected ? " nav-item-selected" : ""
         }${opened ? " open-link" : ""}`}
         tabIndex={0}
         data-testid="nav-item"


### PR DESCRIPTION
### Description
Originally we only supported selected prop on the top level navigation items. Since sub items still do not need this property I removed code that I introduced to check for that property on sub items.

I did discover that WS2 does incorrectly send items as an empty string, but I have added comments and code to handle this