### PR TITLE
chore(unity-react-core): update plop template to use react 18.3.1

### DIFF
--- a/packages/unity-react-core/plop/general/example-html.txt
+++ b/packages/unity-react-core/plop/general/example-html.txt
@@ -19,13 +19,12 @@
 
   <!-- *************************************************************** -->
   <!-- Load React. -->
-  <!-- Note: when deploying, replace "development.js" with "production.min.js". -->
   <!-- ATTENTION! IF REACT IS NOT BUNDLED INTO THE LIBRARY UNCOMMENT
         THOSE LINES BELOW
       -->
   <!-- *************************************************************** -->
-  <script src="https://unpkg.com/react@17/umd/react.production.min.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" crossorigin></script>
   <!-- *************************************************************** -->
   <!-- include bundled scripts from packages -->
   <script src="../dist/unityReactCore.umd.js"></script>


### PR DESCRIPTION
### Description

Example story failed to work with minimally helpful error when I was doing Grid Links. Turned out to be that the example template file was still pointing to React 17. This fixes that.

### Links

- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)