### PR TITLE
fix(unity-bootstrap-theme): improve hero small button positioning

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -375,7 +375,7 @@ div.uds-hero-lg {
   }
 
   div.uds-hero-sm {
-    grid-template-rows: 0px 1fr 0px auto;
+    grid-template-rows: 0px 1fr auto auto;
 
     > a.btn {
       position: relative;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -375,17 +375,21 @@ div.uds-hero-lg {
   }
 
   div.uds-hero-sm {
-    grid-template-rows: 1fr auto auto $uds-size-spacing-7;
-    &.has-btn-row {
-      .btn-row {
-        top: 90%;
-      }
-    }
+    grid-template-rows: 0px 1fr 0px auto;
 
     > a.btn {
-      grid-row: unset;
-      position: absolute;
-      top: 14.5rem;
+      position: relative;
+      top: auto;
+      grid-row: 4;
+    }
+
+    &.has-btn-row {
+      .btn-row {
+        position: relative;
+        margin-top: 1rem;
+        top: auto;
+        grid-row: 4;
+      }
     }
   }
 


### PR DESCRIPTION
### Description

  **Problem:**
  The `uds-hero-sm` component uses absolute positioning for buttons, which causes overlap issues with
  header content when text is long or on small screens. The fixed `top: 14.5rem` value doesn't adapt
  to different content sizes.
This issue is reported at : https://asudev.jira.com/browse/WS2-2385
  **Solution:**
  - Changed button positioning from `position: absolute` to `position: relative`
  - Updated grid layout from `grid-template-rows: 1fr auto auto $uds-size-spacing-7` to
  `grid-template-rows: 0px 1fr 0px auto`
  - Set buttons to use `grid-row: 4` for proper grid placement
  - Added `margin-top: 1rem` to `.has-btn-row .btn-row` for better spacing
  - Buttons now flow naturally within the grid instead of using fixed positioning

  **Testing Steps:**
  1. Build the package: `cd packages/unity-bootstrap-theme && yarn build`
  2. Start Storybook: `yarn storybook`
  3. Navigate to "Molecules/Heroes/Examples" → "Hero Small With Buttons"
  4. Verify buttons are positioned correctly without overlapping content (Also, try zooming in until 200%)
  5. Test with long headings (2-3 lines) to ensure no overlap occurs
  6. Test responsive behavior on mobile, tablet, and desktop viewports
  7. Verify both single button and button row scenarios work correctly

  ## Checklist

  - [x] Tests pass for relevant code changes

  ## Important Reminders
  <!-- Add meaningful tests -->
  <!-- Remove tests that do not provide value -->

  ### Links

  - [JIRA ticket](https://asudev.jira.com/browse/UDS-2124)
  - [Unity reference site](https://asu.github.io/asu-unity-stack/)
  - [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)