### PR TITLE
UDS-1937: fix(component-header-footer): removed aria-labelledby and added span for desktop

### DIFF
--- a/packages/component-header-footer/src/footer/components/ColumnSection/index.js
+++ b/packages/component-header-footer/src/footer/components/ColumnSection/index.js
@@ -76,28 +76,31 @@ const ColumnSection = ({ columnIndex, column: { title, links } }) => {
       <div className="card accordion-item desktop-disable-xl">
         <div className="accordion-header">
           <div className="h5">
-            <button
-              id={`footlink-header-${columnIndex}`}
-              className="accordion-button"
-              aria-expanded={show || isLgDesktop}
-              aria-controls={`footlink-${columnIndex}`}
-              onClick={handleToggle}
-              type="button"
-              disabled={isLgDesktop}
-            >
-              {title}
-              <FontAwesomeIcon
-                className={show || isLgDesktop ? "open" : ""}
-                icon={faChevronDown}
-              />
-            </button>
+            {isLgDesktop ? (
+              <p className="accordion-button">{title}</p>
+            ) : (
+              <button
+                id={`footlink-header-${columnIndex}`}
+                className="accordion-button"
+                aria-expanded={show || isLgDesktop}
+                aria-controls={`footlink-${columnIndex}`}
+                onClick={handleToggle}
+                type="button"
+                disabled={isLgDesktop}
+              >
+                {title}
+                <FontAwesomeIcon
+                  className={show || isLgDesktop ? "open" : ""}
+                  icon={faChevronDown}
+                />
+              </button>
+            )}
           </div>
         </div>
         <div
           id={`footlink-${columnIndex}`}
           className="accordion-body"
           role="region"
-          aria-labelledby={`footlink-header-${columnIndex}`}
           ref={accordionBodyRef}
         >
           {links.map(link => (


### PR DESCRIPTION
UDS-1937

<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1937)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

