### PR TITLE
fix(component-events): Li elements should alway use 100% of UL width

### DIFF
--- a/packages/component-events/src/components/CardsListEvents/ListView/index.styles.js
+++ b/packages/component-events/src/components/CardsListEvents/ListView/index.styles.js
@@ -7,6 +7,10 @@ const ListViewWrapper = styled.ul`
   display: flex;
   flex-direction: column;
   row-gap: 24px;
+  li {
+    max-width: 100%;
+    width: 100%;
+  }
   .card {
     height: 235px;
     .card-img-top {


### PR DESCRIPTION
Resolve conflict with `li` rule max-width

### Description

- Should this code be moved to UDS at this time
  - https://github.com/ASUWebPlatforms/webspark-ci/blob/284060a00b6bdcbeae4151c7fc3cac2afc58a63d/web/themes/webspark/renovation/src/components/paragraphs/_paragraphs.scss#L4
  - If so, do both rules need to move? or is the comment only referring to the first rule for `p,li`

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1728)
- [JIRA ticket](https://asudev.jira.com/browse/WS2-1881)
- http://localhost:9060/?path=/story/events-component-cards-list--with-filters
- https://test-webspark-ci.ws.asu.edu/events
  - use can add a style rule in the inspector to test
```
.igpkyn li {
    max-width: 100%;
    width: 100%;
}
``` 

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

<!-- Provide screenshots -->
<img width="1453" alt="image" src="https://github.com/ASU/asu-unity-stack/assets/5209283/b8b6f121-77c2-481f-a42b-1ccfe5adf696">

