### PR TITLE
fix(app-rfi): revert MilitaryStatus Field to multiple choice

### DIFF
--- a/packages/app-rfi/src/components/steps/questions/MilitaryStatus.js
+++ b/packages/app-rfi/src/components/steps/questions/MilitaryStatus.js
@@ -1,12 +1,45 @@
 import React from "react";
 
-import { gaEventPropTypes } from "../../../../../../shared";
-import { RfiRadioGroup } from "../../controls";
+import { gaEventPropTypes, trackGAEvent } from "../../../../../../shared";
+import { RfiSelect } from "../../controls";
+
+const veteranStatusOptions = [
+  { key: "1", value: "None", text: "None" },
+  { key: "2", value: "Active Duty", text: "Active Duty" },
+  { key: "3", value: "National Guard", text: "National Guard" },
+  { key: "4", value: "Veteran", text: "Veteran" },
+  { key: "5", value: "Armed forces reserve", text: "Armed forces reserve" },
+  { key: "6", value: "Spouse/Dependent", text: "Spouse/Dependent" },
+];
 
 /**
  * @param {{ gaData: import("../../../../../../shared/services/googleAnalytics").GAEventObject}} props
  */
 export const MilitaryStatus = ({ gaData }) => {
+  const label = "Military/veteran status";
+  const name = "MilitaryStatus";
+  return (
+    <RfiSelect
+      label={label}
+      id={name}
+      name={name}
+      options={veteranStatusOptions}
+      onBlur={e =>
+        trackGAEvent({
+          ...gaData,
+          event: "select",
+          type: label,
+          text: e.target.selectedOptions[0].innerText,
+        })
+      }
+    />
+  );
+};
+
+/*
+  TODO: Field will be replaced in the near future
+  We became aware of the need to revert this field in ERFI-148 2024-07-08
+
   return (
     <RfiRadioGroup
       label="Have you served in the U.S. Military or are you a military dependent?"
@@ -18,6 +51,6 @@ export const MilitaryStatus = ({ gaData }) => {
       ]}
     />
   );
-};
+*/
 
 MilitaryStatus.propTypes = { gaData: gaEventPropTypes };


### PR DESCRIPTION
SalesForce and form handler are not compatible for Boolean MilitaryStatus Field

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/ERFI-148)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
