### PR TITLE
fix(unity-bootstrap-theme): left aligned the heading

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -696,8 +696,12 @@ Cards - Table of Contents
   }
   .accordion-header .accordion-icon {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     margin-bottom: 0;
+  }
+
+  .accordion-header button{
+    text-align: left;
   }
 }
 


### PR DESCRIPTION

### Description

<!-- Description of problem --> The heading was being centered so it had to be left aligned
<!-- Solution --> 
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1893?atlOrigin=eyJpIjoiOTBmMjJlMTM3OGJmNDY1YTkyMmQ5Y2Q2NTg1YjFjMmIiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
