### PR TITLE
fix(unity-bootstrap-theme): add process.env to vite build

### DIFF
--- a/packages/unity-bootstrap-theme/vite.config.bundle.js
+++ b/packages/unity-bootstrap-theme/vite.config.bundle.js
@@ -33,6 +33,10 @@ export default defineConfig((/** @type {import('vite').ConfigEnv} */ _) => {
         },
       },
     ],
+    define: {
+    process: {env: {NODE_ENV: process.env.NODE_ENV}}, // import.meta not available in cjs
+    global: {}
+  },
     build: {
       ...baseConfig.build,
       emptyOutDir: false,


### PR DESCRIPTION
There was an error in the js for unity where it was attempting to access process.env. It needs that at runtime

<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [ ] Tests pass for relevant code changes

