### PR TITLE
fix(unity-bootstrap-theme): large hero text now hidden on mobile

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -258,6 +258,10 @@ div.uds-hero-md {
 div.uds-hero-lg {
   height: $uds-size-spacing-64;
 
+  .content {
+    display: none;
+  }
+
   h1 {
     margin-bottom: $uds-size-spacing-2;
   }
@@ -398,6 +402,10 @@ div.uds-hero-lg {
     height: 42.75rem;
     // TODO; remove this, it's a fallback for buttons without has-btn-row
     grid-template-rows: 1fr repeat(4, auto) $uds-size-spacing-6;
+
+    .content {
+      display: block;
+    }
 
     &.has-btn-row {
       grid-template-rows: 1fr repeat(4, auto) $uds-size-spacing-6;


### PR DESCRIPTION
### Description

large hero text now is hidden on mobile sizes

<!-- Description of problem -->
<!-- Solution -->

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1702?atlOrigin=eyJpIjoiMzc3MDczMjlhYTkxNDQ3MjljOTRhZjIxODE0OTMzMWUiLCJwIjoiaiJ9)
- [Unity Design Kit](https://asu.github.io/asu-unity-stack/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-heroes-examples--hero-large-one-button)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [ ] No new console errors
- [ ] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
