### PR TITLE
fix(unity-bootstrap-theme): added css for long pagination on mobile

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_pager.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_pager.scss
@@ -140,7 +140,9 @@ span.page-link {
 }
 @include media-breakpoint-down(md) {
   .pagination {
-    gap: .4rem;
+    gap: 0rem;
+    padding-right: 0.2rem;
+    padding-left: 0.2rem;
   }
   a.page-link {
     font-size: 14px;


### PR DESCRIPTION
UDS-1754

### Description

<!-- Description of problem -->
#### Solution
Added css for long pagination on mobile
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1754)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

