### PR TITLE
fix(unity-react-core): fix horizontal card rendering

### DIFF
--- a/packages/unity-react-core/src/components/CardArrangement/CardArrangement.jsx
+++ b/packages/unity-react-core/src/components/CardArrangement/CardArrangement.jsx
@@ -61,7 +61,8 @@ export const CardArrangement = ({ cards, cardType = "card", columns }) => {
       {cards.map((cardProps, index) => {
 
         return (
-          <div key={index} data-testid="uds-card-arrangement-content-container" className={`${ cardProps.horizontal === true ? "" : getColumnClass(columns)} mb-4`}>
+          /* If horizontal is true, webspark only allows 2 columns to display the horizontal card properly */
+          <div key={index} data-testid="uds-card-arrangement-content-container" className={`${ cardProps.horizontal === true ? "col-6" : getColumnClass(columns)} mb-4`}>
             <CardComponent {...cardProps} />
           </div>
         );

--- a/packages/unity-react-core/src/components/CardArrangement/CardArrangement.test.jsx
+++ b/packages/unity-react-core/src/components/CardArrangement/CardArrangement.test.jsx
@@ -77,7 +77,7 @@ describe("CardArrangement", () => {
     const { getAllByTestId: getHorizontal } = render(
       <CardArrangement cards={horizontalCards} columns={3} />
     );
-    expect(getHorizontal("uds-card-arrangement-content-container")[0].className).not.toContain("col");
+    expect(getHorizontal("uds-card-arrangement-content-container")[0].className).toContain("col-6");
   });
 
   it("should render cards with correct titles", () => {


### PR DESCRIPTION
 fix horizontal card rendering. The horizontal cards were not being displayed according to webspark's default horizontal 2-column style

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-1899)

