### PR TITLE
UDS-1970: feat(unity-bootstrap-theme): added mixin to expand clickable area

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_buttons.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_buttons.scss
@@ -5,15 +5,12 @@
     1rem;
 }
 
-@mixin clickable-area($min-width: 80px, $min-height: 44px) {
+@mixin clickable-area() {
   position: relative;
   &::before {
     content: "";
     position: absolute;
-    min-width: $min-width;
-    min-height: $min-height;
-    z-index: -1;
-    inset: 0;
+    inset: -10px;
     margin: auto;
   }
 }
@@ -24,6 +21,8 @@
   font-weight: bold;
   white-space: nowrap;
   width: max-content !important;
+  @include clickable-area();
+
   &::first-letter {
     text-transform: uppercase;
   }
@@ -33,14 +32,11 @@
   }
   &.btn-md {
     @include btn-md;
-    @include clickable-area(80px, 44px);
   }
   &.btn-sm {
     font-size: 0.75rem;
     padding: $uds-component-button-padding-y-small
       $uds-component-button-padding-x-small;
-
-    @include clickable-area(64px, 44px);
   }
   &.btn-tag {
     font-size: 0.75rem;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_buttons.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_buttons.scss
@@ -5,6 +5,19 @@
     1rem;
 }
 
+@mixin clickable-area($min-width: 80px, $min-height: 44px) {
+  position: relative;
+  &::before {
+    content: "";
+    position: absolute;
+    min-width: $min-width;
+    min-height: $min-height;
+    z-index: -1;
+    inset: 0;
+    margin: auto;
+  }
+}
+
 // Extra styles that don't have bootstrap variables to override
 .btn {
   text-decoration: none;
@@ -20,11 +33,14 @@
   }
   &.btn-md {
     @include btn-md;
+    @include clickable-area(80px, 44px);
   }
   &.btn-sm {
     font-size: 0.75rem;
     padding: $uds-component-button-padding-y-small
       $uds-component-button-padding-x-small;
+
+    @include clickable-area(64px, 44px);
   }
   &.btn-tag {
     font-size: 0.75rem;


### PR DESCRIPTION
added mixin to expand clickable area for btn

UDS-1970

<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1970)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [Unity Design Kit](https://shared-assets.adobe.com/link/fb14b288-bf63-47e0-5d30-384de5560455)

