### PR TITLE
UDS-2015: Image With Caption: text size too small, below minimum standards required size

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_images.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_images.scss
@@ -43,7 +43,7 @@
       opacity: 1;
       background: $uds-color-background-white 0% 0% no-repeat padding-box;
       padding: 2rem;
-      font-size: $uds-size-font-tiny;
+      font-size: $uds-size-font-medium;
       h3, .h3 {
         color: $uds-color-base-gray-7;
         margin: 0 0 1rem 0;


### PR DESCRIPTION
feat(unity-bootstrap-theme): increase font size from 12px up to 16px in uds-figure-caption

UDS-2015

<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2015)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

