### PR TITLE
UDS-1630: fix(unity-bootstrap-theme): remove problematic anchor styles

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_misc.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_misc.scss
@@ -87,16 +87,6 @@ label {
 .card-event .card-header {
   border-top: solid 4px $gold;
 }
-.bg-dark a:not(.btn, .nav-item),
-.bg-primary a:not(.btn, .nav-item),
-.bg-black a:not(.btn, .nav-item) {
-  color: $light;
-}
-.bg-light a:not(.btn, .nav-item),
-.bg-secondary a:not(.btn, .nav-item),
-.bg-white a:not(.btn, .nav-item) {
-  color: $primary;
-}
 
 .visually-hidden:not(:focus):not(:active),
 .visually-hidden-focusable:not(:focus):not(:active) {


### PR DESCRIPTION
UDS-1630

### Description

<!-- Description of problem -->
The previous PR was insufficient to solve the problem. So, we're trying again. In a post-scrum we decided that the best path forward was to remove these styles, as they were overgeneralized and were causing problems with basic functionality. Removing them doesn't seem to have caused any problem, but we should pay attention to Percy to see if any unanticipated visual regressions occur.
<!-- Solution -->

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1630)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks
