### PR TITLE
fix(unity-bootstrap-theme): updated anchor menu logic to account for …

### DIFF
--- a/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.js
@@ -9,7 +9,6 @@ function initializeAnchorMenu () {
   const navbarOriginalParent = navbar.parentNode;
   const navbarOriginalNextSibling = navbar.nextSibling;
   const anchors = navbar.getElementsByClassName('nav-link');
-  const navbarInitialPosition = navbar.getBoundingClientRect().bottom;
   const anchorTargets = new Map();
   let previousScrollPosition = window.scrollY;
   let isNavbarAttached = false;  // Flag to track if navbar is attached to header
@@ -24,6 +23,7 @@ function initializeAnchorMenu () {
   let toolbarItemAdministrationTrayHeight = toolbarItemAdministrationTray ? toolbarItemAdministrationTray.offsetHeight : 0;
 
   let combinedToolbarHeightOffset = toolbarBarHeight + toolbarItemAdministrationTrayHeight;
+  const navbarInitialTop = navbar.getBoundingClientRect().top + window.scrollY - combinedToolbarHeightOffset;
 
   // Cache the anchor target elements
   for (let anchor of anchors) {
@@ -41,6 +41,13 @@ function initializeAnchorMenu () {
     target: '#uds-anchor-menu nav',
     rootMargin: '20%'
   });
+
+  const shouldAttachNavbarOnLoad = window.scrollY > navbarInitialTop;
+    if (shouldAttachNavbarOnLoad) {
+      globalHeader.appendChild(navbar);
+      isNavbarAttached = true;
+      navbar.classList.add("uds-anchor-menu-attached");
+    }
 
   window.addEventListener("scroll", function () {
     const navbarY = navbar.getBoundingClientRect().top;
@@ -63,13 +70,12 @@ function initializeAnchorMenu () {
     // If scrolling UP and past the initial navbar position
     if (
       window.scrollY < previousScrollPosition &&
-      (window.scrollY - navbarInitialPosition < (navbarInitialPosition - combinedToolbarHeightOffset) || window.scrollY === 0) && isNavbarAttached
+      window.scrollY <= navbarInitialTop && isNavbarAttached
     ) {
-        // Detach navbar and return to original position
-        navbarOriginalParent.insertBefore(navbar, navbarOriginalNextSibling);
-        isNavbarAttached = false;
-        navbar.classList.remove('uds-anchor-menu-attached');
-        previousScrollPosition = window.scrollY;
+      // Detach navbar and return to original position
+      navbarOriginalParent.insertBefore(navbar, navbarOriginalNextSibling);
+      isNavbarAttached = false;
+      navbar.classList.remove('uds-anchor-menu-attached');
     }
 
     previousScrollPosition = window.scrollY;

--- a/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.js
@@ -43,11 +43,11 @@ function initializeAnchorMenu () {
   });
 
   const shouldAttachNavbarOnLoad = window.scrollY > navbarInitialTop;
-    if (shouldAttachNavbarOnLoad) {
-      globalHeader.appendChild(navbar);
-      isNavbarAttached = true;
-      navbar.classList.add("uds-anchor-menu-attached");
-    }
+  if (shouldAttachNavbarOnLoad) {
+    globalHeader.appendChild(navbar);
+    isNavbarAttached = true;
+    navbar.classList.add("uds-anchor-menu-attached");
+  }
 
   window.addEventListener("scroll", function () {
     const navbarY = navbar.getBoundingClientRect().top;


### PR DESCRIPTION
…header height

### Description
This update is mainly to match the webspark-ci repo PR but the logic in the anchor menu js file in webspark-ci should match the code in this unity repo
<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1961?atlOrigin=eyJpIjoiNWU4Njk5ZDJmNmUzNDE2Yzg0NjgyOGQ0M2MzNGQ3MDAiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
