### PR TITLE
feat(unity-bootstrap-theme): apply dark maroon to visited links

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_misc.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_misc.scss
@@ -9,6 +9,11 @@
   }
 }
 
+// Global link visited state
+a:visited:not(.btn):not(.nav-link):not(.page-link):not(.card-link) {
+  color: $uds-color-base-darkmaroon;
+}
+
 // Separate Secondary Nav link that matches nav link used in global footer
 // Will be used in future efforts to make link more reusable.
 .secondary-nav-link {

--- a/packages/unity-bootstrap-theme/src/scss/variables/_colors.scss
+++ b/packages/unity-bootstrap-theme/src/scss/variables/_colors.scss
@@ -94,6 +94,7 @@ $link-color: $maroon;
 $link-decoration: underline;
 $link-hover-color: $maroon;
 $link-hover-decoration: none;
+$link-visited-color: $uds-color-base-darkmaroon;
 
 :focus {
   outline: 0;


### PR DESCRIPTION
### Description

**Problem:** Normal visited links do not currently have a distinct visual state, which can affect user experience by not indicating which links have been previously visited.

**Solution:** Applied dark maroon color (#440e22) to visited links to provide clear visual feedback. The implementation:
- Adds global visited link styling using `$uds-color-base-darkmaroon`
- Excludes buttons, navigation links, page links, and card links from the visited state to maintain their intended styling
- Maintains consistency with ASU brand guidelines for visited link states

**Testing Steps:**
1. Build the theme package: `cd packages/unity-bootstrap-theme && yarn build`
2. Open any page with standard links (not buttons or nav items)
3. Click on a link to visit it
4. Navigate back to verify the link now displays in dark maroon color (#440e22)

## Checklist

- [x] Tests pass for relevant code changes

## Important Reminders
No additional tests needed for this visual styling change. Existing build process validates SCSS compilation.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1677)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)