### PR TITLE
chore: add preflight check to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
+<!--   - CHECK: Do tests need to be added or updated? -->
+<!--   - CHECK: Are data layer additions or updates needed? -->
+
 ### Description
 
 <!-- Description of problem -->
@@ -13,4 +17,3 @@
 ### FOR APPROVERS
 
 - [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
-


### PR DESCRIPTION
### Description

Adding a preflight check section to the PR request template. Intent is that this section is reviewed and removed by the PR creator before the PR is submitted.  It's easy to forget to include tests or test updates and data layer additions and updates.

I'm hoping this won't be as easy to "look past" as the older checklist we had...

I didn't add it as a checklist to remain on the content... but we could do that. Thoughts?