### PR TITLE
fix(unity-bootstrap-theme): add tabindex=0 to tab contents for access…

### DIFF
--- a/packages/unity-bootstrap-theme/stories/molecules/tabbed-panels/tabbed-panels.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/tabbed-panels/tabbed-panels.templates.stories.js
@@ -168,6 +168,7 @@ export const TabbedPanels = (args) => {
           id="nav-home"
           role="tabpanel"
           aria-labelledby="nav-home-tab"
+          tabIndex="0"
         >
           TAB 1. <a href="#">This is an ordinary paragraph</a> that is long enough to wrap to
           multiple lines so that you can see how spacing looks. At vero eos et
@@ -181,6 +182,7 @@ export const TabbedPanels = (args) => {
           id="nav-profile"
           role="tabpanel"
           aria-labelledby="nav-profile-tab"
+          tabIndex="0"
         >
           TAB 2. This is an ordinary paragraph that is long enough to wrap to
           multiple lines so that you can see how spacing looks. At vero eos et
@@ -194,6 +196,7 @@ export const TabbedPanels = (args) => {
           id="nav-contact"
           role="tabpanel"
           aria-labelledby="nav-contact-tab"
+          tabIndex="0"
         >
           TAB 3. This is an ordinary paragraph that is long enough to wrap to
           multiple lines so that you can see how spacing looks. At vero eos et
@@ -207,6 +210,7 @@ export const TabbedPanels = (args) => {
           id="nav-another"
           role="tabpanel"
           aria-labelledby="nav-another-tab"
+          tabIndex="0"
         >
           TAB 4. This is an ordinary paragraph that is long enough to wrap to
           multiple lines so that you can see how spacing looks. At vero eos et
@@ -220,6 +224,7 @@ export const TabbedPanels = (args) => {
           id="nav-another-2"
           role="tabpanel"
           aria-labelledby="nav-another-2-tab"
+          tabIndex="0"
         >
           TAB 5. This is an ordinary paragraph that is long enough to wrap to
           multiple lines so that you can see how spacing looks. At vero eos et
@@ -233,6 +238,7 @@ export const TabbedPanels = (args) => {
           id="nav-another-3"
           role="tabpanel"
           aria-labelledby="nav-another-3-tab"
+          tabIndex="0"
         >
           TAB 6. This is an ordinary paragraph that is long enough to wrap to
           multiple lines so that you can see how spacing looks. At vero eos et


### PR DESCRIPTION
…ibility

UDS-1637

### Description

This goes back to WS2-2004, which goes back to SCHWEB-1172. Kathy had indicated that we needed to comply with WCAG on tabbed panels, and for the most part this had happened. But, UDS hadn't added `tabindex="0"` to the tab body content, which is recommended in the WCAG standards https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/#accessibilityfeatures. So, I have added that here.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1637)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
