### PR TITLE
fix(app-webdir-ui): fix grid profile squishing on 50% layout

### DIFF
--- a/packages/app-webdir-ui/src/WebDirectoryComponent/index.styles.js
+++ b/packages/app-webdir-ui/src/WebDirectoryComponent/index.styles.js
@@ -11,6 +11,13 @@ const WebDirLayout = styled.div`
     "results results";
   grid-column-gap: 100px;
 
+  .uds-grid > .row {
+    gap: 1rem;
+    & > div {
+    flex: 0 0 282px;
+    }
+  }
+
   .sort {
     grid-area: sort;
   }
@@ -37,6 +44,12 @@ const WebDirLayout = styled.div`
 const FacultyRankLayout = styled.div`
   display: flex;
   flex-wrap: wrap;
+  .uds-grid > .row {
+    gap: 1rem;
+    & > div {
+    flex: 0 0 282px;
+    }
+  }
   .view-toggle {
     width: 100%;
     justify-content: flex-start;

--- a/packages/app-webdir-ui/src/helpers/Filter/index.styles.js
+++ b/packages/app-webdir-ui/src/helpers/Filter/index.styles.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const FilterContainer = styled.fieldset`
-  width: 100%;
+  width: 85%;
   margin: 0 0 2rem 0;
 
   .choices-wrapper {


### PR DESCRIPTION
fix grid profile squishing on 50% layout

### Links

- [JIRA ticket](https://asudev.jira.com/browse/ws2-2190)



See new 50% layout in webspark below
![Screenshot 2025-01-10 at 3 07 00 PM](https://github.com/user-attachments/assets/fbfc0e6f-93d0-4b5e-a8dc-aa732d5cbfdd)
