### PR TITLE
feat(app-webdir-ui): hide empty faculty rank tabs

### DIFF
--- a/packages/app-webdir-ui/src/FacultyRankComponent/index.stories.js
+++ b/packages/app-webdir-ui/src/FacultyRankComponent/index.stories.js
@@ -29,7 +29,7 @@ const filters = {
 };
 */
 
-export const facultyRankWebDirectory = args => {
+export const FacultyRankWebDirectory = args => {
   return (
     <div className="uds-content-align">
       <WebDirectory

--- a/packages/app-webdir-ui/src/SearchResultsList/index.js
+++ b/packages/app-webdir-ui/src/SearchResultsList/index.js
@@ -67,7 +67,6 @@ const ASUSearchResultsList = ({
   const [subtitle, setSubtitle] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalResults, setTotalResults] = useState(null);
-  const [isAnon, setIsAnon] = useState(false);
   const cardSize = type === "micro" ? "micro" : "large";
   const searchList = useRef(null);
   const controller = new AbortController();
@@ -151,11 +150,8 @@ const ASUSearchResultsList = ({
                 GASource={GASource}
               />
             );
-          } else {
-            // setSubtitle(
-            //   `Results found: ${formattedResults.page.total_results}`
-            // );
           }
+
           setIsLoading(false);
           trackGAEvent({
             event: "search",
@@ -231,7 +227,7 @@ const ASUSearchResultsList = ({
           ) : (
             <div className="results-found">No results found</div>
           )}
-          {!hidePaginator && !isAnon && totalResults >= itemsPerPage && (
+          {!hidePaginator && totalResults >= itemsPerPage && (
             <Pagination
               type="default"
               background="white"

--- a/packages/app-webdir-ui/src/WebDirectoryComponent/index.js
+++ b/packages/app-webdir-ui/src/WebDirectoryComponent/index.js
@@ -3,13 +3,13 @@
 import PropTypes from "prop-types";
 import React, { useState, useEffect } from "react";
 
+import trackReactComponent from "../../../../shared/services/componentDatalayer";
 import FacultyRankTabPanels from "../FacultyRankComponent";
 import { FilterComponent } from "../helpers/Filter";
 import { engineNames, engines } from "../helpers/search";
 import { SortPicker } from "../SearchPage/components/sort";
 import { ASUSearchResultsList } from "../SearchResultsList";
 import { WebDirLayout, FacultyRankLayout } from "./index.styles";
-import trackReactComponent from "../../../../shared/services/componentDatalayer";
 
 /**
  * React component for displaying web directory search results.

--- a/packages/app-webdir-ui/src/helpers/search.js
+++ b/packages/app-webdir-ui/src/helpers/search.js
@@ -489,8 +489,6 @@ export const performSearch = function ({
 
     APICall()
       .then(res => {
-        // engine.inFlight = false;
-        // engine.abortController = null;
         const { data } = res;
         resolve(data);
       })


### PR DESCRIPTION
Empty faculty rank tabs will not show up. If there are no results, error is clear



### Links

- [JIRA ticket](https://asudev.jira.com/browse/SCHWEB-1121?atlOrigin=eyJpIjoiYTRjMjQ3ZDQ1OTExNDk3OTg4YjViZjhlOTRlMWJmNjciLCJwIjoiaiJ9)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [ ] No new console errors
- [ ] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
