### PR TITLE
chore(static-site): update UX links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,33 +2,15 @@
 
 <!-- Description of problem -->
 <!-- Solution -->
+<!-- Testing Steps -->
 
 ### Links
 
-- [Unity reference site](https://unity.web.asu.edu/)
 - [JIRA ticket](https://asudev.jira.com/browse/UDS-0000)
-- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)
+- [Unity reference site](https://asu.github.io/asu-unity-stack/)
+- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)
 
 ### FOR APPROVERS
 
 - [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
 
-### Checklist
-
-- [ ] Unity project successfully builds from root `yarn install` & `yarn build`
-- [ ] Commits do not contain multiple scopes
-- [ ] Add/updated examples
-- [ ] Add/updated READMEs/docs
-- [ ] No new console errors
-- [ ] Accessibility checks
-
-### Browsers
-
-- [ ] Chrome
-- [ ] Safari
-- [ ] Firefox
-- [ ] Edge
-
-### Images
-
-<!-- Provide screenshots -->

--- a/packages/component-carousel/README.md
+++ b/packages/component-carousel/README.md
@@ -358,7 +358,8 @@ For example, if you want to use the `npm` package `lite-server` follow these ste
 
 # UX documents
 
-- [XD Carousel](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/c4656960-099f-4e74-9f14-7647a5053621/)
+- [XD Carousel](https://assets.adobe.com/public/fb14b288-bf63-47e0-5d30-384de5560455/1d2d856b-86c3-4f0e-b388-f32115a27c56)
+- [XD Carousel (old version)](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/screen/c4656960-099f-4e74-9f14-7647a5053621/)
 
 
 ## Future improvements

--- a/server/storybook-index-generator.js
+++ b/server/storybook-index-generator.js
@@ -153,9 +153,15 @@ module.exports = generateHTML = packages => `
       <div class="row my-6">
 
         <div class="col-md-6 pb-8">
-          <h2>Unity Design Kit</h2>
+          <h2>UDS UI Kit</h2>
+          <p>Guidelines, standards, and best-practices for Unity Design System across all ASU web projects.</p>
+          <p><a class="btn btn-maroon btn-medium" href="https://zeroheight.com/9f0b32a56">Explore the UDS UI Kit</a></p>
+        </div>
+
+        <div class="col-md-6 pb-8">
+          <h2>UDS Component Library</h2>
           <p>A community-built design system built with Adobe XD.</p>
-          <p><a class="btn btn-maroon btn-medium" href="https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/">View the document</a></p>
+          <p><a class="btn btn-maroon btn-medium" href="https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455">View the document</a></p>
         </div>
 
         <div class="col-md-6 pb-8">

--- a/server/storybook-index-generator.js
+++ b/server/storybook-index-generator.js
@@ -153,13 +153,13 @@ module.exports = generateHTML = packages => `
       <div class="row my-6">
 
         <div class="col-md-6 pb-8">
-          <h2>UDS UI Kit</h2>
+          <h2>Unity Design System UI Kit</h2>
           <p>Guidelines, standards, and best-practices for Unity Design System across all ASU web projects.</p>
           <p><a class="btn btn-maroon btn-medium" href="https://zeroheight.com/9f0b32a56">Explore the UDS UI Kit</a></p>
         </div>
 
         <div class="col-md-6 pb-8">
-          <h2>UDS Component Library</h2>
+          <h2>Unity Design System Styles Library</h2>
           <p>A community-built design system built with Adobe XD.</p>
           <p><a class="btn btn-maroon btn-medium" href="https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455">View the document</a></p>
         </div>


### PR DESCRIPTION
### Description

1. Replace current 1st card with 2 new cards

Title: UDS UI Kit
Link: [ Explore the UDS UI Kit ] https://zeroheight.com/9f0b32a56
Description: Guidelines, standards, and best-practices for Unity Design System across all ASU web projects.

Title: UDS Component Library
Link: [ View the document ] https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455
Description: A community-built design system built with Adobe XD.

2. Other references to the old XD document are updated.

3. Since I had to touch the PR template I cleaned it up, I thought we had a ticket in the backlog for this but my quick search did not find it.

### Links

- [Unity reference site](https://unity.web.asu.edu/)
- [JIRA ticket](https://asudev.jira.com/browse/UDS-1739)
- [Unity Design Kit](https://xd.adobe.com/view/56f6cb78-9af5-4b12-b4ce-ef319f71113f-03a5/)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)


![image](https://github.com/user-attachments/assets/4d448b80-90c7-4114-b42f-ea455cf75493)
