### PR TITLE
fix(unity-bootstrap-theme): focus state centered

### DIFF
--- a/packages/component-header-footer/src/footer/index.styles.js
+++ b/packages/component-header-footer/src/footer/index.styles.js
@@ -164,7 +164,7 @@ const StyledFooter = styled.footer`
 
         &:last-child {
           @media (min-width: 768px) {
-            padding-right: 0;
+            /* padding-right: 0; */
           }
         }
       }

--- a/packages/unity-bootstrap-theme/src/scss/extends/_globalfooter.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_globalfooter.scss
@@ -140,7 +140,7 @@ footer {
       font-size: $uds-size-icon-base;
       color: $uds-color-base-gray-4;
       line-height: 1;
-      padding-top: 7px; // Magic number. Reducing the padding by 1px to make the height = 48px.
+      padding: 7px 16px; // Magic number. Reducing the padding by 1px to make the height = 48px.
 
       :hover {
         color: $uds-color-base-white;


### PR DESCRIPTION

### Description

<!-- Description of problem --> Focus state not centered on last element
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1955?atlOrigin=eyJpIjoiMWY3ZjNkZjUzZjQ1NGQzYWFhNDFiZGI2ZjA4MTJmM2QiLCJwIjoiaiJ9)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

