### PR TITLE
fix(app-rfi): fixed CareerAndStudentType not showing and submit issue

### DIFF
--- a/packages/app-rfi/src/components/steps/questions/CareerAndStudentType.js
+++ b/packages/app-rfi/src/components/steps/questions/CareerAndStudentType.js
@@ -32,17 +32,13 @@ export const CareerAndStudentType = ({ gaData }) => {
       // Set only undergrad options for studentTypeOptions.
       setStudentTypeOptions([STUDENT.FRESHMAN, STUDENT.TRANSFER]);
     } else if (programOfInterest) {
-      // PoI is graduate degree.
-      // Setting the options here helps trigger dependent useEffects, even
-      // though we won't display this single option.
+      // PoI is graduate degree but we still show the option and default it to graduate.
       setStudentTypeOptions([STUDENT.READMISSION]);
-      // setFieldValue(name, STUDENT.READMISSION.value);
+      setFieldValue(name, STUDENT.READMISSION.value);
     }
-  }, []);
+  }, [degreeData]);
 
-  return studentTypeOptions.length === 1 ? (
-    <input type="hidden" name={name} value={studentTypeOptions[0].value} />
-  ) : (
+  return (
     <RfiSelect
       label={label}
       id={name}
@@ -59,7 +55,7 @@ export const CareerAndStudentType = ({ gaData }) => {
         })
       }
     />
-  );
+  )
 };
 
 CareerAndStudentType.propTypes = { gaData: gaEventPropTypes };


### PR DESCRIPTION
### Description
CareerAndStudentType Component was not re-rendering because of missing  degreeData dependency in useEffect.
Also, changed it to always show that option, even if there is only 1 option

Note: Changing the variant in storybook controls caused it to show correctly because that caused it to re-render and show correct options


<!-- Description of problem -->
<!-- Solution -->

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-0000)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [ ] No new console errors
- [ ] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
