### PR TITLE
fix(unity-bootstrap-theme): notification Banner size enlarged and gap…

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
@@ -29,8 +29,8 @@
     flex: 3;
     a,
     button {
-      margin-top: 0.25rem;
-      margin-bottom: 0.25rem;
+      margin-top: calc($uds-size-spacing-1 / 2);
+      margin-bottom: calc($uds-size-spacing-1 / 2);
       margin-left: 0;
     }
     // Do buttons in their own flexbox, column-style, no stretching.

--- a/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_banners.scss
@@ -29,14 +29,21 @@
     flex: 3;
     a,
     button {
-      margin-top: $uds-size-spacing-1;
-      margin-bottom: $uds-size-spacing-1;
+      margin-top: 0.25rem;
+      margin-bottom: 0.25rem;
       margin-left: 0;
     }
     // Do buttons in their own flexbox, column-style, no stretching.
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+
+    a.btn.btn-sm.btn-dark{
+      height: 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
   .banner-close {
     flex: 2;


### PR DESCRIPTION
… reduced

### Description

<!-- Description of problem --> Notification Banner button enlarged and gap between buttons reduced to 8px
<!-- Solution -->
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1647?atlOrigin=eyJpIjoiOTFhODdlNzQwMjA4NDEzNDg1YWJiYzE2M2MwOGY4NTYiLCJwIjoiaiJ9)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

