### PR TITLE
Add wait timeout for percy visual testing

### DIFF
--- a/packages/app-degree-pages/.storybook/preview.js
+++ b/packages/app-degree-pages/.storybook/preview.js
@@ -14,6 +14,7 @@ const parameters = {
       "Program Listing Page: Default\$",
       "Program Detail Page: Default\$",
     ],
+    waitForTimeout: 5000,
   },
 };
 

--- a/packages/app-webdir-ui/.storybook/preview.js
+++ b/packages/app-webdir-ui/.storybook/preview.js
@@ -14,6 +14,7 @@ const parameters = {
       "Web Directory/Templates: Web Directory Example Departments\$",
       "Search Page/Templates: Search Page Example\$"
     ],
+    waitForTimeout: 5000,
   },
 };
 


### PR DESCRIPTION
### Description
Adding a timeout for Percy visual testing should fix the issue where the screenshot gets taken before the page finishes fetching the data.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-0000)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [ ] No new console errors
- [ ] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
