### PR TITLE
fix(unity-bootstrap-theme): prevent video script conflict

### DIFF
--- a/packages/unity-bootstrap-theme/src/js/heroes-video.js
+++ b/packages/unity-bootstrap-theme/src/js/heroes-video.js
@@ -2,9 +2,10 @@ import { EventHandler } from "./bootstrap-helper";
 
 function initHeroesVideo() {
   // common selectors
-  const DOM_ELEMENT_VIDEO = "video";
-  const DOM_ELEMENT_BTN_PLAY = "#playHeroVid";
-  const DOM_ELEMENT_BTN_PAUSE = "#pauseHeroVid";
+  const DOM_PARENT = ".uds-video-hero";
+  const DOM_ELEMENT_VIDEO = DOM_PARENT + " video";
+  const DOM_ELEMENT_BTN_PLAY = DOM_PARENT + " #playHeroVid";
+  const DOM_ELEMENT_BTN_PAUSE = DOM_PARENT + " #pauseHeroVid";
   const EVENT_CLICK = "click";
   const STYLE_DISPLAY_BLOCK = "block";
   const STYLE_DISPLAY_NONE = "none";

--- a/packages/unity-bootstrap-theme/src/js/video.js
+++ b/packages/unity-bootstrap-theme/src/js/video.js
@@ -2,9 +2,10 @@ import { EventHandler } from "./bootstrap-helper";
 
 function initVideo() {
   // constants
-  const DOM_ELEMENT_VIDEO = "video";
-  const DOM_ELEMENT_VIDEO_BTN = ".uds-video-btn-play";
-  const DOM_ELEMENT_VIDEO_OVERLAY = ".uds-video-overlay";
+  const DOM_PARENT = ".uds-video-player";
+  const DOM_ELEMENT_VIDEO = DOM_PARENT + " video";
+  const DOM_ELEMENT_VIDEO_BTN = DOM_PARENT + " .uds-video-btn-play";
+  const DOM_ELEMENT_VIDEO_OVERLAY = DOM_PARENT + " .uds-video-overlay";
   const EVENT_CLICK = "click";
   const EVENT_ENDED = "ended";
   const STYLE_DISPLAY_FLEX = "flex";


### PR DESCRIPTION
<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

 - video.js and heroes-video scripts were both attaching events to the same video elements

Solution
- add parent to query selector
<!-- Testing Steps -->

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2070)

