### PR TITLE
fix(unity-react-core): fix image card rendering in card arrangement

### DIFF
--- a/packages/unity-react-core/src/components/CardArrangement/CardArrangement.jsx
+++ b/packages/unity-react-core/src/components/CardArrangement/CardArrangement.jsx
@@ -74,8 +74,9 @@ export const CardArrangement = ({ cards, cardType = "card", columns }) => {
 
 CardArrangement.propTypes = {
   /**
-   * Array of card objects to render. Each object should contain props for the Card or RankingCard component.
-   * Cards will wrap naturally based on their intrinsic min/max widths.
+   * Array of card objects to render. Each object should contain props for the
+   * Card or RankingCard component. Cards will wrap naturally based on their
+   * intrinsic min/max widths.
    */
   cards: PropTypes.arrayOf(PropTypes.object).isRequired,
   /**

--- a/packages/unity-react-core/src/components/CardArrangement/CardArrangement.jsx
+++ b/packages/unity-react-core/src/components/CardArrangement/CardArrangement.jsx
@@ -2,6 +2,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Card } from "../Card/Card";
+import { Image } from "../Image/Image";
 import { RankingCard } from "../RankingCard/RankingCard";
 
 /**
@@ -14,8 +15,8 @@ import { RankingCard } from "../RankingCard/RankingCard";
 
 /**
  * @typedef {Object} CardArrangementProps
- * @property {(IndividualCardProps[] | IndividualRankingCardProps[])} cards - Array of card props objects to render
- * @property {"card" | "ranking"} [cardType="card"] - Type of card to render
+ * @property {(IndividualCardProps[] | IndividualRankingCardProps[] | import('../Image/Image').ImageProps[] )} cards - Array of card props objects to render
+ * @property {"card" | "ranking" | "image"} [cardType="card"] - Type of card to render
  * @property {1 | 2 | 3 | 4 | "1" | "2" | "3" | "4"} [columns] - Number of columns to display (optional)
  */
 
@@ -38,8 +39,18 @@ export const CardArrangement = ({ cards, cardType = "card", columns }) => {
   if (!cards || cards.length === 0) {
     return null;
   }
-
-  const CardComponent = cardType === "ranking" ? RankingCard : Card;
+  let CardComponent;
+  switch (cardType) {
+    case "ranking":
+      CardComponent = RankingCard;
+      break;
+    case "image":
+      CardComponent = Image;
+      break;
+    default:
+      CardComponent = Card;
+      break;
+  }
   const defaultColClass = COLUMN_CLASSES[columns] || "col-12 col-md-auto";
 
   return (
@@ -68,9 +79,9 @@ CardArrangement.propTypes = {
    */
   cards: PropTypes.arrayOf(PropTypes.object).isRequired,
   /**
-   * Type of card to render - either "card" (default) or "ranking"
+   * Type of card to render - either "card" (default), "ranking", or "image"
    */
-  cardType: PropTypes.oneOf(["card", "ranking"]),
+  cardType: PropTypes.oneOf(["card", "ranking", "image"]),
   /**
    * Number of columns to display.
    */

--- a/packages/unity-react-core/src/components/CardArrangement/CardArrangement.stories.jsx
+++ b/packages/unity-react-core/src/components/CardArrangement/CardArrangement.stories.jsx
@@ -5,9 +5,16 @@ import { CardArrangement } from "./CardArrangement";
 
 const img1 = imageAny();
 
+
 export default {
   title: "Components/Card Arrangement",
   component: CardArrangement,
+  argTypes: {
+    cards: {
+      description:
+        'Array of card objects to render. Each object should contain props for the Card, Image or RankingCard component. Cards will wrap naturally based on their intrinsic min/max widths. When using the Card component, cards can supply a type of "default", "degree", "event" or "story"',
+    },
+  },
   parameters: {
     docs: {
       description: {
@@ -15,8 +22,7 @@ export default {
 
 ## Usage
 
-The component accepts an array of card objects and automatically arranges them with flexbox wrapping.
-Cards will flow and wrap based on their min/max width constraints and the available space in the parent container.
+CardArrangement component receives Array of card objects to render. Each object should contain props for the Card, Image or RankingCard component. Cards will wrap naturally based on their intrinsic min/max widths. When using the Card component, cards can supply a type of "default", "degree", "event" or "story"
 
 The parent container determines the overall width - this component simply handles laying out the cards
 with appropriate spacing and letting them wrap naturally.
@@ -183,6 +189,36 @@ const degreeCards = [
     imageAltText: "Degree program 4",
     title: "Psychology, BA",
     body: "Understand human behavior and mental processes through scientific inquiry.",
+  },
+];
+
+const imageCards = [
+  {
+    type: "image",
+    src: img1,
+    alt: "Image card 1",
+    captionTitle: "Image Card One",
+    caption: "This is the body content for the first image card with dropshadow and with cardLink prop provided. Card acts as anchor/link",
+    border: true,
+    dropShadow: true,
+    cardLink: "https://example.com",
+    title: "example"
+  },
+  {
+    type: "image",
+    src: img1,
+    alt: "Image card 2",
+    captionTitle: "Image Card Two",
+    caption: "This is the body content for the second image card with no border",
+  },
+  {
+    type: "image",
+    src: img1,
+    alt: "Image card 3",
+    captionTitle: "Image Card Three",
+    caption: "This is the body content for the third image card with no drop shadow.",
+    border: true,
+    dropShadow: false,
   },
 ];
 
@@ -572,6 +608,30 @@ Example with small ranking cards that include citations and compact layout.
 <CardArrangement
   cards={rankingCardsSmall}
   cardType="ranking"
+/>
+\`\`\`
+      `,
+    },
+  },
+};
+
+export const ImageCards = Template.bind({});
+ImageCards.args = {
+  cards: imageCards,
+  cardType: "image",
+  columns: 3,
+};
+ImageCards.storyName = "Image cards";
+ImageCards.parameters = {
+  docs: {
+    description: {
+      story: `
+Example with image cards that display a visual representation along with heading and body text.
+
+\`\`\`jsx
+<CardArrangement
+  cards={imageCards}
+  cardType="image"
 />
 \`\`\`
       `,

--- a/packages/unity-react-core/src/components/CardArrangement/CardArrangement.stories.jsx
+++ b/packages/unity-react-core/src/components/CardArrangement/CardArrangement.stories.jsx
@@ -261,19 +261,19 @@ Example with four degree cards that will wrap based on available space.
 export const HorizontalCards = Template.bind({});
 HorizontalCards.args = {
   cards: [
-      {
-        type: "default",
-        title: "Horizontal",
-        body: "Body",
-        horizontal: true,
-      },
-      {
-        type: "default",
-        title: "Horizontal",
-        body: "Body",
-        horizontal: true,
-      },
-    ],
+    {
+      type: "default",
+      title: "Horizontal",
+      body: "Body",
+      horizontal: true,
+    },
+    {
+      type: "default",
+      title: "Horizontal",
+      body: "Body",
+      horizontal: true,
+    },
+  ],
 };
 HorizontalCards.storyName = "Horizontal cards example";
 HorizontalCards.parameters = {
@@ -361,7 +361,8 @@ MixedCardTypesNoColProvided.args = {
     },
   ],
 };
-MixedCardTypesNoColProvided.storyName = "Mixed card types (no columns specified)";
+MixedCardTypesNoColProvided.storyName =
+  "Mixed card types (no columns specified)";
 MixedCardTypesNoColProvided.parameters = {
   docs: {
     description: {
@@ -468,7 +469,8 @@ const rankingCardsLarge = [
     heading: "Sustainability Excellence",
     body: "Leading the way in sustainable practices and environmental initiatives.",
     readMoreLink: "#",
-  },{
+  },
+  {
     imageSize: "large",
     image: img1,
     imageAlt: "Ranking image 1",
@@ -533,7 +535,7 @@ export const RankingCardsLarge = Template.bind({});
 RankingCardsLarge.args = {
   cards: rankingCardsLarge,
   cardType: "ranking",
-  columns: 4
+  columns: 4,
 };
 RankingCardsLarge.storyName = "Ranking cards (large)";
 RankingCardsLarge.parameters = {
@@ -557,7 +559,7 @@ export const RankingCardsSmall = Template.bind({});
 RankingCardsSmall.args = {
   cards: rankingCardsSmall,
   cardType: "ranking",
-  columns: 2
+  columns: 2,
 };
 RankingCardsSmall.storyName = "Ranking cards (small)";
 RankingCardsSmall.parameters = {

--- a/packages/unity-react-core/src/components/CardArrangement/CardArrangement.test.jsx
+++ b/packages/unity-react-core/src/components/CardArrangement/CardArrangement.test.jsx
@@ -41,23 +41,29 @@ describe("CardArrangement", () => {
     expect(cardItems).toHaveLength(3);
   });
 
-    it("should apply correct column classes based on columns prop", () => {
+  it("should apply correct column classes based on columns prop", () => {
     const { getAllByTestId: get2Cols, unmount: unmount2 } = render(
       <CardArrangement cards={mockCards} columns={2} />
     );
-    expect(get2Cols("uds-card-arrangement-content-container")[0].className).toContain("col-12 col-md-6");
+    expect(
+      get2Cols("uds-card-arrangement-content-container")[0].className
+    ).toContain("col-12 col-md-6");
     unmount2();
 
     const { getAllByTestId: get3Cols, unmount: unmount3 } = render(
       <CardArrangement cards={mockCards} columns={3} />
     );
-    expect(get3Cols("uds-card-arrangement-content-container")[0].className).toContain("col-12 col-md-6 col-lg-4");
+    expect(
+      get3Cols("uds-card-arrangement-content-container")[0].className
+    ).toContain("col-12 col-md-6 col-lg-4");
     unmount3();
 
     const { getAllByTestId: get4Cols, unmount: unmount4 } = render(
       <CardArrangement cards={mockCards} columns={4} />
     );
-    expect(get4Cols("uds-card-arrangement-content-container")[0].className).toContain("col-12 col-md-6 col-lg-4 col-xl-3");
+    expect(
+      get4Cols("uds-card-arrangement-content-container")[0].className
+    ).toContain("col-12 col-md-6 col-lg-4 col-xl-3");
     unmount4();
 
     const horizontalCards = [
@@ -77,7 +83,9 @@ describe("CardArrangement", () => {
     const { getAllByTestId: getHorizontal } = render(
       <CardArrangement cards={horizontalCards} columns={3} />
     );
-    expect(getHorizontal("uds-card-arrangement-content-container")[0].className).toContain("col-12 col-md-6");
+    expect(
+      getHorizontal("uds-card-arrangement-content-container")[0].className
+    ).toContain("col-12 col-md-6");
   });
 
   it("should render cards with correct titles", () => {
@@ -140,21 +148,22 @@ describe("CardArrangement", () => {
   });
 
   it("should pass through card props correctly", () => {
-    const cardsWithButtons = /** @type {import('./CardArrangement').CardArrangementProps['cards']} */ ([
-      {
-        type: "default",
-        title: "Card with Button",
-        body: "Body content",
-        buttons: [
-          {
-            color: /** @type {"maroon"} */ ("maroon"),
-            size: /** @type {"default"} */ ("default"),
-            label: "Click me",
-            href: "#",
-          },
-        ],
-      },
-    ]);
+    const cardsWithButtons =
+      /** @type {import('./CardArrangement').CardArrangementProps['cards']} */ ([
+        {
+          type: "default",
+          title: "Card with Button",
+          body: "Body content",
+          buttons: [
+            {
+              color: /** @type {"maroon"} */ ("maroon"),
+              size: /** @type {"default"} */ ("default"),
+              label: "Click me",
+              href: "#",
+            },
+          ],
+        },
+      ]);
 
     const { getByTestId } = render(
       <CardArrangement cards={cardsWithButtons} />
@@ -220,7 +229,7 @@ describe("CardArrangement", () => {
     cardItems.forEach(cardItem => {
       const directChild = cardItem.firstElementChild;
       expect(directChild).toBeDefined();
-      expect(directChild.className).toContain('card-ranking');
+      expect(directChild.className).toContain("card-ranking");
     });
   });
 


### PR DESCRIPTION
fix image card rendering in card arrangement
See screenshots below of what it looks like in webspark
<img width="1305" height="627" alt="Screenshot 2026-01-28 at 12 02 20 PM" src="https://github.com/user-attachments/assets/1b49a599-dc4a-47c3-8858-71d5308496d8" />
<img width="1360" height="463" alt="Screenshot 2026-01-28 at 12 03 59 PM" src="https://github.com/user-attachments/assets/380a1aa3-7735-4edc-83c9-b6187eff599b" />
<img width="822" height="529" alt="Screenshot 2026-01-28 at 12 04 13 PM" src="https://github.com/user-attachments/assets/b233a62a-c68c-4b10-a494-4e08e1d41bdd" />
<img width="393" height="485" alt="Screenshot 2026-01-28 at 12 04 22 PM" src="https://github.com/user-attachments/assets/97f6fbe8-0755-4930-8e8c-a89639a3e107" />

