### PR TITLE
Hero H1 A11y issue

### DIFF
--- a/packages/components-core/src/components/Hero/index.js
+++ b/packages/components-core/src/components/Hero/index.js
@@ -58,22 +58,27 @@ function headingHeroHtmlTemplate({
     undefined: "",
   };
 
-  return (
-    <div
-      className={classNames(`uds-hero`, {
-        [imageSize[image?.size]]: image?.size,
-      })}
-    >
-      <div className="hero-overlay"></div>
-      <HeroImage
-        className="hero"
-        src={image?.url}
-        alt={image?.altText}
-        data-testid="hero-image"
-      />
+  let titleElement = <></>;
 
-      {subTitle && (
-        <div role="doc-subtitle" data-testid="hero-subtitle">
+  if (title) {
+    titleElement = (
+      <h1 style={{ maxWidth: title.maxWidth || "" }} data-testid="hero-title">
+        <span
+          className={classNames({
+            [textColor[title.color]]: title.color,
+            [highlightColor[title.highlightColor]]: title.highlightColor,
+          })}
+        >
+          {title.text}
+        </span>
+      </h1>
+    );
+  }
+
+  if (title && subTitle) {
+    titleElement = (
+      <hgroup>
+        <p className="hero-subtitle" data-testid="hero-subtitle">
           <span
             className={classNames({
               [textColor[subTitle.color]]: subTitle.color,
@@ -83,22 +88,26 @@ function headingHeroHtmlTemplate({
           >
             {subTitle.text}
           </span>
-        </div>
-      )}
+        </p>
+        {titleElement}
+      </hgroup>
+    );
+  }
 
-      {title && (
-        <h1 style={{ maxWidth: title.maxWidth || "" }} data-testid="hero-title">
-          <span
-            className={classNames({
-              [textColor[title.color]]: title.color,
-              [highlightColor[title.highlightColor]]: title.highlightColor,
-            })}
-          >
-            {title.text}
-          </span>
-        </h1>
-      )}
-
+  return (
+    <div
+      className={classNames(`uds-hero`, {
+        [imageSize[image?.size]]: image?.size,
+      })}
+    >
+      <div className="hero-overlay" />
+      <HeroImage
+        className="hero"
+        src={image?.url}
+        alt={image?.altText}
+        data-testid="hero-image"
+      />
+      {titleElement}
       {contents && (
         <div
           data-testid="hero-content"

--- a/packages/components-core/src/components/Hero/index.js
+++ b/packages/components-core/src/components/Hero/index.js
@@ -77,7 +77,7 @@ function headingHeroHtmlTemplate({
 
   if (title && subTitle) {
     titleElement = (
-      <hgroup>
+      <header>
         <p className="hero-subtitle" data-testid="hero-subtitle">
           <span
             className={classNames({
@@ -90,7 +90,7 @@ function headingHeroHtmlTemplate({
           </span>
         </p>
         {titleElement}
-      </hgroup>
+      </header>
     );
   }
 

--- a/packages/components-core/src/components/Hero/index.stories.js
+++ b/packages/components-core/src/components/Hero/index.stories.js
@@ -2,6 +2,8 @@
 // @ts-check
 import React from "react";
 
+import { imageName } from "../../../../../shared/assets";
+
 import { Hero } from ".";
 
 /**
@@ -32,14 +34,7 @@ export default {
  * @param {HeroProps} props
  * @returns {JSX.Element}
  */
-const Template = ({ image, title, contents, contentsColor }) => (
-  <Hero
-    title={title}
-    image={image}
-    contents={contents}
-    contentsColor={contentsColor}
-  />
-);
+const Template = props => <Hero {...props} />;
 
 /**
  * @type {{ args: HeroProps, parameters: object }}
@@ -48,9 +43,13 @@ export const HeroSmall = Template.bind({});
 
 HeroSmall.args = {
   image: {
-    url: "https://source.unsplash.com/WLUHO9A_xik/800x400?a=1",
+    url: imageName.hero01,
     altText: "Hero image",
     size: "small",
+  },
+  subTitle: {
+    text: "Sub title",
+    highlightColor: "black",
   },
   title: {
     text: "Heading with a long title 1",
@@ -72,7 +71,7 @@ export const HeroLongTitle = Template.bind({});
 
 HeroLongTitle.args = {
   image: {
-    url: "https://source.unsplash.com/WLUHO9A_xik/800x400?a=1",
+    url: imageName.hero01,
     altText: "Hero image",
     size: "small",
   },
@@ -80,6 +79,10 @@ HeroLongTitle.args = {
     text: "Heading with a long title 2",
     highlightColor: "gold",
     maxWidth: "100%",
+  },
+  subTitle: {
+    text: "Sub title",
+    highlightColor: "black",
   },
 };
 HeroLongTitle.parameters = {
@@ -97,13 +100,17 @@ export const HeroMedium = Template.bind({});
 
 HeroMedium.args = {
   image: {
-    url: "https://source.unsplash.com/WLUHO9A_xik/800x400?a=1",
+    url: imageName.hero01,
     altText: "Hero image",
     size: "medium",
   },
   title: {
     text: "Heading 1",
     highlightColor: "black",
+  },
+  subTitle: {
+    text: "Sub title",
+    highlightColor: "gold",
   },
   contentsColor: "white",
   contents: [
@@ -128,13 +135,17 @@ export const HeroLarge = Template.bind({});
 
 HeroLarge.args = {
   image: {
-    url: "https://source.unsplash.com/WLUHO9A_xik/800x400?a=1",
+    url: imageName.hero01,
     altText: "Hero image",
     size: "large",
   },
   title: {
     text: "Heading 1",
     color: "white",
+  },
+  subTitle: {
+    text: "Sub title",
+    highlightColor: "black",
   },
   contentsColor: "white",
   contents: [

--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -73,7 +73,7 @@ div[class^="uds-hero"] {
   align-content: flex-end;
   margin-bottom: $uds-size-spacing-8;
 
-  hgroup {
+  header {
     display: grid;
     grid-column: 2;
     grid-row: 2;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -73,9 +73,33 @@ div[class^="uds-hero"] {
   align-content: flex-end;
   margin-bottom: $uds-size-spacing-8;
 
+  hgroup {
+    display: grid;
+    grid-column: 2;
+    grid-row: 2;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+
+    p {
+      margin: 0;
+    }
+
+    h1,
+    .h1,
+    [role="doc-subtitle"], // UDS is deprecatated doc-subtitle as a Selector
+    .hero-subtitle,
+    a.btn,
+    a.uds-modal-close-btn,
+    .content,
+    .btn-row {
+      grid-column: 1;
+    }
+  }
+
   // Column alignment for decendent items
   h1,
-  [role="doc-subtitle"],
+  [role="doc-subtitle"], // UDS is deprecatated doc-subtitle as a Selector
+  .hero-subtitle,
   a.btn,
   .content,
   .btn-row {
@@ -92,7 +116,8 @@ div[class^="uds-hero"] {
     object-fit: cover;
   }
 
-  [role="doc-subtitle"] {
+  [role="doc-subtitle"], // UDS is deprecatated doc-subtitle as a Selector
+  .hero-subtitle {
     @include like-h3;
     display: inline-block;
     grid-row: 2;
@@ -307,7 +332,8 @@ div.uds-hero-lg {
 
     // Column alignment for decendent items
     h1,
-    [role="doc-subtitle"],
+    [role="doc-subtitle"], // UDS is deprecatated doc-subtitle as a Selector
+    .hero-subtitle,
     a.btn,
     .content,
     .btn-row {
@@ -445,7 +471,8 @@ div.uds-hero-lg {
 
     // Column alignment for decendent items
     h1,
-    [role="doc-subtitle"],
+    [role="doc-subtitle"], // UDS is deprecatated doc-subtitle as a Selector
+    .hero-subtitle,
     a.btn,
     .content,
     .btn-row {
@@ -460,7 +487,8 @@ div.uds-hero-lg {
 
     // Column alignment for decendent items
     h1,
-    [role="doc-subtitle"],
+    [role="doc-subtitle"], // UDS is deprecatated doc-subtitle as a Selector
+    .hero-subtitle,
     a.btn,
     .content,
     .btn-row {

--- a/packages/unity-bootstrap-theme/stories/atoms/images/images.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/images/images.examples.stories.js
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { imageName } from "../../../../../shared/assets";
 import { defaultDecorator } from "../../../../../shared/components/Layout";
 
 export default {

--- a/packages/unity-bootstrap-theme/stories/molecules/heroes/heroes.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/heroes/heroes.templates.stories.js
@@ -4,6 +4,51 @@ import React from "react";
 import { fullLayoutDecorator } from "../../../../../shared/components/Layout.js";
 import cardsImage from "../cards/cards-image.jpg";
 
+const titleArgs = {
+  title: {
+    name: "Title",
+    control: {
+      type: "text"
+    }
+  },
+  titleColors: {
+    name: "Title Colors",
+    options: ["Black Text", "White Text", "Black Background", "Gold Background"],
+    mapping: {
+      "Black Text": "",
+      "White Text": "text-white",
+      "Black Background": "text-white highlight-black",
+      "Gold Background": "highlight-gold",
+    },
+    control: {
+      type: "radio",
+    },
+  },
+}
+
+const subTitleArgs = {
+  subTitle: {
+    name: "Sub Title",
+    control: {
+      type: "text"
+    }
+  },
+  subTitleColors: {
+    name: "Sub Title Colors",
+    options: ["Black Text", "White Text", "Black Background", "Gold Background"],
+    mapping: {
+      "Black Text": "",
+      "White Text": "text-white",
+      "Black Background": "text-white highlight-black",
+      "Gold Background": "highlight-gold",
+    },
+    control: {
+      type: "radio",
+    },
+  },
+}
+
+
 const heroArgTypes = {
   size: {
     name: "Size",
@@ -17,7 +62,16 @@ const heroArgTypes = {
       type: "radio",
     },
   },
+  ...titleArgs,
+  ...subTitleArgs,
 };
+
+const heroDefaultArgs = {
+  title: "Default Title",
+  titleColors: "White Text",
+  subTitle: "",
+  subTitleColors: "White Text",
+}
 
 const storyHeroArgTypes = {
   size: {
@@ -31,14 +85,15 @@ const storyHeroArgTypes = {
       type: "radio",
     },
   },
-};;
+};
 
 export default {
   title: "Molecules/Heroes/Templates",
   decorators: [ fullLayoutDecorator ],
+
 };
 
-const Hero = ({size}) => (
+const Hero = ({size, title, titleColors, subTitle, subTitleColors}) => (
   <div className={`${size} has-btn-row`}>
     <div className="hero-overlay"></div>
     <img
@@ -51,11 +106,26 @@ const Hero = ({size}) => (
       decoding="async"
       fetchpriority="high"
     />
-    <h1>
-      <span className="text-white">
-        Lorem ipsum dolor sit amet, consectetur adip
-      </span>
-    </h1>
+    {subTitle ? (
+    <hgroup>
+      <p className="hero-subtitle">
+        <span className={subTitleColors}>
+          {subTitle}
+        </span>
+      </p>
+      <h1>
+        <span className={titleColors}>
+          {title}
+        </span>
+      </h1>
+    </hgroup>) :
+    (
+      <h1>
+        <span className={titleColors}>
+          {title}
+        </span>
+      </h1>)
+    }
     <div className="content">
       <p className="text-white">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -94,19 +164,22 @@ const Hero = ({size}) => (
 );
 export const HeroSmall = Hero.bind({});
 HeroSmall.args = {
-  size: "Small"
+  size: "Small",
+  ...heroDefaultArgs,
 }
 HeroSmall.argTypes = heroArgTypes;
 
 export const HeroMedium = Hero.bind({});
 HeroMedium.args = {
-  size: "Medium"
+  size: "Medium",
+  ...heroDefaultArgs,
 }
 
 HeroMedium.argTypes = heroArgTypes;
 export const HeroLarge = Hero.bind({});
 HeroLarge.args = {
-  size: "Large"
+  size: "Large",
+  ...heroDefaultArgs,
 }
 
 HeroLarge.argTypes = heroArgTypes;

--- a/packages/unity-bootstrap-theme/stories/molecules/heroes/heroes.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/molecules/heroes/heroes.templates.stories.js
@@ -107,7 +107,7 @@ const Hero = ({size, title, titleColors, subTitle, subTitleColors}) => (
       fetchpriority="high"
     />
     {subTitle ? (
-    <hgroup>
+    <header>
       <p className="hero-subtitle">
         <span className={subTitleColors}>
           {subTitle}
@@ -118,7 +118,7 @@ const Hero = ({size, title, titleColors, subTitle, subTitleColors}) => (
           {title}
         </span>
       </h1>
-    </hgroup>) :
+    </header>) :
     (
       <h1>
         <span className={titleColors}>


### PR DESCRIPTION
### Description

This ticket has 3 items, This PR address item 1 `The doc-subtitle role is exposed as a heading with no level`
- The doc-subtitle role is meant for document, it is not meant for web

hgroup was being deprecated, however it may have made a come back as I still see relevant documentation:
- https://html.spec.whatwg.org/multipage/sections.html#the-hgroup-element
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup
There is another option to use header which does have an example of text before the h1
- https://html.spec.whatwg.org/multipage/sections.html#the-header-element


### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1638) 
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

