### PR TITLE
fix(app-rfi): Entry dates should not have dups

### DIFF
--- a/packages/app-rfi/src/components/steps/questions/EntryTerm.js
+++ b/packages/app-rfi/src/components/steps/questions/EntryTerm.js
@@ -59,14 +59,43 @@ export const EntryTerm = ({ gaData }) => {
       values.Campus !== KEY.ONLINE &&
       degreeData.degreeType === KEY.GR
     ) {
-      // Convert object to array so we can .sort and .map.
       const termData = degreeData.applicationDeadlines
         ?.sort((a, b) => (a.strm > b.strm ? 1 : -1))
-        .map(({ strm, strmDescription }, i) => ({
-          key: `${i}`,
-          value: strm,
-          text: strmDescription,
-        }));
+        /**
+         * if program is offered at more than one campus it is possible for each
+         * campus to duplicate the entry date. Since this list does not show the
+         * campus, we need to check and remove duplicate items.
+         *
+         * Example (item 1 and 3):
+         * "applicationDeadlines": [
+          {
+              "campus": "ONLNE",
+              "strm": "2251",
+              "strmDescription": "2025 Spring",
+              ...
+          },
+          {
+              "campus": "ONLNE",
+              "strm": "2257",
+              "strmDescription": "2025 Fall",
+              ...
+          },{
+              "campus": "TEMPE",
+              "strm": "2251",
+              "strmDescription": "2025 Spring",
+              ...
+          },
+         */
+        .reduce((result, { strm, strmDescription }) => {
+          if (!result.find(item => item.value === strm)) {
+            result.push({
+              key: `${strm}`,
+              value: strm,
+              text: strmDescription,
+            });
+          }
+          return result;
+        }, []);
       if (termData && termData.length > 0) {
         setTermOptions(termData);
       }


### PR DESCRIPTION
### Description

Anticipate starting dates repeat on some programs.
Caused by more than one campus having the same start date

to reproduce use `BAACCMACC`

https://api.myasuplat-dpl.asu.edu/api/codeset/acad-plan/BAACCMACC?include=degreeDescriptionShort&include=degreeDescriptionLong&include=campusesOffered&include=planCategories&include=degreeType&include=applicationDeadlines

### Links

- [JIRA ticket](https://asudev.jira.com/browse/ERFI-154)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

