### PR TITLE
fix(app-degree-pages): fixed error in anchor menu detail page

### DIFF
--- a/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
@@ -341,7 +341,6 @@ const hasValidAnchorMenu = anchorMenu => {
   );
   const hasExternalAnchors = anchorMenu?.externalAnchors?.length > 0;
   const res = hasExternalAnchors || validItemsInAnchorMenu.length > 0;
-  console.log(res, anchorMenu);
   return res;
 };
 

--- a/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
@@ -336,9 +336,12 @@ const filterAnchorMenu = (anchorMenu, resolver) => {
  * @returns
  */
 const hasValidAnchorMenu = anchorMenu => {
-  const res =
-    Object.keys(anchorMenu).filter(key => key !== "externalAnchors").length >
-      0 || anchorMenu?.externalAnchors?.length > 0;
+  const validItemsInAnchorMenu = Object.values(anchorMenu).filter(
+    key => key === true
+  );
+  const hasExternalAnchors = anchorMenu?.externalAnchors?.length > 0;
+  const res = hasExternalAnchors || validItemsInAnchorMenu.length > 0;
+  console.log(res, anchorMenu);
   return res;
 };
 


### PR DESCRIPTION
### Description
There was a console error in the Degree Detail page when there was no anchor menu present.
This was caused by trying to render the AnchorMenu even if there was no valid anchor menu items


### Links

- [Unity reference site](https://asu.github.io/asu-unity-stack/@asu/app-degree-pages/index.html?path=/story/program-detail-page--default)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1734?atlOrigin=eyJpIjoiODYxZDM2MGZiOTlkNDM2MmIyMzZkMjI1YWY5ODQxMDkiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

### Checklist

- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
- [ ] Commits do not contain multiple scopes
- [ ] Add/updated examples
- [ ] Add/updated READMEs/docs
- [ ] No new console errors
- [ ] Accessibility checks

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge

### Images

<!-- Provide screenshots -->
![Screen Shot 2024-07-03 at 6 09 28 PM](https://github.com/ASU/asu-unity-stack/assets/21250684/464fcffd-c747-4960-8361-789b89ea752d)
