### PR TITLE
fix(unity-bootstrap-theme): apply a11y breadcrumbs min size

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/_custom-asu-variables.scss
+++ b/packages/unity-bootstrap-theme/src/scss/_custom-asu-variables.scss
@@ -114,3 +114,6 @@ $uds-component-button-padding-x-medium: 1rem;
 $uds-component-button-padding-x: 2rem;
 $uds-component-list-ol-styles-steplist-styles-li-padding-bottom: 2rem;
 $uds-component-border-radius: 400rem;
+
+// Accessibility
+$a11y-target-size-minimum: 1.5rem; // only required for certain links, see docs: https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum

--- a/packages/unity-bootstrap-theme/src/scss/extends/_breadcrumb.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_breadcrumb.scss
@@ -1,8 +1,21 @@
 .breadcrumb {
-  padding-left: 0;
+  & {
+    padding-left: 0;
+  }
   &.bg-gray-7 {
     li.active {
       color: $uds-color-base-gray-1;
+    }
+  }
+  .breadcrumb-item {
+    & {
+      min-height: $a11y-target-size-minimum;
+      min-width: $a11y-target-size-minimum;
+    }
+    a {
+      min-height: $a11y-target-size-minimum;
+      min-width: $a11y-target-size-minimum;
+      display: flex;
     }
   }
 }


### PR DESCRIPTION
https://github.com/ASU/asu-unity-stack/pull/1428

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1917)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)
- https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum
- Local storybook link: http://localhost:9000/?path=/story/atoms-breadcrumbs-examples--breadcrumbs-against-white-background
