### PR TITLE
fix(unity-react-core): sidebar menu should auto-expand if it contains…

### DIFF
--- a/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.stories.tsx
+++ b/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.stories.tsx
@@ -20,6 +20,7 @@ const defaultProps = {
         {
           href: "https://example.com",
           text: "Link 2.1",
+          isActive: false,
         },
         {
           href: "https://example.com",
@@ -56,18 +57,33 @@ const defaultProps = {
           text: "Link 5.2",
         },
       ],
-    }
-  ]
-}
+    },
+  ],
+};
 
-const sidebarMenuTemplate = args => <div className="row">
-<SidebarMenu {...args} />
-</div>;
+const sidebarMenuTemplate = args => (
+  <div className="row">
+    <SidebarMenu {...args} />
+  </div>
+);
 
 export const Overview = {
   render: sidebarMenuTemplate.bind({}),
   name: "Sidebar",
   args: {
     ...defaultProps,
-  }
+  },
+};
+
+const defaultProps2 = JSON.parse(JSON.stringify(defaultProps));
+defaultProps2.links[0].text = "Link 1";
+defaultProps2.links[0].isActive = false;
+defaultProps2.links[1].items[0].isActive = true;
+defaultProps2.links[1].items[0].text = "Active Link";
+
+export const WithNestedActivePage = {
+  render: sidebarMenuTemplate.bind({}),
+  args: {
+    ...defaultProps2,
+  },
 };

--- a/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.test.tsx
+++ b/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.test.tsx
@@ -53,7 +53,7 @@ describe("SidebarMenu tests", () => {
   it("should have nested level active link", () => {
     component = renderComponent(defaultProps2);
     expect(component.getByText("Link 2.1")).toBeVisible();
-    expect(component.getByText("Link 2 dropdown")).toHaveClass("is-active");
+    expect(component.getByText("Link 2.1")).toHaveClass("is-active");
     expect(component.queryByText("Link 2 dropdown")).toHaveAttribute(
       "aria-expanded",
       "true"

--- a/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.test.tsx
+++ b/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.test.tsx
@@ -10,6 +10,7 @@ const defaultProps: SidebarProps = {
     {
       href: "https://example.com",
       text: "Link 1",
+      isActive: true,
     },
     {
       text: "Link 2 dropdown",
@@ -23,24 +24,39 @@ const defaultProps: SidebarProps = {
           text: "Link 2.2",
         },
       ],
-    }
-  ]
+    },
+  ],
 };
 
-const renderComponent = (props:SidebarProps) => {
+const defaultProps2 = JSON.parse(JSON.stringify(defaultProps));
+delete defaultProps2.links[0].isActive;
+defaultProps2.links[1].items[0].isActive = true;
+
+const renderComponent = (props: SidebarProps) => {
   return render(<SidebarMenu {...props} />);
 };
 
 describe("SidebarMenu tests", () => {
-  let component:RenderResult;
-
-  beforeEach(() => {
-    component = renderComponent(defaultProps);
-  });
+  let component: RenderResult;
 
   afterEach(cleanup);
 
-  it("should define component", () => {
-    expect(component).toBeDefined();
+  it("should have top level active link", () => {
+    component = renderComponent(defaultProps);
+    expect(component.getByText("Link 1")).toHaveClass("is-active");
+    expect(component.queryByText("Link 2 dropdown")).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
+  it("should have nested level active link", () => {
+    component = renderComponent(defaultProps2);
+    expect(component.getByText("Link 2.1")).toBeVisible();
+    expect(component.getByText("Link 2.1")).toHaveClass("is-active");
+    expect(component.queryByText("Link 2 dropdown")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
   });
 });

--- a/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.test.tsx
+++ b/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.test.tsx
@@ -53,7 +53,7 @@ describe("SidebarMenu tests", () => {
   it("should have nested level active link", () => {
     component = renderComponent(defaultProps2);
     expect(component.getByText("Link 2.1")).toBeVisible();
-    expect(component.getByText("Link 2.1")).toHaveClass("is-active");
+    expect(component.getByText("Link 2 dropdown")).toHaveClass("is-active");
     expect(component.queryByText("Link 2 dropdown")).toHaveAttribute(
       "aria-expanded",
       "true"

--- a/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.tsx
+++ b/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import { GaEventWrapper } from "../GaEventWrapper/GaEventWrapper";
 
+interface SidebarItemProps {
+  href: string;
+  text: string;
+  isActive?: boolean;
+}
+
 export interface Link {
   href?: string;
   text: string;
   isActive?: boolean;
-  items?: Array<{
-    href: string;
-    text: string;
-    isActive?: boolean;
-  }>;
-};
+  items?: SidebarItemProps[];
+}
 
 const defaultGaProps = {
   name: "onclick",
@@ -23,6 +25,16 @@ export interface SidebarProps {
   title: string;
   links: Link[];
 }
+
+const SidebarItem: React.FC<SidebarItemProps | Link> = ({
+  href,
+  text,
+  isActive,
+}) => (
+  <a href={href} className={`nav-link${isActive ? " is-active" : ""}`}>
+    {text}
+  </a>
+);
 
 export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
   return (
@@ -46,9 +58,10 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
       >
         {links.map((link, index) => {
           if (link.items) {
+            const isExpanded = link.items.some(({ isActive }) => isActive);
             // Render dropdown card
             return (
-              <div key={index} className="card card-foldable">
+              <div key={link.text} className="card card-foldable">
                 <div className="card-header">
                   <GaEventWrapper
                     gaData={{ ...defaultGaProps, section: title }}
@@ -59,7 +72,7 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
                       href={`#cardBody${index}`}
                       data-bs-toggle="collapse"
                       data-bs-target={`#cardBody${index}`}
-                      aria-expanded="false"
+                      aria-expanded={isExpanded}
                       aria-controls={`cardBody${index}`}
                     >
                       {link.text}
@@ -69,18 +82,12 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
                 </div>
                 <div
                   id={`cardBody${index}`}
-                  className="collapse card-body"
+                  className={`collapse card-body ${isExpanded ? " show" : ""}`}
                   aria-labelledby={`card${index}`}
                   data-bs-parent=".sidebar"
                 >
                   {link.items.map(item => (
-                    <a
-                      key={link.href}
-                      href={item.href}
-                      className={`nav-link${item.isActive ? " is-active" : ""}`}
-                    >
-                      {item.text}
-                    </a>
+                    <SidebarItem key={`${item.text}${item.href}`} {...item} />
                   ))}
                 </div>
               </div>
@@ -88,13 +95,11 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
           } else {
             // Render regular link
             return (
-              <div key={index} className="nav-link-container">
-                <a
-                  className={`nav-link${link.isActive ? " is-active" : ""}`}
-                  href={link.href}
-                >
-                  {link.text}
-                </a>
+              <div
+                key={`${link.text}${link.href}`}
+                className="nav-link-container"
+              >
+                <SidebarItem {...link} />
               </div>
             );
           }

--- a/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.tsx
+++ b/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.tsx
@@ -25,6 +25,15 @@ export interface SidebarProps {
   title: string;
   links: Link[];
 }
+const SidebarItem: React.FC<SidebarItemProps | Link> = ({
+  href,
+  text,
+  isActive,
+}) => (
+  <a href={href} className={`nav-link${isActive ? " is-active" : ""}`}>
+    {text}
+  </a>
+);
 
 export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
   return (
@@ -58,9 +67,7 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
                   >
                     <a
                       id={`card${index}`}
-                      className={`collapsed nav-link${
-                        isExpanded ? " is-active" : ""
-                      }`}
+                      className="collapsed nav-link"
                       href={`#cardBody${index}`}
                       data-bs-toggle="collapse"
                       data-bs-target={`#cardBody${index}`}
@@ -79,13 +86,7 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
                   data-bs-parent=".sidebar"
                 >
                   {link.items.map(item => (
-                    <a
-                      key={`${item.text}${item.href}`}
-                      href={item.href}
-                      className={`nav-link`}
-                    >
-                      {item.text}
-                    </a>
+                    <SidebarItem key={`${item.text}${item.href}`} {...item} />
                   ))}
                 </div>
               </div>

--- a/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.tsx
+++ b/packages/unity-react-core/src/components/SidebarMenu/SidebarMenu.tsx
@@ -26,16 +26,6 @@ export interface SidebarProps {
   links: Link[];
 }
 
-const SidebarItem: React.FC<SidebarItemProps | Link> = ({
-  href,
-  text,
-  isActive,
-}) => (
-  <a href={href} className={`nav-link${isActive ? " is-active" : ""}`}>
-    {text}
-  </a>
-);
-
 export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
   return (
     <div className="col-xl-3 col-lg-4 col-md-5 col-sm-12">
@@ -58,8 +48,8 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
       >
         {links.map((link, index) => {
           if (link.items) {
-            const isExpanded = link.items.some(({ isActive }) => isActive);
             // Render dropdown card
+            const isExpanded = link.items.some(({ isActive }) => isActive);
             return (
               <div key={link.text} className="card card-foldable">
                 <div className="card-header">
@@ -68,7 +58,9 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
                   >
                     <a
                       id={`card${index}`}
-                      className="collapsed nav-link"
+                      className={`collapsed nav-link${
+                        isExpanded ? " is-active" : ""
+                      }`}
                       href={`#cardBody${index}`}
                       data-bs-toggle="collapse"
                       data-bs-target={`#cardBody${index}`}
@@ -87,7 +79,13 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
                   data-bs-parent=".sidebar"
                 >
                   {link.items.map(item => (
-                    <SidebarItem key={`${item.text}${item.href}`} {...item} />
+                    <a
+                      key={`${item.text}${item.href}`}
+                      href={item.href}
+                      className={`nav-link`}
+                    >
+                      {item.text}
+                    </a>
                   ))}
                 </div>
               </div>
@@ -99,7 +97,12 @@ export const SidebarMenu: React.FC<SidebarProps> = ({ title, links }) => {
                 key={`${link.text}${link.href}`}
                 className="nav-link-container"
               >
-                <SidebarItem {...link} />
+                <a
+                  className={`nav-link${link.isActive ? " is-active" : ""}`}
+                  href={link.href}
+                >
+                  {link.text}
+                </a>
               </div>
             );
           }


### PR DESCRIPTION
<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

sidebar menu should auto-expand if it contains an active page item

## Checklist

- [x] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1598)
- [Unity reference site - sidebarmenu](https://asu.github.io/asu-unity-stack/@asu/unity-react-core/index.html?path=/story/components-sidebarmenu--overview)
- [@asu/unity-react-core/index.html?path=/story/components-sidebarmenu--with-nested-active-page](https://unity-uds-staging.s3.us-west-2.amazonaws.com/pr-1568/@asu/unity-react-core/index.html?path=/story/components-sidebarmenu--with-nested-active-page)
- [Unity Design Kit - sidemenu states](https://zeroheight.com/9f0b32a56/p/00bdf9-sidebar-menu/b/81be66)

