### PR TITLE
fix(unity-bootstrap-theme): contain list styles

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
@@ -166,7 +166,7 @@ ul.uds-list {
   &.fa-ul {
     @include uds-list-spacing;
 
-    padding-left: 2.25rem; // Avoid icon clipping. fa-ul sets padding, Do not use cssVar
+    --list-padding-left: 2.25rem; // Avoid icon clipping.
     margin-left: 0rem;
     margin-bottom: 0rem;
     li .fa-li {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
@@ -16,23 +16,23 @@
       margin-bottom: 0rem;
     }
   }
-}
 
-/* Apply CSS vars */
-ol, ul {
-  max-width: var(--list-max-width);
-  padding-top: var(--list-padding-top);
-  padding-right: var(--list-padding-right);
-  padding-bottom: var(--list-padding-bottom);
-  padding-left: var(--list-padding-left);
-  list-style: var(--list-list-style);
+  /* Apply CSS vars */
+  & {
+    max-width: var(--list-max-width);
+    padding-top: var(--list-padding-top);
+    padding-right: var(--list-padding-right);
+    padding-bottom: var(--list-padding-bottom);
+    padding-left: var(--list-padding-left);
+    list-style: var(--list-list-style);
 
-  li:before {
-    content: var(--li-before-content);
-    font-size: var(--li-before-font-size);
-    color: var(--li-before-color);
-    background-color: var(--li-before-background-color);
-    line-height: var(--li-before-line-height);
+    li:before {
+      content: var(--li-before-content);
+      font-size: var(--li-before-font-size);
+      color: var(--li-before-color);
+      background-color: var(--li-before-background-color);
+      line-height: var(--li-before-line-height);
+    }
   }
 }
 


### PR DESCRIPTION
### Description

Only set the uds-list css variable if inside an element with `.uds-list`

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-0000)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [ ] No new console errors
- [ ] Accessibility checks
