### PR TITLE
fix(unity-bootstrap-theme): form error on dark background contrast error

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/_custom-asu-variables.scss
+++ b/packages/unity-bootstrap-theme/src/scss/_custom-asu-variables.scss
@@ -69,8 +69,8 @@ $uds-color-background-warning: #ffeade; // Background - Warning
 $uds-color-background-info: #d6f0fa; // Background - Information
 
 $uds-color-font-dark-base: $uds-color-base-gray-7; // Default text color on light background
-$uds-color-font-dark-error: #b72a2a; // Error text on light background
-$uds-color-font-dark-success: #446d12; // Success text on light background
+$uds-color-font-dark-error: #FF7B7D; // Error text on dark background
+$uds-color-font-dark-success: #446d12; // Success text on dark background
 $uds-color-font-light-base: $uds-color-base-gray-1; // Default text on dark background
 $uds-color-font-light-link: $uds-color-base-gold; // Link text on dark background
 $uds-color-font-light-visited: $uds-color-base-darkgold; // Visited link text on dark background

--- a/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
@@ -5,6 +5,8 @@ form.uds-form {
     margin: 0 0 $uds-size-spacing-4 0;
   }
 
+  --invalid-feedback-light-background: #{map-get(map-get($form-validation-states, 'invalid'), 'color')};
+
   /* Labels */
   label,
   legend {
@@ -201,12 +203,12 @@ form.uds-form {
   &.was-validated {
     .form-control:invalid {
       border-style: solid;
-      border: 1px solid $uds-color-font-dark-error;
-      border-bottom: 8px solid $uds-color-font-dark-error;
+      border: 1px solid var(--invalid-feedback-light-background);
+      border-bottom: 8px solid var(--invalid-feedback-light-background);
       // BS4 input height led to border eating padding. Resolved in variable
       // overrides by setting input heights to auto.
       &:focus {
-        border-bottom: 8px solid $uds-color-font-dark-error !important;
+        border-bottom: 8px solid var(--invalid-feedback-light-background) !important;
       }
     }
     // Radios and checks individual labels shouldn't be colored.
@@ -248,12 +250,12 @@ form.uds-form {
   textarea.is-invalid:enabled,
   select.is-invalid:enabled {
     border-style: solid;
-    border: 1px solid $uds-color-font-dark-error;
-    border-bottom: 8px solid $uds-color-font-dark-error;
+    border: 1px solid var(--invalid-feedback-light-background);
+    border-bottom: 8px solid var(--invalid-feedback-light-background);
     // BS4 input height led to border eating padding. Resolved in variable
     // overrides by setting input heights to auto.
     &:focus {
-      border-bottom: 8px solid $uds-color-font-dark-error !important;
+      border-bottom: 8px solid var(--invalid-feedback-light-background) !important;
     }
   }
   /* checks and radios */
@@ -269,7 +271,7 @@ form.uds-form {
   select ~ div.is-invalid {
     margin-left: inherit;
     margin-top: inherit;
-    color: $uds-color-font-dark-error;
+    color: var(--invalid-feedback-light-background);
   }
   .invalid-feedback {
     display: inline-block;
@@ -278,7 +280,7 @@ form.uds-form {
     svg {
       // We don't implement svg icons as bkg images due to need for color
       // manipulation.
-      color: $uds-color-font-dark-error;
+      color: var(--invalid-feedback-light-background);
       margin-right: $uds-size-spacing-1;
     }
   }
@@ -372,6 +374,12 @@ form.uds-form {
         color: $uds-color-base-gray-1;
       }
 
+      &:invalid {
+        border-style: solid;
+        border: 1px solid $uds-color-font-dark-error;
+        border-bottom: 8px solid $uds-color-font-dark-error;
+      }
+
       /* Disabled input */
       &:disabled,
       &[readonly] {
@@ -405,7 +413,7 @@ form.uds-form {
     }
     &.was-validated select ~ small.is-invalid,
     &.was-validated select ~ div.is-invalid {
-      color: $uds-color-alerts-error;
+      color: $uds-color-font-dark-error;
     }
     /* TODO Likely we'll find more work to do with client side validation rules
       in order to take advantage of having both valid/invalid markup present.
@@ -491,21 +499,21 @@ form.uds-form {
     textarea.is-invalid,
     select.is-invalid {
       border-style: solid;
-      border: 1px solid $uds-color-alerts-error;
-      border-bottom: 8px solid $uds-color-alerts-error !important;
+      border: 1px solid $uds-color-font-dark-error;
+      border-bottom: 8px solid $uds-color-font-dark-error !important;
       // BS4 input height led to border eating padding. Resolved in variable
       // overrides by setting input heights to auto.
       &:focus {
-        border-bottom: 8px solid $uds-color-alerts-error !important;
+        border-bottom: 8px solid $uds-color-font-dark-error !important;
       }
     }
     .invalid-feedback {
       font-weight: bold;
-      color: $uds-color-alerts-error;
+      color: $uds-color-font-dark-error;
       svg {
         // We don't implement svg icons as bkg images due to need for color
         // manipulation.
-        color: $uds-color-alerts-error;
+        color: $uds-color-font-dark-error;
         margin-right: $uds-size-spacing-1;
       }
     }

--- a/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
@@ -368,7 +368,7 @@ form.uds-form {
 
     label, legend {
       svg.uds-field-required {
-        color: $uds-color-font-dark-error;
+        color: $uds-color-base-gold;
       }
     }
 

--- a/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
@@ -366,6 +366,12 @@ form.uds-form {
   &.uds-form-gray7 {
     background-color: $uds-color-base-gray-7;
 
+    label, legend {
+      svg.uds-field-required {
+        color: $uds-color-font-dark-error;
+      }
+    }
+
     .form-control {
       &::placeholder {
         color: $uds-color-base-gray-4;

--- a/packages/unity-bootstrap-theme/stories/atoms/form-fields/form-fields.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/form-fields/form-fields.examples.stories.js
@@ -3107,8 +3107,8 @@ Selects.args = {
 export const KitchenSinkForm = createStory(
   <div>
     <p>
-      <a href="https://getbootstrap.com/docs/4.0/components/forms/">
-        Bootstrap 4 form docs
+      <a href="https://getbootstrap.com/docs/5.0/forms/overview/">
+        Bootstrap 5 form docs
       </a>
     </p>
 
@@ -3261,8 +3261,8 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidNotYetValidat
   createStory(
     <div>
       <p>
-        <a href="https://getbootstrap.com/docs/4.0/components/forms/#validation">
-          Bootstrap 4 form docs regarding validation
+        <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
+          Bootstrap 5 form docs regarding validation
         </a>
       </p>
 
@@ -3725,8 +3725,8 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidValidatedForm
   createStory(
     <div>
       <p>
-        <a href="https://getbootstrap.com/docs/4.0/components/forms/#validation">
-          Bootstrap 4 form docs regarding validation
+        <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
+          Bootstrap 5 form docs regarding validation
         </a>
       </p>
 
@@ -4213,8 +4213,8 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidNotYetValidat
   createStory(
     <div>
       <p>
-        <a href="https://getbootstrap.com/docs/4.0/components/forms/#validation">
-          Bootstrap 4 form docs regarding validation
+        <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
+          Bootstrap 5 form docs regarding validation
         </a>
       </p>
 
@@ -4695,8 +4695,8 @@ export const KitchenSinkFormClientSideValidationWithInvalidAndValidValidatedForm
   createStory(
     <div>
       <p>
-        <a href="https://getbootstrap.com/docs/4.0/components/forms/#validation">
-          Bootstrap 4 form docs regarding validation
+        <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
+          Bootstrap 5 form docs regarding validation
         </a>
       </p>
 


### PR DESCRIPTION
Forms with a dark background had an accessibility error with contrast. It now matches the UDS UI kit

### Description

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/atoms-form-fields-examples--kitchen-sink-form-client-side-validation-with-invalid-and-valid-validated-form-in-was-validated-state-gray-7-background)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1471?atlOrigin=eyJpIjoiZjBiNTA4MjUwMmEyNDAyZmE3MTk2MjNjZWRkOGJiYjEiLCJwIjoiaiJ9)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/cef73b00-d811-4c1f-9eab-2bca5ae95522/specs/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
