### PR TITLE
fix(unity-bootstrap-theme): updated modal and allerts/banners to new …

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_alerts.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_alerts.scss
@@ -23,7 +23,10 @@
     .close
     {
       opacity: 1;
-      font-size: 1rem;
+      font-size: $uds-size-font-small;
+      display: flex;
+      justify-content: center;
+      align-items: center;
 
       &:hover
       {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
@@ -39,11 +39,12 @@
     flex: 2;
     margin-top: -$uds-size-spacing-2;
     margin-right: -$uds-size-spacing-2;
+    width: 12px;
 
     // Edits close button content (i.e. "X" inside bubble)
     .close {
       opacity: 1;
-      font-size: 1rem;
+      font-size: $uds-size-font-small;
 
       &:hover {
         opacity: 1;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
@@ -45,6 +45,9 @@
     .close {
       opacity: 1;
       font-size: $uds-size-font-small;
+      display: flex;
+      justify-content: center;
+      align-items: center;
 
       &:hover {
         opacity: 1;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_modals.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_modals.scss
@@ -21,7 +21,7 @@
   &-container {
     background-color: $uds-color-background-white;
     flex: 1;
-    height: 530px;
+    height: fit-content;
     max-width: 1200px;
     opacity: 1;
     padding: 32px;
@@ -31,10 +31,9 @@
 
   &-close-btn {
     @extend .btn;
-    background-color: $uds-color-base-gray-4;
+    background-color: $uds-color-background-white;
     border: 1px solid transparent;
     height: $uds-size-spacing-4; // 2rem
-    opacity: 0.5;
     padding: 0.25rem;
     position: absolute;
     right: 0;
@@ -42,12 +41,14 @@
     top: -$uds-size-spacing-7; // -56 px (24px away from top + 32px height of button)
     width: $uds-size-spacing-4 !important; // 2rem
 
-    .fa-times {
+    .fa-xmark {
       color: $uds-color-base-gray-7;
+      font-size: $uds-size-font-small;
     }
 
     &:hover {
-      opacity: 1;
+      background-color: $uds-color-background-white;
+      opacity: .7;
     }
   }
 }

--- a/packages/unity-bootstrap-theme/src/scss/extends/_modals.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_modals.scss
@@ -40,6 +40,9 @@
     text-decoration: none;
     top: -$uds-size-spacing-7; // -56 px (24px away from top + 32px height of button)
     width: $uds-size-spacing-4 !important; // 2rem
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     .fa-xmark {
       color: $uds-color-base-gray-7;

--- a/packages/unity-bootstrap-theme/stories/atoms/modals/modals.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/modals/modals.examples.stories.js
@@ -39,10 +39,15 @@ export const ModalComponent = () => (
             data-ga-section="modal name/title"
             data-ga="close cross"
           >
-            <i className="fas fa-times fa-stack-1x"></i>
+            <i className="fas fa-times"></i>
             <span className="visually-hidden">Close</span>
           </button>
           <h1>Content</h1>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod incididuntåç ut labore et dolore magna aliqua eiusmod tempo.
+          </p>
+          <button className="btn btn-primary">button</button>
         </div>
       </div>
     </div>

--- a/packages/unity-bootstrap-theme/stories/atoms/modals/modals.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/modals/modals.templates.stories.js
@@ -44,10 +44,15 @@ export const ModalComponent = ({open}) => <>
             data-ga-section="modal name/title"
             data-ga="close cross"
           >
-            <i className="fas fa-times fa-stack-1x"></i>
+            <i className="fas fa-times"></i>
             <span className="visually-hidden">Close</span>
           </button>
           <h1>Content</h1>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod incididuntåç ut labore et dolore magna aliqua eiusmod tempo.
+          </p>
+          <button className="btn btn-primary">button</button>
         </div>
       </div>
     </>;


### PR DESCRIPTION
…mockups

There are only slight changes, mostly the sizes of the close icons

### Description

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1646?atlOrigin=eyJpIjoiYmNhOTY4ZGNjN2M1NGYzYzkwZGExYWM5ZDg1ZjUxMjgiLCJwIjoiaiJ9)
- [Updated Unity Design Kit](https://xd.adobe.com/view/ff2c049b-410d-41bc-bcc4-9dc7711e04a7-aa7f/screen/6a7ff559-d8b4-4e8b-bef3-777d8504cd05/specs/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
