### PR TITLE
fix(unity-bootstrap-theme): fix anchor menu js

### DIFF
--- a/packages/unity-bootstrap-theme/src/js/anchor-menu.js
+++ b/packages/unity-bootstrap-theme/src/js/anchor-menu.js
@@ -15,9 +15,9 @@ function initAnchorMenu() {
   const globalHeader = document.getElementById(globalHeaderId);
   const navbar = document.getElementById("uds-anchor-menu");
   if (!navbar || !globalHeader) {
-    console.warn(
-      "Anchor menu initialization failed: required elements not found"
-    );
+    return;
+  }
+  if (Array.from(navbar.classList).some(cls => cls.startsWith("sc-"))) {
     return;
   }
 
@@ -203,10 +203,26 @@ function initAnchorMenu() {
         return;
       }
 
-      // Get current viewport height and calculate the 1/4 position so that the
-      // top of section is visible when you click on the anchor.
+      // For the first anchor item, skip scrolling if the section top is
+      // already clearly visible in the viewport (above the midpoint).
+      const isFirstAnchor = anchor === anchors[0];
+      if (isFirstAnchor) {
+        const headerBottom = globalHeader.getBoundingClientRect().bottom;
+        const navbarHeight = navbar.offsetHeight;
+        const topOffset = headerBottom + navbarHeight;
+        const targetTop = anchorTarget.getBoundingClientRect().top;
+        const viewportMid = window.innerHeight / 2;
+        console.log("viewportmid", viewportMid, "targetTop", targetTop);
+
+        if (targetTop >= topOffset && targetTop <= viewportMid) {
+          history.replaceState(null, "", anchor.getAttribute("href"));
+          moveFocusToTarget(anchorTarget);
+          return;
+        }
+      }
+
       const viewportHeight = window.innerHeight;
-      const targetQuarterPosition = Math.round(viewportHeight * 0.25);
+      const targetQuarterPosition = Math.round(viewportHeight * 0.35); // 35% was determined to be a good position for the section top after testing different offsets, including centering the section in the viewport. Can work in wordpress or any other platform where there are admin toolbars
 
       const targetAbsoluteTop =
         anchorTarget.getBoundingClientRect().top + window.scrollY;
@@ -226,7 +242,33 @@ function initAnchorMenu() {
       }
 
       e.target.classList.add("active");
+
+      const targetHash = anchor.getAttribute("href");
+      if (targetHash) {
+        history.replaceState(null, "", targetHash);
+      }
+
+      // Move focus to the target section so keyboard users can Tab
+      // into its content (WCAG 2.4.3 Focus Order).
+      moveFocusToTarget(anchorTarget);
     });
+  }
+
+  /**
+   * Moves keyboard focus to the anchor target section.
+   * Adds tabindex="-1" if needed so the element is programmatically
+   * focusable without entering the natural tab order.
+   *
+   * fixes
+   * WCAG 2.4.3 Focus Order (Level A) — focus sequence doesn't match visual/logical order
+   * WCAG 2.1.1 Keyboard (Level A) — functionality isn't fully keyboard operable
+   */
+  function moveFocusToTarget(target) {
+    if (!target.hasAttribute("tabindex")) {
+      target.setAttribute("tabindex", "-1");
+      target.style.outline = "none";
+    }
+    target.focus({ preventScroll: true });
   }
 }
 

--- a/packages/unity-bootstrap-theme/src/js/anchor-menu.js
+++ b/packages/unity-bootstrap-theme/src/js/anchor-menu.js
@@ -53,8 +53,6 @@ function initAnchorMenu() {
     const target = document.getElementById(targetId);
     if (target) {
       anchorTargets.set(anchor, target);
-    } else {
-      console.warn(`Anchor menu: target element "${targetId}" not found`);
     }
   }
 
@@ -199,7 +197,7 @@ function initAnchorMenu() {
       e.preventDefault();
 
       if (!anchorTarget || !document.body.contains(anchorTarget)) {
-        console.warn("Anchor target no longer exists in DOM");
+        console.warn("Anchor target no longer exists in DOM"); // This should be rare but if the target element has been removed from the DOM, this will make debuggin easier in webspark sites
         return;
       }
 
@@ -212,7 +210,6 @@ function initAnchorMenu() {
         const topOffset = headerBottom + navbarHeight;
         const targetTop = anchorTarget.getBoundingClientRect().top;
         const viewportMid = window.innerHeight / 2;
-        console.log("viewportmid", viewportMid, "targetTop", targetTop);
 
         if (targetTop >= topOffset && targetTop <= viewportMid) {
           history.replaceState(null, "", anchor.getAttribute("href"));

--- a/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.jsx
+++ b/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.jsx
@@ -56,11 +56,21 @@ export const AnchorMenu = ({
     showMenu: false,
     sticky: false,
   });
-  const headerHeight = isSmallDevice ? 110 : 142;
+
+  const getPageHeader = () =>
+    document.getElementById("asu-header") ||
+    document.getElementById("headerContainer") ||
+    document.getElementById("asuHeader");
+
+  const getHeaderBottomOffset = () => {
+    const pageHeader = getPageHeader();
+    return Math.max(pageHeader?.getBoundingClientRect().bottom || 0, 0);
+  };
 
   const handleWindowScroll = () => {
     const newState = {};
     const curPos = window.scrollY;
+    const headerBottomOffset = getHeaderBottomOffset();
     // Select first next sibling element of the anchor menu
     const firstElement = document
       .getElementById(firstElementId)
@@ -77,7 +87,7 @@ export const AnchorMenu = ({
 
     // Change active containers on scroll
     const subsHeight = state.hasHeader
-      ? headerHeight + anchorMenuHeight
+      ? headerBottomOffset + anchorMenuHeight
       : anchorMenuHeight;
     items?.forEach(({ targetIdName }) => {
       const container = document.getElementById(targetIdName);
@@ -105,10 +115,7 @@ export const AnchorMenu = ({
 
   // Is ASU Header on the document
   const isHeader = () => {
-    const pageHeader =
-      document.getElementById("asu-header") ||
-      document.getElementById("headerContainer") ||
-      document.getElementById("asuHeader");
+    const pageHeader = getPageHeader();
     return !!pageHeader;
   };
 
@@ -162,9 +169,10 @@ export const AnchorMenu = ({
   }, [state.hasHeader]);
 
   const handleClickLink = container => {
+    const headerBottomOffset = getHeaderBottomOffset();
     // Set scroll position considering if ASU Header is setted or not
     const curScroll =
-      window.scrollY - (state.hasHeader ? headerHeight + 100 : 100);
+      window.scrollY - (state.hasHeader ? headerBottomOffset + 100 : 100);
     const anchorMenuHeight = isSmallDevice ? 410 : 90;
     // Set where to scroll to
     let scrollTo =
@@ -187,11 +195,19 @@ export const AnchorMenu = ({
     }));
   };
 
+  const headerBottomOffset = state.hasHeader ? getHeaderBottomOffset() : 0;
+  const WrapperComponent = isBootstrap ? "div" : AnchorMenuWrapper;
+  const wrapperProps = isBootstrap
+    ? {}
+    : {
+        // @ts-ignore
+        requiresAltMenuSpacing: state.hasAltMenuSpacing,
+      };
+
   return (
     items?.length > 0 && (
-      <AnchorMenuWrapper
-        // @ts-ignore
-        requiresAltMenuSpacing={state.hasAltMenuSpacing}
+      <WrapperComponent
+        {...wrapperProps}
         ref={anchorMenuRef}
         id="uds-anchor-menu"
         className={classNames(
@@ -203,7 +219,10 @@ export const AnchorMenu = ({
             [`with-header`]: state.hasHeader,
           }
         )}
-        style={state.showMenu ? { borderBottom: 0 } : {}}
+        style={{
+          ...(state.showMenu ? { borderBottom: 0 } : {}),
+          "--uds-anchor-menu-top": `${headerBottomOffset}px`,
+        }}
       >
         <div className={`${state.containerClass} uds-anchor-menu-wrapper`}>
           {isSmallDevice ? (
@@ -265,7 +284,7 @@ export const AnchorMenu = ({
             </nav>
           </div>
         </div>
-      </AnchorMenuWrapper>
+      </WrapperComponent>
     )
   );
 };

--- a/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.stories.jsx
+++ b/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.stories.jsx
@@ -95,8 +95,7 @@ const Template = args => {
 
   return (
     <>
-      {/* Bootstrap version of anchor menu depends on the header component */}
-      {isBootstrap && <Header />}
+      <Header />
 
       <div className={classNames("container")}>
         <div className={classNames("row", "row-spaced", "pt-2", "pb-2")}>

--- a/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.styles.js
+++ b/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.styles.js
@@ -3,16 +3,9 @@ import styled from "styled-components";
 const AnchorMenuWrapper = styled.div`
   &.sticky {
     position: fixed;
-    top: 0;
+    top: var(--uds-anchor-menu-top, 0px);
     left: 0;
     width: 100%;
-    &.with-header {
-      top: ${({ requiresAltMenuSpacing }) =>
-        requiresAltMenuSpacing ? "112px" : "142px"};
-      @media (max-width: 992px) {
-        top: 110px;
-      }
-    }
   }
   .mobile-menu-toggler {
     background-color: transparent;


### PR DESCRIPTION
Anchor menu fix to fix the focus order as well as adds correct hash in url bar. Also adds check for unity-react-core react anchor menu since that handles its own logic, currently used in app degree detail page. Eventually we want to remove that logic in the unity-react-core anchor menu but that will be a breaking change. 


I tried using scroll padding and scroll margin only but when I tested it on Fulton engineering's wordpress site, it did not work as expected. This was tested on multiple sites and seems to be the best solution I have used so far
### Description

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [x] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1717)

