### PR TITLE
fix(app-webdir-ui): prevent SearchResultsList from fetching titles when there are no results

### DIFF
--- a/packages/app-webdir-ui/src/SearchResultsList/dataFormatter.js
+++ b/packages/app-webdir-ui/src/SearchResultsList/dataFormatter.js
@@ -100,9 +100,11 @@ export class ProfileService {
    * "title" and "dept_name" field to the individual results used in dataConverter.js
    */
   async processProfiles(term, filteredResults) {
-    if (!this.engine.doTitleLogic) {
+    if (this.engine.method === "POST") return filteredResults;
+    if (!this.engine.doTitleLogic || filteredResults.results.length < 1) {
       return filteredResults;
     }
+
     await this.getSessionToken();
     /**
      * If term is present, request is coming from search page


### PR DESCRIPTION
prevent SearchResultsList from fetching titles when there are no results

Also added early return for any webdirectory that has the method of POST, since these already have the title info 

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

![Screen Shot 2024-09-20 at 11 59 41 AM](https://github.com/user-attachments/assets/d405f0d8-6bff-4821-b555-01b1927c1c9e)
