### PR TITLE
fix(unity-bootstrap-theme): changed height to min-height on hero-overlay classes

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -282,7 +282,7 @@ div.uds-hero-md {
 }
 
 div.uds-hero-lg {
-  height: $uds-size-spacing-64;
+  min-height: $uds-size-spacing-64;
 
   .content {
     display: none;
@@ -426,7 +426,7 @@ div.uds-hero-lg {
   }
 
   div.uds-hero-lg {
-    height: 42.75rem;
+    min-height: 42.75rem;
     // TODO; remove this, it's a fallback for buttons without has-btn-row
     grid-template-rows: 1fr repeat(4, auto) $uds-size-spacing-6;
 
@@ -498,7 +498,7 @@ div.uds-hero-lg {
   }
 
   div.uds-hero-lg {
-    height: 42.75rem;
+    min-height: 42.75rem;
 
     &.uds-video-hero {
       position: relative;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -212,7 +212,7 @@ div[class^="uds-hero"] {
 }
 
 div.uds-hero-sm {
-  height: $uds-size-spacing-32;
+  min-height: $uds-size-spacing-32;
   grid-template-rows: 1fr auto auto 3rem;
 
   h1,
@@ -255,7 +255,7 @@ div.uds-hero-sm {
 }
 
 div.uds-hero-md {
-  height: 21rem;
+  min-height: 21rem;
   // by design, the hero-md has no content on mobile, change grid template rows and hide .content
   grid-template-rows: 1fr auto auto 3rem;
 
@@ -379,7 +379,7 @@ div.uds-hero-lg {
     grid-template-rows: 1fr auto auto $uds-size-spacing-7;
     &.has-btn-row {
       .btn-row {
-        top: 14.5rem;
+        top: 92%;
       }
     }
 
@@ -391,7 +391,7 @@ div.uds-hero-lg {
   }
 
   div.uds-hero-md {
-    height: $uds-size-spacing-64;
+    min-height: $uds-size-spacing-64;
     // TODO; remove this, it's a fallback for buttons without has-btn-row
     grid-template-rows: 1fr repeat(4, auto) $uds-size-spacing-6;
     h1 {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -79,6 +79,7 @@ div[class^="uds-hero"] {
     grid-row: 2;
     grid-template-columns: 1fr;
     grid-template-rows: 1fr 1fr;
+    margin-top: $uds-size-spacing-10;
 
     p {
       margin: 0;
@@ -244,7 +245,7 @@ div.uds-hero-sm {
     }
 
     .hero-overlay {
-      height: $uds-size-spacing-32;
+      min-height: $uds-size-spacing-32;
     }
   }
 
@@ -270,7 +271,7 @@ div.uds-hero-md {
     }
 
     .hero-overlay {
-      height: 21rem;
+      min-height: 21rem;
     }
   }
 
@@ -307,7 +308,7 @@ div.uds-hero-lg {
     }
 
     .hero-overlay {
-      height: $uds-size-spacing-64;
+      min-height: $uds-size-spacing-64;
     }
   }
 
@@ -419,7 +420,7 @@ div.uds-hero-lg {
       }
 
       .hero-overlay {
-        height: $uds-size-spacing-64;
+        min-height: $uds-size-spacing-64;
       }
     }
   }
@@ -448,7 +449,7 @@ div.uds-hero-lg {
       }
 
       .hero-overlay {
-        height: 42.75rem;
+        min-height: 42.75rem;
       }
     }
 

--- a/packages/unity-bootstrap-theme/src/scss/extends/_xx_Hero-Competing.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_xx_Hero-Competing.scss
@@ -61,18 +61,18 @@ div[class^='uds-hero'] {
   }
 
   &.uds-hero-sm {
-    height: $uds-size-spacing-32;
+    min-height: $uds-size-spacing-32;
     .hero-body {
       display: none;
     }
   }
 
   &.uds-hero-md {
-    height: $uds-size-spacing-64;
+    min-height: $uds-size-spacing-64;
   }
 
   &.uds-hero-lg {
-    height: 42.75rem;
+    min-height: 42.75rem;
   }
 }
 


### PR DESCRIPTION
Changed height to min-height on `hero-overlay `classes

**Test steps :**
For some reason, the [provided extension](https://chromewebstore.google.com/detail/zoom-text-only/jamhfhbppcmkgghlkeieococonlbppjg?hl=en-US) twhich allows us to zoom in and out, doesn’t work in Storybook, making it difficult to test this PR.

Additionally, manually zooming in or out isn’t a viable solution since it affects the entire page, whereas the extension is designed to zoom **only** the text we’re working on. In other words, the extension adjusts the font size.

![WhatsApp Image 2025-02-17 at 10 00 08 AM](https://github.com/user-attachments/assets/f668646d-d3cf-47c7-a05e-c245e3455d46)

In conclusion, I believe the best way to test it is by integrating it into an instance in WS2.



URL to test it : 
https://unity-uds-staging.s3.us-west-2.amazonaws.com/pr-1466/@asu/unity-bootstrap-theme/iframe.html?id=molecules-heroes-examples--hero-large-with-buttons&viewMode=story


[UDS-1765
](https://asudev.jira.com/browse/UDS-1765)
<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1765)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

