### PR TITLE
fix(app-degree-pages): udpate at a glance online url

### DIFF
--- a/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
+++ b/packages/app-degree-pages/src/core/services/degree-data-prop-resolver-service.js
@@ -287,16 +287,23 @@ function getCampusLocations(resolver) {
     text: location,
     url: "",
   });
+  const getOnlineLocation = url => ({
+    text: "Online",
+    url,
+  });
 
   const campusList = resolver.getCampusList().map(campus => campus.campusCode);
-  if (campusList.length > 0)
+  if (campusList.length > 0) {
     locations.push(
       ...campusList.map(
         location =>
+          (location === "ONLNE" &&
+            getOnlineLocation(resolver.getCurriculumUrl())) ||
           findCampusDefinition(location, program) ||
           getDefaultLocation(location)
       )
     );
+  }
 
   const campusWueLocation = resolver.getCampusWue();
   if (campusWueLocation) {


### PR DESCRIPTION
### Description

Per request from Degree Search product owner, we should be using `asuOnlineAcadPlanUrl` for the Online campus location links in the At a Glance section.

Fast-tracking this one for WS2 2.13.0

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1737)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)