### PR TITLE
UDS-2010: feat(unity-bootstrap-theme): added js for trucate aria-describedby on…

### DIFF
--- a/packages/unity-bootstrap-theme/src/js/card-bodies.js
+++ b/packages/unity-bootstrap-theme/src/js/card-bodies.js
@@ -1,0 +1,59 @@
+import { EventHandler } from "./bootstrap-helper";
+
+function initCardBodies() {
+
+  const cardBodies = document.querySelectorAll('.card-body');
+  cardBodies.forEach((cardBody, index) => {
+    const paragraph = cardBody.querySelector('div p');
+    const originalText = paragraph.textContent;
+    const style = window.getComputedStyle(cardBody);
+    const lineClamp = parseInt(style.webkitLineClamp || style.lineClamp);
+    const lineHeight = parseFloat(style.lineHeight);
+    const fontSize = parseFloat(style.fontSize);
+    const actualLineHeight = isNaN(lineHeight) ? parseFloat(style.lineHeight) * fontSize : lineHeight;
+    const maxHeight = lineClamp * actualLineHeight;
+
+    if (paragraph.offsetHeight >= maxHeight) {
+      let visibleText = '';
+      const words = originalText.split(' ');
+      let visibleWordCount = 0;
+      let tempText = '';
+      while (visibleWordCount < words.length && getTextHeight(tempText + (tempText ? ' ' : '') + words[visibleWordCount], paragraph) <= maxHeight) {
+        tempText += (tempText ? ' ' : '') + words[visibleWordCount];
+        visibleWordCount++;
+      }
+      visibleText = tempText + '...';
+
+      const visibleTextElementId = `visible-text-${Math.random().toString(36).substring(7)}`;
+      const visibleTextElement = document.createElement('div');
+      visibleTextElement.id = visibleTextElementId;
+      visibleTextElement.textContent = visibleText;
+      visibleTextElement.style.position = 'absolute';
+      visibleTextElement.style.left = '-9999px';
+      visibleTextElement.style.top = '-9999px';
+      visibleTextElement.setAttribute('aria-hidden', 'true');
+
+      cardBody.appendChild(visibleTextElement);
+
+      paragraph.setAttribute('aria-describedby', visibleTextElementId);
+    }
+  });
+
+
+};
+
+function getTextHeight(text, element) {
+  const tempElement = document.createElement(element.tagName);
+  tempElement.style.font = window.getComputedStyle(element).font;
+  tempElement.style.width = window.getComputedStyle(element).width;
+  tempElement.style.whiteSpace = 'pre-wrap';
+  tempElement.textContent = text;
+  document.body.appendChild(tempElement);
+  const height = tempElement.offsetHeight;
+  document.body.removeChild(tempElement);
+  return height;
+}
+
+EventHandler.on(window, 'load.uds.card-bodies', initCardBodies);
+
+export { initCardBodies };

--- a/packages/unity-bootstrap-theme/src/js/card-bodies.js
+++ b/packages/unity-bootstrap-theme/src/js/card-bodies.js
@@ -42,22 +42,8 @@ function initCardBodies() {
       }
       visibleText = tempText + '...';
 
-      // Create a new hidden element to store the truncated text
-      const visibleTextElementId = `visible-text-${Math.random().toString(36).substring(7)}`;
-      const visibleTextElement = document.createElement('div');
-      visibleTextElement.id = visibleTextElementId;
-      visibleTextElement.textContent = visibleText;
-      visibleTextElement.style.position = 'absolute';
-      visibleTextElement.style.top = '0';
-      visibleTextElement.style.zIndex = '-1';
+      paragraph.setAttribute('aria-label', visibleText);
 
-      // Add the hidden element to the DOM
-      cardBody.appendChild(visibleTextElement);
-
-      paragraph.setAttribute('aria-describedby', visibleTextElementId);
-
-      // Hide the original paragraph from screen readers
-      paragraph.setAttribute('aria-hidden', 'true');
     }
   });
 

--- a/packages/unity-bootstrap-theme/src/js/card-bodies.js
+++ b/packages/unity-bootstrap-theme/src/js/card-bodies.js
@@ -1,5 +1,12 @@
 import { EventHandler } from "./bootstrap-helper";
 
+/**
+ * Initializes the card body elements by applying text truncation if the content exceeds
+ * a specified height based on the CSS line-clamp and line-height properties. Adds
+ * accessible text for truncated content.
+ *
+ * @return {void} This function does not return any value.
+ */
 function initCardBodies() {
 
   const cardBodies = document.querySelectorAll('.card-body');
@@ -7,23 +14,35 @@ function initCardBodies() {
     const paragraph = cardBody.querySelector('div p');
     const originalText = paragraph.textContent;
     const style = window.getComputedStyle(cardBody);
+
+    // Get the number of lines allowed (line clamp), usually set via CSS like -webkit-line-clamp
     const lineClamp = parseInt(style.webkitLineClamp || style.lineClamp);
+
+    // Get the line height and font size from the styles
     const lineHeight = parseFloat(style.lineHeight);
     const fontSize = parseFloat(style.fontSize);
+
+    // Calculate the actual line height. If lineHeight is not a number, estimate using fontSize
     const actualLineHeight = isNaN(lineHeight) ? parseFloat(style.lineHeight) * fontSize : lineHeight;
+
+    // Calculate the maximum height allowed for the paragraph (lines × line height)
     const maxHeight = lineClamp * actualLineHeight;
 
+    // Check if the paragraph exceeds the maximum allowed height
     if (paragraph.offsetHeight >= maxHeight) {
       let visibleText = '';
       const words = originalText.split(' ');
       let visibleWordCount = 0;
       let tempText = '';
+
+      // Add words one by one until the text height exceeds the max allowed height
       while (visibleWordCount < words.length && getTextHeight(tempText + (tempText ? ' ' : '') + words[visibleWordCount], paragraph) <= maxHeight) {
         tempText += (tempText ? ' ' : '') + words[visibleWordCount];
         visibleWordCount++;
       }
       visibleText = tempText + '...';
 
+      // Create a new hidden element to store the truncated text
       const visibleTextElementId = `visible-text-${Math.random().toString(36).substring(7)}`;
       const visibleTextElement = document.createElement('div');
       visibleTextElement.id = visibleTextElementId;
@@ -32,16 +51,27 @@ function initCardBodies() {
       visibleTextElement.style.top = '0';
       visibleTextElement.style.zIndex = '-1';
 
+      // Add the hidden element to the DOM
       cardBody.appendChild(visibleTextElement);
 
       paragraph.setAttribute('aria-describedby', visibleTextElementId);
+
+      // Hide the original paragraph from screen readers
       paragraph.setAttribute('aria-hidden', 'true');
     }
   });
 
 
-};
+}
 
+/**
+ * Calculates the rendered height of a given text when styled and constrained
+ * within the dimensions and styles of the specified HTML element.
+ *
+ * @param {string} text - The text content whose height is to be measured.
+ * @param {HTMLElement} element - The element used to derive styling and width constraints.
+ * @return {number} The height in pixels of the rendered text.
+ */
 function getTextHeight(text, element) {
   const tempElement = document.createElement(element.tagName);
   tempElement.style.font = window.getComputedStyle(element).font;

--- a/packages/unity-bootstrap-theme/src/js/card-bodies.js
+++ b/packages/unity-bootstrap-theme/src/js/card-bodies.js
@@ -28,11 +28,14 @@ function initCardBodies() {
       const visibleTextElement = document.createElement('div');
       visibleTextElement.id = visibleTextElementId;
       visibleTextElement.textContent = visibleText;
-      visibleTextElement.setAttribute('hidden', 'true');
+      visibleTextElement.style.position = 'absolute';
+      visibleTextElement.style.top = '0';
+      visibleTextElement.style.zIndex = '-1';
 
       cardBody.appendChild(visibleTextElement);
 
       paragraph.setAttribute('aria-describedby', visibleTextElementId);
+      paragraph.setAttribute('aria-hidden', 'true');
     }
   });
 

--- a/packages/unity-bootstrap-theme/src/js/card-bodies.js
+++ b/packages/unity-bootstrap-theme/src/js/card-bodies.js
@@ -42,7 +42,27 @@ function initCardBodies() {
       }
       visibleText = tempText + '...';
 
-      paragraph.setAttribute('aria-label', visibleText);
+      // Create a new hidden element to store the truncated text
+      const visibleTextElementId = `visible-text-${Math.random().toString(36).substring(7)}`;
+      const visibleTextElement = document.createElement('div');
+      visibleTextElement.id = visibleTextElementId;
+      visibleTextElement.textContent = visibleText;
+      visibleTextElement.style.position = 'absolute';
+      visibleTextElement.style.top = `${paragraph.offsetTop}px`;
+      visibleTextElement.style.left = `${paragraph.offsetLeft}px`;
+      visibleTextElement.style.width = `${paragraph.offsetWidth}px`;
+      visibleTextElement.style.height = `${paragraph.offsetHeight}px`;
+      visibleTextElement.style.opacity = '0';
+      visibleTextElement.style.pointerEvents = 'none';
+      visibleTextElement.style.zIndex = '1';
+
+      // Add the hidden element to the DOM
+      cardBody.appendChild(visibleTextElement);
+
+      paragraph.setAttribute('aria-describedby', visibleTextElementId);
+
+      // Hide the original paragraph from screen readers
+      paragraph.setAttribute('aria-hidden', 'true');
 
     }
   });

--- a/packages/unity-bootstrap-theme/src/js/card-bodies.js
+++ b/packages/unity-bootstrap-theme/src/js/card-bodies.js
@@ -28,10 +28,7 @@ function initCardBodies() {
       const visibleTextElement = document.createElement('div');
       visibleTextElement.id = visibleTextElementId;
       visibleTextElement.textContent = visibleText;
-      visibleTextElement.style.position = 'absolute';
-      visibleTextElement.style.left = '-9999px';
-      visibleTextElement.style.top = '-9999px';
-      visibleTextElement.setAttribute('aria-hidden', 'true');
+      visibleTextElement.setAttribute('hidden', 'true');
 
       cardBody.appendChild(visibleTextElement);
 

--- a/packages/unity-bootstrap-theme/src/js/unity-bootstrap.js
+++ b/packages/unity-bootstrap-theme/src/js/unity-bootstrap.js
@@ -2,6 +2,7 @@
 import { initAnchorMenu } from "./anchor-menu.js";
 import { initBlockquoteAnimation } from "./blockquote-animated.js";
 import { initCalendar } from "./calendar.js";
+import { initCardBodies } from "./card-bodies.js";
 import { initRankingCard } from "./card-ranking.js";
 import { initChart } from "./charts-and-graphs.js";
 import { initDataLayer } from "./data-layer.js";
@@ -28,6 +29,7 @@ const unityBootstrap = {
   initRankingCard,
   initTabbedPanels,
   initVideo,
+  initCardBodies,
 }
 
 export default unityBootstrap;


### PR DESCRIPTION
… card-body

UDS-2010

<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description
Screen readers are reading  the whole text instead of the summary.

### Test
You can test it (using Voice Over) at this jenkins url [https://unity-uds-staging.s3.us-west-2.amazonaws.com/pr-1536/@asu/unity-bootstrap-theme/iframe.html[…]ge-templates--left-floated-card&viewMode=story](https://unity-uds-staging.s3.us-west-2.amazonaws.com/pr-1536/@asu/unity-bootstrap-theme/iframe.html?args=&id=molecules-content-sections-card-and-image-templates--left-floated-card&viewMode=story) .
Basically,  the main function initCardBodies finds all .card-body elements on the page. For each .card-body, it checks if the contained paragraph’s text overflows beyond a certain number of lines. If it does:
It truncates the text manually.
Appends a visually hidden element with the visible (truncated) text for screen readers.
Hides the original overflowing paragraph from screen readers.


<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2010)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

