### PR TITLE
Uds 1793: Fix onclick in header navtree

### DIFF
--- a/packages/component-header/__mocks__/data/props-mock.js
+++ b/packages/component-header/__mocks__/data/props-mock.js
@@ -16,11 +16,23 @@ const testNavTreeWithOnClickEventAndNoHref = [
     }
   },
   {
-    text: "Fun",
+    text: "Test 2",
     selected: false,
-    onClick: () => {
-      console.log("Test 2 clicked");
-    }
+    items: [
+      [
+        {
+          text: "Sublink 1",
+          selected: false,
+          onClick: () => {
+            console.log("Sublink 1 clicked");
+          },
+        },
+        {
+          href: "https://www.asu.edu/",
+          text: "Sublink 2",
+        },
+      ],
+    ]
   }
 ];
 

--- a/packages/component-header/__mocks__/data/props-mock.js
+++ b/packages/component-header/__mocks__/data/props-mock.js
@@ -1,5 +1,29 @@
 import { basicNavTree, navTreeWithButtons } from "../../src/core/utils";
 
+const testNavTreeWithOnClickEventAndNoHref = [
+  {
+    text: "Home",
+    selected: false,
+    onClick: () => {
+      console.log("Home clicked");
+    }
+  },
+  {
+    text: "Test 1",
+    selected: false,
+    onClick: () => {
+      console.log("Test 1 clicked");
+    }
+  },
+  {
+    text: "Fun",
+    selected: false,
+    onClick: () => {
+      console.log("Test 2 clicked");
+    }
+  }
+];
+
 const defaultState = {
   loggedIn: false,
   userName: "",
@@ -72,6 +96,14 @@ const onHoverState = {
   expandOnHover: true,
   breakpoint: "Lg",
 };
+const withOnClickAndNoHref = {
+  navTree: testNavTreeWithOnClickEventAndNoHref,
+  title: "Ira A. Fulton Schools of Engineering",
+  parentOrg:
+    "School of Computing, Informatics, and Decisions Systems Engineering",
+  parentOrgUrl: "https://engineering.asu.edu",
+  loggedIn: false,
+};
 
 export {
   defaultState,
@@ -80,4 +112,6 @@ export {
   withButtonsState,
   partnersState,
   onHoverState,
+  withOnClickAndNoHref,
+  testNavTreeWithOnClickEventAndNoHref
 };

--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/DropdownItem/index.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/DropdownItem/index.js
@@ -7,7 +7,68 @@ import { useAppContext } from "../../../../core/context/app-context";
 import { ButtonPropTypes } from "../../../../core/models/app-prop-types";
 import { Button } from "../../../Button";
 import { DropdownWrapper } from "./index.styles";
-import { LINK_DEFAULT_PROPS } from "../NavItem";
+
+const LINK_DEFAULT_PROPS = {
+  event: "link",
+  action: "click",
+  name: "onclick",
+  type: "internal link",
+  region: "navbar",
+  section: "main navbar",
+  text: "",
+};
+
+const HeadingItem = ({ text }) => <h3 className="ul-heading">{text}</h3>;
+
+HeadingItem.propTypes = {
+  text: PropTypes.string,
+};
+
+const ButtonItem = ({ link, dropdownName, handleLinkEvent }) => (
+  <li className="nav-button">
+    <Button
+      text={link.text}
+      color={link.color || "dark"}
+      href={link.href}
+      onClick={e => handleLinkEvent(e, link)}
+      onKeyDown={handleLinkEvent}
+      onFocus={() => trackGAEvent({ text: link.text, component: dropdownName })}
+    />
+  </li>
+);
+
+ButtonItem.propTypes = {
+  link: PropTypes.shape({
+    text: PropTypes.string,
+    color: PropTypes.string,
+    href: PropTypes.string,
+  }),
+  dropdownName: PropTypes.string,
+  handleLinkEvent: PropTypes.func,
+};
+
+const LinkItem = ({ link, dropdownName, handleLinkEvent }) => (
+  <li className="nav-link">
+    <a
+      {...(!link.href ? { tabIndex: 0 } : {})}
+      href={link.href}
+      onClick={e => handleLinkEvent(e, link)}
+      onKeyDown={e => handleLinkEvent(e, link)}
+      onFocus={() => trackGAEvent({ text: link.text, component: dropdownName })}
+    >
+      {link.text}
+    </a>
+  </li>
+);
+
+LinkItem.propTypes = {
+  link: PropTypes.shape({
+    text: PropTypes.string,
+    href: PropTypes.string,
+  }),
+  dropdownName: PropTypes.string,
+  handleLinkEvent: PropTypes.func,
+};
 
 /**
  * @typedef { import("../../../../core/models/types").Button } Button
@@ -53,7 +114,7 @@ const DropdownItem = ({
 
   const handleLinkEvent = (e, link) => {
     const { key, type, target } = e;
-    const parentElement = target.parentElement;
+    const { parentElement } = target;
 
     const focusNextLink = () => {
       const nextLink = parentElement.nextElementSibling?.firstChild;
@@ -81,39 +142,6 @@ const DropdownItem = ({
       trackGAEvent({ ...LINK_DEFAULT_PROPS, text: link.text });
     }
   };
-
-  const HeadingItem = ({ text }) => <h3 className="ul-heading">{text}</h3>;
-
-  const ButtonItem = ({ link, dropdownName }) => (
-    <li className="nav-button">
-      <Button
-        text={link.text}
-        color={link.color || "dark"}
-        href={link.href}
-        onClick={e => handleLinkEvent(e, link)}
-        onKeyDown={handleLinkEvent}
-        onFocus={() =>
-          trackGAEvent({ text: link.text, component: dropdownName })
-        }
-      />
-    </li>
-  );
-
-  const LinkItem = ({ link, dropdownName }) => (
-    <li className="nav-link">
-      <a
-        {...(!link.href ? { tabIndex: 0 } : {})}
-        href={link.href}
-        onClick={e => handleLinkEvent(e, link)}
-        onKeyDown={e => handleLinkEvent(e, link)}
-        onFocus={() =>
-          trackGAEvent({ text: link.text, component: dropdownName })
-        }
-      >
-        {link.text}
-      </a>
-    </li>
-  );
 
   const renderItem = (link, index) => {
     const key = `${link.text}-${link.href || index}`;
@@ -167,7 +195,14 @@ const DropdownItem = ({
 
 DropdownItem.propTypes = {
   dropdownName: PropTypes.string,
-  items: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)),
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string,
+      selected: PropTypes.bool,
+      onClick: PropTypes.func,
+      href: PropTypes.string,
+    })
+  ),
   buttons: PropTypes.arrayOf(PropTypes.shape(ButtonPropTypes)),
   classes: PropTypes.string,
   listId: PropTypes.string,

--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/DropdownItem/index.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/DropdownItem/index.js
@@ -148,8 +148,22 @@ const DropdownItem = ({
     if (link.type === "heading")
       return <HeadingItem key={key} text={link.text} />;
     if (link.type === "button")
-      return <ButtonItem key={key} link={link} dropdownName={dropdownName} />;
-    return <LinkItem key={key} link={link} dropdownName={dropdownName} />;
+      return (
+        <ButtonItem
+          key={key}
+          link={link}
+          dropdownName={dropdownName}
+          handleLinkEvent={handleLinkEvent}
+        />
+      );
+    return (
+      <LinkItem
+        key={key}
+        link={link}
+        dropdownName={dropdownName}
+        handleLinkEvent={handleLinkEvent}
+      />
+    );
   };
 
   return (

--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
@@ -187,7 +187,7 @@ const NavItem = ({ link, setItemOpened, itemOpened }) => {
         onClick={handleKeyDown}
         href={link.href}
         {...(link.items ? { "aria-expanded": opened } : {})}
-        {...(!link.href ? {tabIndex: 0} : {})}
+        {...(!link.href ? { tabIndex: 0 } : {})}
         aria-owns={link.items ? `dropdown-${link.id}` : null}
         className={`${link.class ? link.class : ""}${
           link.selected ? " nav-item-selected" : ""

--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/NavItem/index.js
@@ -160,6 +160,9 @@ const NavItem = ({ link, setItemOpened, itemOpened }) => {
     } else if (e.type === "click" && link.items) {
       e.preventDefault();
       setItemOpened();
+    } else if (e.type === "click") {
+      dispatchGAEvent();
+      link.onClick?.(e);
     }
   };
 
@@ -184,6 +187,7 @@ const NavItem = ({ link, setItemOpened, itemOpened }) => {
         onClick={handleKeyDown}
         href={link.href}
         {...(link.items ? { "aria-expanded": opened } : {})}
+        {...(!link.href ? {tabIndex: 0} : {})}
         aria-owns={link.items ? `dropdown-${link.id}` : null}
         className={`${link.class ? link.class : ""}${
           link.selected ? " nav-item-selected" : ""

--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/index.test.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/index.test.js
@@ -8,7 +8,7 @@ import { NavbarContainer } from ".";
 import {
   defaultState,
   onHoverState,
-  testNavTreeWithOnClickEventAndNoHref
+  testNavTreeWithOnClickEventAndNoHref,
 } from "../../../../__mocks__/data/props-mock";
 import { AppContextProvider } from "../../../core/context/app-context";
 
@@ -78,18 +78,19 @@ describe("#Navbar Container Component with onClick and no href", () => {
   /** @type {import("@testing-library/react").RenderResult} */
   let component;
   let navItems;
-  let onClick = jest.fn();
+  const onClick = jest.fn();
 
   beforeEach(() => {
     component = renderNavbarContainer({
       title: "Ira A. Fulton Schools of Engineering",
-      parentOrg: "School of Computing, Informatics, and Decisions Systems Engineering",
+      parentOrg:
+        "School of Computing, Informatics, and Decisions Systems Engineering",
       parentOrgUrl: "https://engineering.asu.edu",
       loggedIn: false,
       navTree: testNavTreeWithOnClickEventAndNoHref.map(item => ({
         ...item,
-        onClick: item.items?.length ? undefined : () => onClick()
-      }))
+        onClick: item.items?.length ? undefined : () => onClick(),
+      })),
     });
     navItems = component.queryAllByTestId("nav-item");
   });

--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/index.test.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/index.test.js
@@ -83,14 +83,13 @@ describe("#Navbar Container Component with onClick and no href", () => {
   beforeEach(() => {
     component = renderNavbarContainer({
       title: "Ira A. Fulton Schools of Engineering",
-  parentOrg:
-    "School of Computing, Informatics, and Decisions Systems Engineering",
-  parentOrgUrl: "https://engineering.asu.edu",
-  loggedIn: false,
-  navTree: testNavTreeWithOnClickEventAndNoHref.map(item => ({
-    ...item,
-    onClick: () => onClick()
-  }))
+      parentOrg: "School of Computing, Informatics, and Decisions Systems Engineering",
+      parentOrgUrl: "https://engineering.asu.edu",
+      loggedIn: false,
+      navTree: testNavTreeWithOnClickEventAndNoHref.map(item => ({
+        ...item,
+        onClick: item.items?.length ? undefined : () => onClick()
+      }))
     });
     navItems = component.queryAllByTestId("nav-item");
   });
@@ -99,5 +98,11 @@ describe("#Navbar Container Component with onClick and no href", () => {
   it("should call onClick", () => {
     fireEvent.click(navItems[0]);
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it("should open up the dropdown on the 3rd link", () => {
+    fireEvent.click(navItems[2]);
+    const dropdown = component.container.querySelector("#dropdown-2");
+    expect(dropdown).toBeVisible();
   });
 });

--- a/packages/component-header/src/components/HeaderMain/NavbarContainer/index.test.js
+++ b/packages/component-header/src/components/HeaderMain/NavbarContainer/index.test.js
@@ -8,6 +8,7 @@ import { NavbarContainer } from ".";
 import {
   defaultState,
   onHoverState,
+  testNavTreeWithOnClickEventAndNoHref
 } from "../../../../__mocks__/data/props-mock";
 import { AppContextProvider } from "../../../core/context/app-context";
 
@@ -70,5 +71,33 @@ describe("#Navbar Container Component opened/closed on hover", () => {
     fireEvent.mouseEnter(navItems[0].parentElement);
     fireEvent.mouseLeave(navItems[0].parentElement);
     expect(navItems[0].className).not.toContain("open-link");
+  });
+});
+
+describe("#Navbar Container Component with onClick and no href", () => {
+  /** @type {import("@testing-library/react").RenderResult} */
+  let component;
+  let navItems;
+  let onClick = jest.fn();
+
+  beforeEach(() => {
+    component = renderNavbarContainer({
+      title: "Ira A. Fulton Schools of Engineering",
+  parentOrg:
+    "School of Computing, Informatics, and Decisions Systems Engineering",
+  parentOrgUrl: "https://engineering.asu.edu",
+  loggedIn: false,
+  navTree: testNavTreeWithOnClickEventAndNoHref.map(item => ({
+    ...item,
+    onClick: () => onClick()
+  }))
+    });
+    navItems = component.queryAllByTestId("nav-item");
+  });
+  afterAll(cleanup);
+
+  it("should call onClick", () => {
+    fireEvent.click(navItems[0]);
+    expect(onClick).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Description
fixed navtree with onclick not getting called

<!-- Testing Steps -->
1. Add these props to a story `
navTree: [
  {
    text: "Home",
    selected: false,
    onClick: () => {
      console.log("Home clicked");
    }
  },
  {
    text: "Test 1",
    selected: false,
    onClick: () => {
      console.log("Test 1 clicked");
    }
  },
  {
    text: "Fun",
    selected: false,
    onClick: () => {
      console.log("Test 2 clicked");
    }
  }
],
  title: "Ira A. Fulton Schools of Engineering",
  parentOrg:
    "School of Computing, Informatics, and Decisions Systems Engineering",
  parentOrgUrl: "https://engineering.asu.edu",
  loggedIn: false,`
2. Check to make sure the oncall is called and that it is keyboard navigable

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1793?atlOrigin=eyJpIjoiMDVkZDRkYjg0YzNhNDc3MmEyZWY3NzExODM1ZDUzMDIiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

