### PR TITLE
Uds 1866 notification banner

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
@@ -9,7 +9,7 @@
 
   .banner-icon {
     text-align: left;
-    svg {
+    svg, i, span {
       font-size: $uds-size-spacing-4;
       margin: calc(#{$uds-size-spacing-1} / 2) $uds-size-spacing-4
         calc(#{$uds-size-spacing-1} / 2) 0;
@@ -111,7 +111,7 @@
       flex: 1;
       margin-bottom: $uds-size-spacing-1;
 
-      svg {
+      svg, i, span {
         font-size: $uds-size-spacing-5;
         margin: $uds-size-spacing-0;
       }

--- a/packages/unity-react-core/src/components/Button/Button.jsx
+++ b/packages/unity-react-core/src/components/Button/Button.jsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { gaDataType } from "../../core/models/shared-prop-types";
 import { GaEventWrapper } from "../GaEventWrapper/GaEventWrapper";
 
 const gaDefaultObject = {
@@ -25,6 +26,7 @@ const gaDefaultObject = {
 export const Button = ({
   label,
   cardTitle,
+  gaData,
   ariaLabel,
   block,
   color,
@@ -52,13 +54,14 @@ export const Button = ({
     Tag = "a";
   }
 
-  const handleClick = text => {
-    onClick?.();
-  };
-
   return (
     <GaEventWrapper
-      gaData={{ ...gaDefaultObject, text: label, section: cardTitle }}
+      gaData={{
+        ...gaDefaultObject,
+        section: cardTitle, // @deprecated - remove at some point
+        ...gaData,
+        text: label,
+      }}
     >
       <Tag
         type={Tag === "button" && onClick ? "button" : undefined}
@@ -66,7 +69,7 @@ export const Button = ({
         className={classNames(classes) || btnClasses}
         href={href}
         ref={innerRef}
-        onClick={handleClick}
+        onClick={onClick}
         aria-label={ariaLabel}
         target={Tag === "a" ? target : null}
       >
@@ -83,9 +86,14 @@ Button.propTypes = {
    */
   label: PropTypes.string,
   /**
-   * Card title
+   * @deprecated
+   * Card title, use `gaData.section` instead
    */
   cardTitle: PropTypes.string,
+  /**
+   * Google Analytics event data
+   */
+  gaData: gaDataType,
   /**
     ARIA label for accessibility
   */

--- a/packages/unity-react-core/src/components/ButtonIconOnly/ButtonIconOnly.jsx
+++ b/packages/unity-react-core/src/components/ButtonIconOnly/ButtonIconOnly.jsx
@@ -2,6 +2,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { gaDataType } from "../../core/models/shared-prop-types";
 import { GaEventWrapper } from "../GaEventWrapper/GaEventWrapper";
 
 const gaDefaultObject = {
@@ -28,6 +29,7 @@ export const ButtonIconOnly = ({
   size,
   cardTitle,
   className,
+  gaData,
   ...rest
 }) => {
   const handleClick = () => {
@@ -38,8 +40,9 @@ export const ButtonIconOnly = ({
     <GaEventWrapper
       gaData={{
         ...gaDefaultObject,
+        section: cardTitle, // @deprecated - remove at some point
+        ...gaData,
         text: `${icon?.[1]} icon`,
-        section: cardTitle,
       }}
     >
       <button
@@ -82,9 +85,14 @@ ButtonIconOnly.propTypes = {
   */
   onClick: PropTypes.func,
   /**
-   * Card title
+   * @deprecated
+   * Card title, use `gaData.section` instead
    */
   cardTitle: PropTypes.string,
+  /**
+   * Google Analytics event data
+   */
+  gaData: gaDataType,
   /**
     Button size
   */

--- a/packages/unity-react-core/src/components/ButtonTag/ButtonTag.jsx
+++ b/packages/unity-react-core/src/components/ButtonTag/ButtonTag.jsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { gaDataType } from "../../core/models/shared-prop-types";
 import { GaEventWrapper } from "../GaEventWrapper/GaEventWrapper";
 
 const gaDefaultObject = {
@@ -25,6 +26,7 @@ const gaDefaultObject = {
 export const ButtonTag = ({
   label,
   cardTitle,
+  gaData,
   ariaLabel,
   color,
   disabled,
@@ -48,7 +50,12 @@ export const ButtonTag = ({
 
   return (
     <GaEventWrapper
-      gaData={{ ...gaDefaultObject, text: label, section: cardTitle }}
+      gaData={{
+        ...gaDefaultObject,
+        section: cardTitle, // @deprecated - remove at some point
+        ...gaData,
+        text: label,
+      }}
     >
       {/* @ts-ignore */}
       <Tag
@@ -72,9 +79,14 @@ ButtonTag.propTypes = {
   */
   label: PropTypes.string,
   /**
-   * Card title
+   * @deprecated
+   * Card title, use `gaData.section` instead
    */
   cardTitle: PropTypes.string,
+  /**
+   * Google Analytics event data
+   */
+  gaData: gaDataType,
   /**
     ARIA label for accessibility
   */

--- a/packages/unity-react-core/src/components/ComponentCarousel/components/CardCarousel/CardCarousel.jsx
+++ b/packages/unity-react-core/src/components/ComponentCarousel/components/CardCarousel/CardCarousel.jsx
@@ -8,11 +8,10 @@
  *
  */
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import { Card } from "../../../Card/Card";
 import { BaseCarousel } from "../../core/components/BaseCarousel";
-import { useEffect, useState } from "react";
 
 /**
  * @typedef {import('../../core/components/BaseCarousel').CarouselItem} CarouselItem

--- a/packages/unity-react-core/src/components/GaEventWrapper/GaEventWrapper.jsx
+++ b/packages/unity-react-core/src/components/GaEventWrapper/GaEventWrapper.jsx
@@ -2,13 +2,13 @@
  * GaEventType represents the structure of Google Analytics event data.
  *
  * @typedef {Object} GaEventType
- * @property {string} text - The text associated with the event.
- * @property {string} name - The name of the event.
- * @property {string} event - The event type.
- * @property {string} action - The action taken.
- * @property {string} type - The type of event.
- * @property {string} region - The region where the event occurred.
- * @property {string} section - The section of the application.
+ * @property {string} [text] - The text associated with the event.
+ * @property {string} [name] - The name of the event.
+ * @property {string} [event] - The event type.
+ * @property {string} [action] - The action taken.
+ * @property {string} [type] - The type of event.
+ * @property {string} [region] - The region where the event occurred.
+ * @property {string} [section] - The section of the application.
  * @property {string} [component] - The component associated with the event.
  */
 

--- a/packages/unity-react-core/src/components/NotificationBanner/NotificationBanner.stories.tsx
+++ b/packages/unity-react-core/src/components/NotificationBanner/NotificationBanner.stories.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+import {
+  NotificationBanner,
+  NotificationBannerProps,
+} from "./NotificationBanner";
+
+export default {
+  title: "More Examples/Notification Banner",
+  component: NotificationBanner,
+  args: { color: "orange" },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Example only. Not currently included in unity-react-core package. A notification banner to alert users of important information.",
+      },
+    },
+  },
+};
+
+const defaultProps: NotificationBannerProps = {
+  title: "Stay up-to-date on what's new at ASU",
+  children: (
+    <>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud{" "}
+      <a href="https://asunow.asu.edu/">read the latest updates here</a>
+    </>
+  ),
+  buttons: [
+    {
+      href: "https://provost.asu.edu/sync/students",
+      label: "Info. on teaching and learning remotely",
+    },
+    {
+      href: "https://students.asu.edu/faq",
+      label: " FAQ Page",
+    },
+  ],
+};
+
+const notificationBannerTemplate = args => <NotificationBanner {...args} />;
+
+export const Overview = {
+  render: notificationBannerTemplate.bind({}),
+  args: {
+    ...defaultProps,
+  },
+};

--- a/packages/unity-react-core/src/components/NotificationBanner/NotificationBanner.stories.tsx
+++ b/packages/unity-react-core/src/components/NotificationBanner/NotificationBanner.stories.tsx
@@ -6,9 +6,16 @@ import {
 } from "./NotificationBanner";
 
 export default {
-  title: "More Examples/Notification Banner",
+  title: "Components/Notification Banner",
   component: NotificationBanner,
   args: { color: "orange" },
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+  },
   parameters: {
     docs: {
       description: {

--- a/packages/unity-react-core/src/components/NotificationBanner/NotificationBanner.test.tsx
+++ b/packages/unity-react-core/src/components/NotificationBanner/NotificationBanner.test.tsx
@@ -1,0 +1,68 @@
+import {
+  render,
+  cleanup,
+  RenderResult,
+  fireEvent,
+} from "@testing-library/react";
+import React from "react";
+import { expect, describe, it, afterEach, beforeEach } from "vitest";
+
+import {
+  NotificationBanner,
+  NotificationBannerProps,
+} from "./NotificationBanner";
+
+const defaultProps: NotificationBannerProps = {
+  title: "Header",
+  children: "Content",
+  color: "orange",
+};
+
+const renderComponent = (props: NotificationBannerProps) => {
+  return render(<NotificationBanner {...props} />);
+};
+
+describe("NotificationBanner tests", () => {
+  let component: RenderResult;
+
+  beforeEach(() => {
+    component = renderComponent(defaultProps);
+  });
+
+  afterEach(cleanup);
+
+  it("should define component", () => {
+    expect(component).toBeDefined();
+  });
+
+  it("should render title", () => {
+    const { getByText } = component;
+    expect(getByText("Header")).toBeInTheDocument();
+  });
+
+  it("should render children", () => {
+    const { getByText } = component;
+    expect(getByText("Content")).toBeInTheDocument();
+  });
+
+  it("should render with default color", () => {
+    const { container } = component;
+    expect(container.firstChild).toHaveClass("banner-orange");
+  });
+
+  it("should render buttons if provided", () => {
+    const props: NotificationBannerProps = {
+      ...defaultProps,
+      buttons: [{ href: "#", label: "Click me" }],
+    };
+    const { getByText } = renderComponent(props);
+    expect(getByText("Click me")).toBeInTheDocument();
+  });
+
+  it("should close the banner when close button is clicked", () => {
+    const { getByLabelText, queryByRole } = component;
+    const closeButton = getByLabelText("Close");
+    fireEvent.click(closeButton);
+    expect(queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/packages/unity-react-core/src/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/unity-react-core/src/components/NotificationBanner/NotificationBanner.tsx
@@ -1,0 +1,82 @@
+import cx from "classnames";
+import React, { ReactElement, useState } from "react";
+
+import { Button } from "../Button/Button";
+import { ButtonIconOnly } from "../ButtonIconOnly/ButtonIconOnly";
+import { useBaseSpecificFramework } from "../GaEventWrapper/useBaseSpecificFramework";
+
+export interface NotificationBannerProps {
+  /**
+   * Title or heading.
+   */
+  title?: string;
+  /**
+   * Optional buttons to display in the banner.
+   */
+  buttons?: { href: string; label: string }[];
+  /**
+   * Background color of the banner.
+   */
+  color?: "orange" | "blue" | "gray" | "black";
+  /**
+   * Main content in the banner.
+   */
+  children: ReactElement | ReactElement[] | string;
+}
+
+export const NotificationBanner: React.FC<NotificationBannerProps> = ({
+  title,
+  color = "orange",
+  buttons = [],
+  children,
+}) => {
+  const { isBootstrap, isReact } = useBaseSpecificFramework();
+  const [isVisible, setIsVisible] = useState(true);
+  const handleClose = () => setIsVisible(false);
+
+  return (
+    isVisible && (
+      <div role="alert" className={`banner-${color} alert alert-dismissable`}>
+        <div className="banner uds-content-align">
+          <div className="banner-icon">
+            <span className="fa fa-icon fa-bell" />
+          </div>
+          <div className="banner-content">
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+            <h1 tabIndex={0}>{title}</h1>
+            {children}
+          </div>
+          {buttons.length && (
+            <div className="banner-buttons">
+              {buttons.map(item => (
+                <Button
+                  key={`${item.label}${item.href}`}
+                  classes={cx("btn btn-sm", {
+                    "btn-dark": color !== "black",
+                    "btn-light": color === "black",
+                  })}
+                  href={item.href}
+                  label={item.label}
+                  gaData={{
+                    section: "NotificationBanner",
+                  }}
+                />
+              ))}
+            </div>
+          )}
+          <div className="banner-close">
+            <ButtonIconOnly
+              aria-label="Close"
+              icon={["fas", "times"]}
+              onClick={isReact && handleClose}
+              data-bs-dismiss={isBootstrap && "alert"}
+              gaData={{
+                section: "NotificationBanner",
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    )
+  );
+};

--- a/packages/unity-react-core/src/components/NotificationBanner/init.js
+++ b/packages/unity-react-core/src/components/NotificationBanner/init.js
@@ -1,0 +1,1 @@
+export { initNotificationBanner as default } from "../../core/utils";

--- a/packages/unity-react-core/src/components/NotificationBanner/init.js
+++ b/packages/unity-react-core/src/components/NotificationBanner/init.js
@@ -1,1 +1,1 @@
-export { initNotificationBanner as default } from "../../core/utils";
+// export { initNotificationBanner as default } from "../../core/utils";

--- a/packages/unity-react-core/src/core/models/shared-prop-types.js
+++ b/packages/unity-react-core/src/core/models/shared-prop-types.js
@@ -24,4 +24,15 @@ const accordionCardPropTypes = PropTypes.shape({
   }),
 });
 
-export { imagePropType, contentPropType, accordionCardPropTypes };
+const gaDataType = PropTypes.shape({
+  text: PropTypes.string,
+  name: PropTypes.string,
+  event: PropTypes.string,
+  action: PropTypes.string,
+  type: PropTypes.string,
+  region: PropTypes.string,
+  section: PropTypes.string,
+  component: PropTypes.string,
+});
+
+export { imagePropType, contentPropType, accordionCardPropTypes, gaDataType };

--- a/packages/unity-react-core/src/core/types/shared-types.js
+++ b/packages/unity-react-core/src/core/types/shared-types.js
@@ -3,7 +3,8 @@
 /**
  * @typedef {Object} ButtonProps
  * @property {string}   [label]
- * @property {string}   [cardTitle]
+ * @property {string}   [cardTitle] // @deprecated
+ * @property {import("../../components/GaEventWrapper/GaEventWrapper").GaEventType} [gaData]
  * @property {string}   [ariaLabel]
  * @property {boolean}  [block]
  * @property {boolean}  [disabled]
@@ -11,7 +12,7 @@
  * @property {string}   [href]
  * @property {string[]} [icon]
  * @property {any}      [innerRef]
- * @property {string[]} [classes]
+ * @property {string|string[]} [classes]
  * @property {function():void} [onClick]
  * @property {"default"|"small"|"xsmall"}   [size]
  * @property {"gold"|"maroon"|"gray"|"dark"} [color]
@@ -25,14 +26,16 @@
  * @property {React.RefObject} [innerRef]
  * @property {function():void} [onClick]
  * @property {"large"|"small"} [size]
- * @property {string}   [cardTitle]
+ * @property {string}   [cardTitle] // @deprecated
+ * @property {import("../../components/GaEventWrapper/GaEventWrapper").GaEventType} [gaData]
  * @property {string}   [className]
  */
 
 /**
  * @typedef {Object} TagsProps
  * @property {string}  [label]
- * @property {string}   [cardTitle]
+ * @property {string}   [cardTitle] // @deprecated
+ * @property {import("../../components/GaEventWrapper/GaEventWrapper").GaEventType} [gaData]
  * @property {string}  [ariaLabel]
  * @property {string}  [color]
  * @property {boolean} [disabled]
@@ -85,7 +88,7 @@
  * @callback ReactMouseEvent
  * @param {React.MouseEvent<HTMLAnchorElement, MouseEvent>} event
  * @param {number} id
- * @param {string} [cardTitle]
+ * @param {string} [cardTitle] // @deprecated
  * @returns {void}
  */
 
@@ -95,7 +98,7 @@
  * @property {AccordionCard} item
  * @property {number} openCard
  * @property {ReactMouseEvent} onClick
- * @property {import("../../components/GaEventWrapper/GaEventWrapper").GaEventType} gaData
+ * @property {import("../../components/GaEventWrapper/GaEventWrapper").GaEventType} [gaData]
  */
 
 /**


### PR DESCRIPTION
Some work with GaEventWrapper
Adding Notification banner as example only (We can export it, as it might be good)

I am not really concerned about where these are added at this time, but we will want to follow up and figure this out before we are done `title: "More Examples/Notification Banner",`

I have added notes to the doc page, but also created this follow up ticket as a nice to have: (Unity-react-core: Storybook Custom doc generator)
https://asudev.jira.com/browse/UDS-1913