### PR TITLE
fix(unity-bootstrap-theme): updated grid profile styles

### DIFF
--- a/packages/app-webdir-ui/src/ProfileCard/index.styles.js
+++ b/packages/app-webdir-ui/src/ProfileCard/index.styles.js
@@ -7,16 +7,16 @@ const ProfileCardLayout = styled.div`
     display: block;
     font-weight: bold;
   }
-  .fas {
+  [class*="fa-"] {
     display: none;
   }
   &.uds-grid-profile {
-  .fas {
-    display: inline;
-    color: #8C1D40;
-    padding-right: 8px;
+    [class*="fa-"] {
+      display: inline;
+      color: #8c1d40;
+      padding-right: 8px;
+    }
   }
-}
 `;
 
 export { ProfileCardLayout };


### PR DESCRIPTION
updated grid profile styles. "fas" gets stripped out so need to target any element with the class that contains "fa-" to account for any icon changes

No ticket

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
