### PR TITLE
chore: static site rank logo name fixed

### DIFF
--- a/server/storybook-index-generator.js
+++ b/server/storybook-index-generator.js
@@ -203,7 +203,7 @@ module.exports = generateHTML = packages => `
                 href="https://www.asu.edu/rankings"
               >
                 <img
-                  src="./@asu/unity-bootstrap-theme/img/innovation-lockup/on-gold/2024-ranked-1.png"
+                  src="./@asu/unity-bootstrap-theme/img/innovation-lockup/on-gold/footer-rank.png"
                   alt="Number one in the U.S. for innovation. #1 ASU, #2 Stanford, #3 MIT. - U.S. News and World Report, 5 years, 2016-2020"
                 />
               </a>


### PR DESCRIPTION

### Description

Missed in previous PR for this update. Will fix broken path to rank logo in static site.