### PR TITLE
UDS-1783: Add caption styles for tables

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_tables.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_tables.scss
@@ -74,6 +74,15 @@
       }
     }
   }
+
+  caption, figcaption {
+    background-color: var(--bs-gray-1);
+    caption-side: top;
+    font-size: 0.85rem;
+    padding: 1rem;
+    text-align: center;
+    word-break: break-word;
+  }
 }
 
 .uds-table-fixed {


### PR DESCRIPTION
### Description

Users can add captions in Webspark via the CKEditor, but on the front end the caption styles do not match. This PR essentially copies the caption styles, and applies then to the front end.

Testing:
- Use a Webspark CI based Drupal site
- For simplicity, you can copy the code from this PR into `renovation.style.css`
- If you do that, remember you are in a pure CSS file so you will need to ensure the code is correct: `.uds-table caption, .uds-table figcaption { ... }`
- Create a page and use the CKEditor to add a table, and add a caption to the table
- Save the page
- View the front end to ensure that the styles for the caption provide a visually similar appearance
- Since the CKEditor styles are not exact to match the ASU Brand, the aim here is not to copy them 1:1, but in order to give the user an expectation of the styles for the front end

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1783)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

