### PR TITLE
fix(component-header): added default GTM info to link clicks

### DIFF
--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
@@ -24,6 +24,7 @@ export const LINK_DEFAULT_PROPS = {
   action: "click",
   name: "onclick",
   type: "internal link",
+  region: "navbar",
   section: "main navbar",
   text: "",
 };
@@ -103,6 +104,7 @@ const NavItem = ({ link, setItemOpened, itemOpened }) => {
       // @ts-ignore
       isDropdown
         ? {
+            ...LINK_DEFAULT_PROPS,
             ...DROPDOWNS_GA_EVENTS,
             action,
             text,

--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
@@ -19,6 +19,15 @@ export const DROPDOWNS_GA_EVENTS = {
   type: "click",
 };
 
+export const LINK_DEFAULT_PROPS = {
+  event: "link",
+  action: "click",
+  name: "onclick",
+  type: "internal link",
+  section: "main navbar",
+  text: "",
+};
+
 /**
  * @param {{ children: React.ReactNode }} props
  * @returns {JSX.Element}
@@ -99,6 +108,7 @@ const NavItem = ({ link, setItemOpened, itemOpened }) => {
             text,
           }
         : {
+            ...LINK_DEFAULT_PROPS,
             text: link.type === "icon-home" ? "home button" : text,
           }
     );


### PR DESCRIPTION
### Description
added default GTM info to link clicks

<!-- Description of problem -->
<!-- Solution -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1726?atlOrigin=eyJpIjoiODliOThiMDdkZTI4NGU4MzhmNjA3ZWEzYTYwNGJlMGMiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge

### Images

<!-- Provide screenshots -->
