### PR TITLE
fix(unity-bootstrap-theme): fix padding in image background with cta

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_image-background-with-cta.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_image-background-with-cta.scss
@@ -24,6 +24,7 @@
       font: normal normal bold 2.5rem Arial;
       flex: 1;
       max-width: 784px;
+      padding-bottom: $uds-size-spacing-4;
     }
   }
 }
@@ -47,7 +48,6 @@
 
       & > span {
         font-size: $uds-size-font-xxl; // 2rem
-        margin-bottom: $uds-size-spacing-4; // 2rem
         max-width: 512px;
       }
     }


### PR DESCRIPTION
### Description
fix padding in image background with cta. Padding on desktop was wrong because padding was only being applied to mobile screens and did not take into account for 3 columns. Removed unnecessary padding/margin on smaller screens since ti can be applied to all screens


### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1749)
- [Unity reference site](https://asu.github.io/asu-unity-stack/@asu/unity-bootstrap-theme/index.html?path=/story/molecules-content-sections-image-background-with-call-to-action-templates--default)
- [ZeroHeight](https://zeroheight.com/9f0b32a56/p/435806-call-to-action-on-image-background/b/324321)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)

