### PR TITLE
build: remove docs generation from local development builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build-storybook": "lerna run build-storybook --stream --parallel && yarn build-static-site",
     "build": "yarn prebuild && lerna run build --ignore=@asu/unity-react-core --stream --parallel && yarn postbuild",
     "prebuild": "lerna run build --scope=@asu/unity-react-core && yarn lint",
-    "postbuild": "lerna run --ignore=@asu/unity-bootstrap-theme docs",
+    "postbuild": "node -e \"process.env.CI && require('child_process').execSync('lerna run --ignore=@asu/unity-bootstrap-theme docs', {stdio: 'inherit'})\"",
     "test": "lerna run test --stream --parallel",
     "test:e2e": "jest",
     "prepublish-packages": "node scripts/copy-license.js && node scripts/copy-release-rc.js",


### PR DESCRIPTION
There is no ticket for this as the effort is so small but this removes doc generation when building locally but keeps it in CI so that published packages still have updated docs

