### PR TITLE
Uds 1978 - unity-react-core required an updated version of the theme package

### DIFF
--- a/packages/unity-bootstrap-theme/vite.config.js
+++ b/packages/unity-bootstrap-theme/vite.config.js
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react";
-import { resolve } from "path";
+import path, { resolve } from "path";
+import fs from "fs";
 import { defineConfig, transformWithEsbuild } from "vite";
 
 import pkg from "./package.json";
@@ -21,6 +22,16 @@ const c = {
         });
       },
     },
+    {
+      name: 'copy-bootstrap-umd-to-dist',
+      // See https://vite.dev/guide/api-plugin#universal-hooks for closeBundle info
+      closeBundle() {
+        const srcPath = path.resolve(__dirname, "../../node_modules", 'bootstrap/dist/js/bootstrap.bundle.min.js');
+        const destDir = path.resolve(__dirname, 'dist/js/bootstrap.bundle.min.js');
+
+        fs.copyFileSync(srcPath, destDir);
+      }
+    }
   ],
   optimizeDeps: {
     esbuildOptions: {

--- a/packages/unity-react-core/package.json
+++ b/packages/unity-react-core/package.json
@@ -48,7 +48,7 @@
     "test:browser": "vitest --workspace=vitest.workspace.ts"
   },
   "devDependencies": {
-    "@asu/unity-bootstrap-theme": "^1.20.2",
+    "@asu/unity-bootstrap-theme": "^1.21.3",
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.21.3",
     "@babel/plugin-transform-runtime": "^7.19.6",
@@ -129,6 +129,7 @@
     "styled-components": "^5.3.0"
   },
   "peerDependencies": {
+    "@asu/unity-bootstrap-theme": "^1.21.3",
     "@fortawesome/fontawesome-free": "^5.15.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,7 +611,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@asu/unity-bootstrap-theme@npm:^1.0.0, @asu/unity-bootstrap-theme@npm:^1.20, @asu/unity-bootstrap-theme@npm:^1.20.2, @asu/unity-bootstrap-theme@workspace:packages/unity-bootstrap-theme":
+"@asu/unity-bootstrap-theme@npm:^1.0.0, @asu/unity-bootstrap-theme@npm:^1.20, @asu/unity-bootstrap-theme@npm:^1.20.2, @asu/unity-bootstrap-theme@npm:^1.21.3, @asu/unity-bootstrap-theme@workspace:packages/unity-bootstrap-theme":
   version: 0.0.0-use.local
   resolution: "@asu/unity-bootstrap-theme@workspace:packages/unity-bootstrap-theme"
   dependencies:
@@ -674,7 +674,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@asu/unity-react-core@workspace:packages/unity-react-core"
   dependencies:
-    "@asu/unity-bootstrap-theme": "npm:^1.20.2"
+    "@asu/unity-bootstrap-theme": "npm:^1.21.3"
     "@babel/cli": "npm:^7.19.3"
     "@babel/core": "npm:^7.21.3"
     "@babel/plugin-transform-runtime": "npm:^7.19.6"
@@ -752,6 +752,7 @@ __metadata:
     vitest: "npm:^2.1.1"
     vitest-browser-react: "npm:^0.0.1"
   peerDependencies:
+    "@asu/unity-bootstrap-theme": ^1.21.3
     "@fortawesome/fontawesome-free": ^5.15.3
     react: ^18.3.1
     react-dom: ^18.3.1


### PR DESCRIPTION
### Description
Add bundled UMD file that was already present in bootstrap library to unity-bootstrap-theme dist file.
Also, unity-react-core required an updated version of the theme package for some styles it relied on. Made unity-bootstrap-theme a peerDependency in unity-react-core so people who download the package will know 


### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1978)

