### PR TITLE
fix(components-core): remove import of bootstrap collapse in accordion

### DIFF
--- a/packages/components-core/.storybook/preview.js
+++ b/packages/components-core/.storybook/preview.js
@@ -1,4 +1,5 @@
 import "@asu/unity-bootstrap-theme/src/scss/unity-bootstrap-theme.bundle.scss";
+import "../../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js";
 
 const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/packages/components-core/src/components/Accordion/index.js
+++ b/packages/components-core/src/components/Accordion/index.js
@@ -1,7 +1,6 @@
 // @ts-nocheck
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import "../../../../../node_modules/bootstrap/js/dist/collapse";
 
 import { trackGAEvent } from "../../../../../shared";
 import { accordionCardPropTypes } from "../../core/models/shared-prop-types";


### PR DESCRIPTION
Bootstrap js should be loaded by user if they use components-core, so it is removed in the package code here



### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2144?atlOrigin=eyJpIjoiNzViMzc4YjUwYWUxNDdiOTkzOGNiMTRlNTZkMmQ2YWMiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [x] Unity project successfully builds from root `yarn install` & `yarn build`
- [x] Commits do not contain multiple scopes
- [x] Add/updated examples
- [x] Add/updated READMEs/docs
- [x] No new console errors
- [x] Accessibility checks


