### PR TITLE
fix(app-rfi): fix false error display on studentstatus

### DIFF
--- a/packages/app-rfi/src/components/controls/RfiSelect.js
+++ b/packages/app-rfi/src/components/controls/RfiSelect.js
@@ -44,7 +44,7 @@ const RfiSelect = ({
       <Field
         as="select"
         id={id}
-        className="form-control"
+        className="form-select"
         required={required}
         disabled={disabled}
         autoFocus={autoFocus}

--- a/packages/app-rfi/src/core/utils/submission-helpers.js
+++ b/packages/app-rfi/src/core/utils/submission-helpers.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { KEY } from "./constants";
 import { pushDataLayerEventToGa, setClientId } from "./google-analytics";
+import { deepCloner } from "../../../../../shared/utils";
 
 /**
  * In order to make a field not required, we set the default or blank value
@@ -97,7 +98,7 @@ function submissionSetHiddenFields(payload, test) {
 export const rfiSubmit = (value, submissionUrl, test, callback = a => ({})) => {
   // MARSHALL FIELDS FOR THE PAYLOAD
 
-  let payload = value;
+  let payload = deepCloner(value);
   payload = submissionFormFieldPrep(payload);
   payload = submissionSetHiddenFields(payload, test);
   payload = removeUnansweredFields(payload);

--- a/shared/utils/deep-cloner.js
+++ b/shared/utils/deep-cloner.js
@@ -1,0 +1,31 @@
+function deepCloner(obj) {
+  // Check if the object is null or not an object, return it if so
+  if (obj === null || typeof obj !== 'object') {
+      return obj;
+  }
+
+  // Handle Date
+  if (obj instanceof Date) {
+      return new Date(obj.getTime());
+  }
+
+  // Handle Array
+  if (Array.isArray(obj)) {
+      const arrCopy = [];
+      for (let i = 0; i < obj.length; i++) {
+          arrCopy[i] = deepClone(obj[i]);
+      }
+      return arrCopy;
+  }
+
+  // Handle Object
+  const objCopy = {};
+  for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+          objCopy[key] = deepClone(obj[key]);
+      }
+  }
+  return objCopy;
+};
+
+export { deepCloner };

--- a/shared/utils/deep-cloner.js
+++ b/shared/utils/deep-cloner.js
@@ -22,7 +22,7 @@ function deepCloner(obj) {
   const objCopy = {};
   for (const key in obj) {
       if (obj.hasOwnProperty(key)) {
-          objCopy[key] = deepClone(obj[key]);
+          objCopy[key] = deepCloner(obj[key]);
       }
   }
   return objCopy;

--- a/shared/utils/index.js
+++ b/shared/utils/index.js
@@ -18,3 +18,4 @@ export * from "./id-generator";
 export * from "./numbers";
 export * from "./script-utils";
 export * from "./timers";
+export * from "./deep-cloner";


### PR DESCRIPTION
fix false error display on studentstatus field on submit.

## Description

The problem was that the payload was pointing to the same value in memory that got passed in and it was causing Formik to reset the state when the value was changed in the submission helpers. Creating a deep clone instead of a shallow clone fixes this

