### PR TITLE
fix(app-webdir-ui): duplicate Aria labels in "Sort by" dropdown menu

### DIFF
--- a/packages/app-webdir-ui/src/SearchPage/components/sort.js
+++ b/packages/app-webdir-ui/src/SearchPage/components/sort.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useId } from "react";
 
 import { trackGAEvent } from "../../../../../shared";
 import { SortLayout } from "./index.styles";
@@ -16,7 +16,7 @@ import { SortLayout } from "./index.styles";
 
 const SortPicker = ({ sort, onChange, customSortOptions }) => {
   const [defaultSortValue, setDefaultSortValue] = useState(sort);
-
+  const sortLabelId = useId();
   const sortOptions = customSortOptions || [
     { value: "_score_desc", label: "Relevancy" },
     { value: "last_name_asc", label: "Last Name (ascending)" },
@@ -76,10 +76,10 @@ const SortPicker = ({ sort, onChange, customSortOptions }) => {
     <SortLayout>
       <form className="uds-form sort-form faculty-sort">
         <div className="form-group">
-          <label htmlFor="sortBySelect">Sort by</label>
+          <label htmlFor={sortLabelId}>Sort by</label>
           <select
             className="form-select"
-            id="sortBySelect"
+            id={sortLabelId}
             onChange={event => {
               updateSort(event.target.value);
               setDefaultSortValue(event.target.value);


### PR DESCRIPTION

### Description

<!-- Description of problem --> Duplicate Aria labels in "Sort by" dropdown menus
<!-- Solution --> Generated a unique Id using useId
<!-- Testing Steps --> 

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1843?atlOrigin=eyJpIjoiNzE3NmE3ODdmY2QwNDA1YjgxMDU3MjEyY2I3MmFjMGEiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
