### PR TITLE
UDS-1775: fix(unity-bootstrap-theme): switch anchor to button on accordions header and added styles

### DIFF
--- a/packages/components-core/README.md
+++ b/packages/components-core/README.md
@@ -91,7 +91,7 @@ yarn test
 
 ```HTML
 <!-- Provide target divs for two carousels. Must have unique ids. -->
-<div id="default-card"></div>
+<div id="default-card"> </div>
 <div id="icon-card"></div>
 
 <!-- Include font awesome -->

--- a/packages/components-core/README.md
+++ b/packages/components-core/README.md
@@ -92,7 +92,7 @@ yarn test
 ```HTML
 <!-- Provide target divs for two carousels. Must have unique ids. -->
 <div id="default-card"> </div>
-<div id="icon-card"></div>
+<div id="icon-card"> </div>
 
 <!-- Include font awesome -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"

--- a/packages/components-core/src/components/Accordion/AccordionCard/index.js
+++ b/packages/components-core/src/components/Accordion/AccordionCard/index.js
@@ -24,12 +24,12 @@ export const AccordionCard = ({ id, item, openCard, onClick }) => (
   >
     <div className="accordion-header">
       <h4>
-        <a
+        <button
+          type="button"
           data-testid="accordion-opener"
           className={classNames({ [`collapsed`]: id !== openCard })}
           data-bs-toggle="collapse"
           href={`#card-body-${id}`}
-          role="button"
           aria-expanded={id === openCard}
           aria-controls={`card-body-${id}`}
           onClick={e => onClick(e, id, item.content?.header)}
@@ -45,7 +45,7 @@ export const AccordionCard = ({ id, item, openCard, onClick }) => (
             item.content?.header
           )}
           <i className="fas fa-chevron-up" />
-        </a>
+        </button>
       </h4>
     </div>
     {item.content?.body && (

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -546,7 +546,7 @@ Cards - Table of Contents
     h5 {
       margin: 0;
 
-      a {
+      a, button {
         padding: 1rem var(--card-child-padding);
         color: $uds-color-base-gray-7;
         text-decoration: none;
@@ -565,6 +565,13 @@ Cards - Table of Contents
         &.collapsed i.fa-chevron-up {
           transform: rotate(180deg);
         }
+      }
+
+      button {
+        width: 100%;
+        background: transparent;
+        border: 0;
+        font-weight: bold;
       }
     }
 
@@ -593,13 +600,20 @@ Cards - Table of Contents
   border-left: 1px solid $uds-color-base-gray-3;
 
   .accordion-header {
-    h4 a {
+    h4 a, h4 button {
       padding-top: $uds-size-spacing-4;
       padding-bottom: $uds-size-spacing-4;
 
       &:hover {
         background-color: transparent;
       }
+    }
+
+    h4 button {
+      width: 100%;
+      background: transparent;
+      border: 0;
+      font-weight: bold;
     }
 
     svg {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -572,7 +572,16 @@ Cards - Table of Contents
         background: transparent;
         border: 0;
         font-weight: bold;
+
+        &:focus {
+          outline: none!important;
+          box-shadow: 0 0 0 1px $uds-color-base-gray-7 !important;
+          border: 1px solid $uds-color-base-gray-7 !important;
+          margin: 4px;
+          width: -webkit-fill-available;
+        }
       }
+
     }
 
     + div > .accordion-body, + .accordion-body{ // TODO: remove '+ .accordion-body' after next major breaking change release. This is for backward compatibility

--- a/packages/unity-bootstrap-theme/src/scss/extends/_globalfooter.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_globalfooter.scss
@@ -203,7 +203,7 @@ footer {
       border-top: 1px solid $uds-color-divider-lighter;
       padding-left: 0;
 
-      a {
+      a, button {
         color: $uds-color-base-gray-2;
         padding: $uds-size-spacing-3 0;
         text-decoration: none;
@@ -242,7 +242,7 @@ footer {
         border-top: 0;
         padding: 0;
 
-        a {
+        a, button {
           padding: 0;
           cursor: default;
         }

--- a/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.examples.stories.js
@@ -15,7 +15,7 @@ export const FoldableCardDefaultOpen = () =>
       <div className="accordion-item mt-3">
         <div className="accordion-header">
           <h3>
-            <a
+            <button
               id="example-header-3"
               data-bs-toggle="collapse"
               className="collapse"
@@ -32,7 +32,7 @@ export const FoldableCardDefaultOpen = () =>
               >
               This card starts off in an unfolded state.
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h3>
         </div>
         <div
@@ -74,7 +74,7 @@ export const ColorAccents = () =>
       <div className="accordion-item mt-3">
         <div className="accordion-header">
           <h4>
-            <a
+            <button
               id="cardOne"
               className="collapsed"
               href="#cardBodyOne"
@@ -91,7 +91,7 @@ export const ColorAccents = () =>
             >
               Accordion gold color (default).
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h4>
         </div>
         {/* end .accordion-header */}
@@ -125,7 +125,7 @@ export const ColorAccents = () =>
       <div className="accordion-item mt-3 accordion-item-maroon">
         <div className="accordion-header">
           <h4>
-            <a
+            <button
               id="cardTwo"
               className="collapsed"
               data-bs-toggle="collapse"
@@ -142,7 +142,7 @@ export const ColorAccents = () =>
             >
               Accordion maroon color.
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h4>
         </div>
         <div
@@ -178,7 +178,7 @@ export const ColorAccents = () =>
       <div className="accordion-item mt-3 accordion-item-gray">
         <div className="accordion-header">
           <h4>
-            <a
+            <button
               id="cardThree"
               className="collapsed"
               data-bs-toggle="collapse"
@@ -195,7 +195,7 @@ export const ColorAccents = () =>
             >
               Accordion gray color.
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h4>
         </div>
         <div
@@ -227,7 +227,7 @@ export const ColorAccents = () =>
       <div className="accordion-item mt-3 accordion-item-dark">
         <div className="accordion-header">
           <h4>
-            <a
+            <button
               id="cardFour"
               className="collapsed"
               href="#cardBodyFour"
@@ -245,7 +245,7 @@ export const ColorAccents = () =>
             >
               Accordion dark color.
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h4>
         </div>
         {/* end .accordion-header */}
@@ -286,7 +286,7 @@ export const IncludedIcons = () =>
       <div className="accordion-item mt-3">
         <div className="accordion-header accordion-header-icon">
           <h4>
-            <a
+            <button
               id="cardOne"
               className="collapsed"
               href="#cardBodyOne"
@@ -306,7 +306,7 @@ export const IncludedIcons = () =>
                 Accordion with icon and gold color.
               </span>
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h4>
         </div>
         {/* end .accordion-header */}
@@ -340,7 +340,7 @@ export const IncludedIcons = () =>
       <div className="accordion-item mt-3 accordion-item-maroon">
         <div className="accordion-header accordion-header-icon">
           <h4>
-            <a
+            <button
               id="cardTwo"
               className="collapsed"
               data-bs-toggle="collapse"
@@ -360,7 +360,7 @@ export const IncludedIcons = () =>
                 Accordion with icon and maroon color.
               </span>
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h4>
         </div>
         <div
@@ -403,7 +403,7 @@ export const DisableFold = () =>
       <div className="accordion-item mt-3 desktop-disable-lg">
         <div className="accordion-header">
           <h4>
-            <a
+            <button
               id="example-header-2"
               data-bs-toggle="collapse"
               href="#example-content-2"
@@ -420,7 +420,7 @@ export const DisableFold = () =>
               >
               This will become an foldable card at the lg breakpoint.
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h4>
         </div>
         <div
@@ -446,7 +446,7 @@ export const DisableFold = () =>
       <div className="accordion-item mt-3 desktop-disable-xl">
         <div className="accordion-header">
           <h4>
-            <a
+            <button
               id="example-header-3"
               data-bs-toggle="collapse"
               className="collapsed"
@@ -463,7 +463,7 @@ export const DisableFold = () =>
               >
               Collapses to an foldable card at the xl breakpoint.
               <span className="fas fa-chevron-up"></span>
-            </a>
+            </button>
           </h4>
         </div>
         <div

--- a/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.templates.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/accordion/accordion.templates.stories.js
@@ -16,7 +16,7 @@ const Template = ({
     <div className="accordion-item mt-3">
       <div className="accordion-header">
         <h3>
-          <a
+          <button
             id={`${linkID}`}
             data-bs-toggle="collapse"
             className="collapsed"
@@ -33,7 +33,7 @@ const Template = ({
           >
             This card unfolds.
             <span className="fas fa-chevron-up"></span>
-          </a>
+          </button>
         </h3>
       </div>
       <div


### PR DESCRIPTION
fix(unity-bootstrap-theme): switch anchor to button on accordions header and added styles

UDS-1775

### Description

<!-- Description of problem -->
#### Solution
Switch over to use buttons instead of anchor tags ad that solves it for us without the need for custom javascript.
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1775)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

