### PR TITLE
fix(component-news): remove KE from default news header

### DIFF
--- a/packages/component-news/src/core/constants/default-props.js
+++ b/packages/component-news/src/core/constants/default-props.js
@@ -4,7 +4,7 @@
 const defaultProps = {
   header: {
     color: "dark",
-    text: "Knowledge and enterprise news",
+    text: "",
   },
   ctaButton: {
     color: "gold",


### PR DESCRIPTION
remove KE from default news header in src/core/constants/default-props.js

### Description

News component heading defaults to "Knowledge and enterprise news" and should be removed.


### Testing steps

In storybook, go to News component and remove header text in the controls. If the heading "Knowledge and enterprise news" doesn't appear, then the issue is fixed.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1811)



