### PR TITLE
fix(unity-react-core): add data layer to grid links

### DIFF
--- a/packages/unity-react-core/examples/grid-links.html
+++ b/packages/unity-react-core/examples/grid-links.html
@@ -28,6 +28,7 @@
   <!-- *************************************************************** -->
   <!-- include bundled scripts from packages -->
   <script src="../dist/unityReactCore.umd.js"></script>
+
 </head>
 
 <body>
@@ -87,6 +88,9 @@
         numColumns: "three-columns",
         textColor: "text-gold",
         gridLinkItems: gridLinkItems,
+        // Optionally set useExternal true to display data-ga* attributes for
+        // non-React app data layer implementations.
+        useExternal: false,
         // children: "Optional children can go here",
       },
     });

--- a/packages/unity-react-core/src/components/GridLinks/GridLinks.stories.tsx
+++ b/packages/unity-react-core/src/components/GridLinks/GridLinks.stories.tsx
@@ -59,10 +59,12 @@ const gridLinkItems = [
 const defaultStoryProps = {
   numColumns: gridLinksNumColumns.TWO_COLUMNS,
   textColor: gridLinksTextColor.NONE,
-  gridLinkItems: gridLinkItems,
+  gridLinkItems,
   // children: "Content to be displayed",
   // bgColor is used story section wrapper, not in component.
   bgColor: gridLinksBgColor.NONE,
+  // Display the data-ga attributes on the links for Storybook HTML references.
+  useExternal: true,
 };
 
 const gridLinksTemplate = ({ bgColor, ...args }) => (

--- a/packages/unity-react-core/src/components/GridLinks/GridLinks.test.tsx
+++ b/packages/unity-react-core/src/components/GridLinks/GridLinks.test.tsx
@@ -3,10 +3,7 @@ import React from "react";
 import { expect, describe, it, afterEach, beforeEach } from "vitest";
 
 import { GridLinks, GridLinksProps } from "./GridLinks";
-import {
-  gridLinksNumColumns,
-  gridLinksTextColor,
-} from "./GridLinksConstants";
+import { gridLinksNumColumns, gridLinksTextColor } from "./GridLinksConstants";
 
 const gridLinkItems = [
   {
@@ -33,8 +30,9 @@ const gridLinkItems = [
 const defaultProps = {
   numColumns: gridLinksNumColumns.TWO_COLUMNS,
   textColor: gridLinksTextColor.NONE,
-  gridLinkItems: gridLinkItems,
+  gridLinkItems,
   // children: "Content to be displayed",
+  useExternal: false,
 };
 
 const renderComponent = (props: GridLinksProps) => {

--- a/packages/unity-react-core/src/components/GridLinks/GridLinks.tsx
+++ b/packages/unity-react-core/src/components/GridLinks/GridLinks.tsx
@@ -1,9 +1,19 @@
 import React, { ReactElement } from "react";
+
+import { dataLayerRender } from "../../../../../shared/utils/datalayer-render";
 import {
   gridLinksNumColumns,
   gridLinksTextColor,
   gridLinksTextColorClassName,
 } from "./GridLinksConstants";
+
+const gaDefaultObject = {
+  name: "onclick",
+  event: "link",
+  action: "click",
+  type: "internal link",
+  region: "main content",
+};
 
 export interface GridLinksProps {
   /**
@@ -19,16 +29,22 @@ export interface GridLinksProps {
    */
   textColor?: gridLinksTextColor;
   /**
+   * Use external. True adds data-ga* attributes to HTML. False (default)
+   * enables internal React-based data layer handling.
+   */
+  useExternal?: boolean;
+  /**
    * The element where we will position the dialog beside.
    */
   children?: ReactElement | ReactElement[] | string;
 }
 
 export const GridLinks: React.FC<GridLinksProps> = ({
-  children,
+  gridLinkItems,
   numColumns,
   textColor,
-  gridLinkItems,
+  useExternal = false,
+  children,
 }) => {
   return (
     <>
@@ -40,9 +56,20 @@ export const GridLinks: React.FC<GridLinksProps> = ({
         ].join(" ")}
       >
         {gridLinkItems &&
-          gridLinkItems.map((item, index) => (
-            <a key={index} href={item.href}>
-              <span className={`fa fa-fw ${item.icon}`}></span>
+          gridLinkItems.map(item => (
+            <a
+              key={item.label + item.href}
+              href={item.href}
+              {...dataLayerRender(
+                {
+                  ...gaDefaultObject,
+                  text: item.label,
+                  section: `grid links ${item.label}`,
+                },
+                useExternal
+              )}
+            >
+              <span className={`fa fa-fw ${item.icon}`} />
               {item.label}
             </a>
           ))}

--- a/shared/utils/datalayer-render.js
+++ b/shared/utils/datalayer-render.js
@@ -1,0 +1,23 @@
+// @ts-check
+import { trackGAEvent } from "../services/googleAnalytics";
+
+export function dataLayerRender(gaObject, useExternal) {
+  if (useExternal) {
+    return {
+      "data-ga": gaObject.text,
+      "data-ga-name": gaObject.name,
+      "data-ga-event": gaObject.event,
+      "data-ga-action": gaObject.action,
+      "data-ga-type": gaObject.type,
+      "data-ga-region": gaObject.region,
+      "data-ga-section": gaObject.section,
+      "data-ga-component": "",
+    }
+  } else {
+    return {
+      onClick: (e) => {
+        trackGAEvent(gaObject);
+      },
+    };
+  }
+}

--- a/shared/utils/datalayer-render.js
+++ b/shared/utils/datalayer-render.js
@@ -1,23 +1,21 @@
 // @ts-check
 import { trackGAEvent } from "../services/googleAnalytics";
 
+const convertToDataAttr = d => ({
+  "data-ga": d.text,
+  "data-ga-name": d.name,
+  "data-ga-event": d.event,
+  "data-ga-action": d.action,
+  "data-ga-type": d.type,
+  "data-ga-region": d.region,
+  "data-ga-section": d.section,
+  "data-ga-component": d.component,
+});
+
+const convertToClickHandler = d => ({ onClick: e => trackGAEvent(d) });
+
 export function dataLayerRender(gaObject, useExternal) {
-  if (useExternal) {
-    return {
-      "data-ga": gaObject.text,
-      "data-ga-name": gaObject.name,
-      "data-ga-event": gaObject.event,
-      "data-ga-action": gaObject.action,
-      "data-ga-type": gaObject.type,
-      "data-ga-region": gaObject.region,
-      "data-ga-section": gaObject.section,
-      "data-ga-component": "",
-    }
-  } else {
-    return {
-      onClick: (e) => {
-        trackGAEvent(gaObject);
-      },
-    };
-  }
+  return useExternal
+    ? convertToDataAttr(gaObject)
+    : convertToClickHandler(gaObject);
 }


### PR DESCRIPTION
### Description

We needed a pattern for the data layer that could be used for this and other instances of design components that are implemented in `unity-react-core`. Requirements
* Allows for "non-React" output that shows the `data-ga*` attributes like we use in CMS contexts
* Allows for default React behavior that uses existing internal datalayer handling and doesn't display `data-ga*` attributes.
* Allows for configurability and customization to for component data layer object variations.
* Displays helpful and meaningful example output and controls within the Storybook UI.

Adds datalayer-render.js shared util.

This PR was made separate from the rest of the ticket so it can be used as a reference to the proposed pattern.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1869)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

