### PR TITLE
fix(unity-bootstrap-theme): pagination hover color fix

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_pager.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_pager.scss
@@ -42,6 +42,10 @@ a.page-link:hover {
   color: $uds-color-base-gray-7;
   text-decoration: none;
 }
+.page-item.active a.page-link:hover {
+  color: $uds-color-base-gray-1;
+}
+
 span.page-link {
   padding-left: 0;
   padding-right: 0;


### PR DESCRIPTION

### Description

<!-- Description of problem --> Pagination color on hover was black, so it had to be changed to white

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1922?atlOrigin=eyJpIjoiZjg5ZmM1Mjg3OGY5NDZjNTlhNWZmOTA1YTk3M2NmZDAiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
