### PR TITLE
fix(unity-bootstrap-theme): breadcrumbs final active link changed to black

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_breadcrumb.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_breadcrumb.scss
@@ -17,8 +17,12 @@
       min-width: $a11y-target-size-minimum;
       display: flex;
     }
+    &.active a {
+      color: var(--bs-breadcrumb-item-active-color) !important;
+    }
   }
 }
+
 // WS2-1036 and UDS-1129 hide breadcrumb on mobile
 @media screen and (max-width: $uds-breakpoint-sm) {
   .breadcrumb {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_breadcrumb.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_breadcrumb.scss
@@ -18,7 +18,7 @@
       display: flex;
     }
     &.active a {
-      color: var(--bs-breadcrumb-item-active-color) !important;
+      color: var(--bs-breadcrumb-item-active-color);
     }
   }
 }


### PR DESCRIPTION

### Description

<!-- Description of problem --> Breadcrumbs final active link should be changed to black
<!-- Solution -->
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1631?atlOrigin=eyJpIjoiYTNmZDhmNzhiMjMwNDdiMGI5N2QzZWYzZmZkMDQwOTgiLCJwIjoiaiJ9)

### FOR APPROVERS

- [Percy build approval](https://percy.io/5eae92d9/-all-UDS-packages)
