### PR TITLE
fix(unity-bootstrap-theme): breadcrumb: "Current Page" Text State Cha…

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_breadcrumb.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_breadcrumb.scss
@@ -25,3 +25,9 @@
     display: none;
   }
 }
+
+.breadcrumb-item.active a {
+  color: inherit;
+  pointer-events: none;
+  text-decoration: none;
+}


### PR DESCRIPTION
…nge to Plain Text

### Description

<!-- Description of problem --> Breadcrumb: "Current Page" Text State Change to Plain Text
<!-- Solution -->
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1851?atlOrigin=eyJpIjoiYmYxYWFlYzE4ZjE1NDNmNGJmNTAzODVjOTBkZGVhZGUiLCJwIjoiaiJ9)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

