### PR TITLE
fix(unity-bootstrap-theme): cSS Padding added to images without header

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -153,6 +153,10 @@ Cards - Table of Contents
   flex-grow: 1;
 }
 
+.card:not(:has(.card-header)) .card-body {
+  margin-top: var(--card-child-padding);
+}
+
 .card-link {
   margin-left: var(--card-child-margin);
   margin-right: var(--card-child-margin);


### PR DESCRIPTION

### Description

<!-- Description of problem --> Fix the CSS padding on the images with no headers
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2013?atlOrigin=eyJpIjoiZmM0MzBiZDk0YTgwNGU5ZGIwMGQyN2M5NDhiYWIzNzUiLCJwIjoiaiJ9)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

