### PR TITLE
UDS-1838: fix(component-carousel): added style for pinch zoom on carousels

### DIFF
--- a/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
+++ b/packages/component-carousel/src/core/components/BaseCarousel/glide/glide.theme.scss
@@ -124,6 +124,7 @@ $uds-color-brand-gold: #ffc627; // ASU Gold brand color
 
     .glide__slides {
       margin-bottom: 0;
+      touch-action: auto;
       .glide__slide {
         .card {
           width: 100%;


### PR DESCRIPTION
UDS-1838

<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

#### Description of problem 
Unable to pinch zoom for this component on mobile devices. While viewing this component on a mobile device, when I pinch the mobile screen to zoom in/out, nothing happens. Thus, users with vision difficulties will be unable to zoom into the component for easier reading.
#### Solution
Added style for pinch zoom on carousels
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1838)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
