### PR TITLE
fix(unity-bootstrap-theme): fixed overlapping h1 when text wraps

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_headings.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_headings.scss
@@ -55,7 +55,7 @@ h1, .h1 {
   letter-spacing: $heading-one-letter-spacing;
 
   span[class^='highlight-'] {
-    padding: 1px 0;
+    padding: .5px 0;
   }
 
   &.article {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_headings.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_headings.scss
@@ -54,6 +54,10 @@ h1, .h1 {
   line-height: $heading-one-line-height;
   letter-spacing: $heading-one-letter-spacing;
 
+  span[class^='highlight-'] {
+    padding: 1px 0;
+  }
+
   &.article {
     font-size: $heading-one-article-font-size;
     line-height: $heading-one-article-line-height;

--- a/packages/unity-bootstrap-theme/src/scss/variables/_headings.scss
+++ b/packages/unity-bootstrap-theme/src/scss/variables/_headings.scss
@@ -6,7 +6,7 @@ $heading-margin: 1rem;
 $heading-line-height: calc(100% + .12em);
 
 $heading-one-font-size: 4rem;
-$heading-one-line-height: 4.25rem;
+$heading-one-line-height: 4.5rem;
 $heading-one-letter-spacing: -0.14rem;
 
 $heading-one-article-font-size: 3rem;


### PR DESCRIPTION
### Description
fixed overlapping h1 when text wraps

<!-- Description of problem -->
<!-- Solution -->

### Links

- [Unity reference site](https://unity.web.asu.edu/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-heroes-examples--hero-small-one-button)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1656?atlOrigin=eyJpIjoiZDliMDI2YWMwOTEzNGYxYWEzYzdhNGZmMjcyNmViMTgiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [ ] No new console errors
- [ ] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
![Problem example](https://github.com/ASU/asu-unity-stack/assets/21250684/aaa71b14-ab23-4621-b4b1-c1b19806dcee)
