### PR TITLE
UDS-1755: fix(unity-bootstrap-theme): removed width from span in commons styles

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_charts-and-graphs.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_charts-and-graphs.scss
@@ -20,7 +20,6 @@
 
   span {
     font: normal normal 700 1.125rem Arial;
-    max-width: 60%;
   }
 
   @include media-breakpoint-down(md) {
@@ -37,6 +36,7 @@
 .uds-charts-and-graphs-overlay {
   @extend %shared-styles;
   justify-content: center;
+  width: 60%;
 }
 
 .uds-charts-and-graphs-overlay p {


### PR DESCRIPTION
UDS-1755

### Description
Removed the width: 60% from the <span> in the donut description and added this style to the parent <div>.

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1755)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

