### PR TITLE
Fix icon cards showing empty image

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -151,6 +151,8 @@ Cards - Table of Contents
 
 .card:not(.card.card-foldable) > div:first-of-type:not(.card-image-content) {
   flex-grow: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .card:not(:has(.card-header)) .card-body {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -456,6 +456,7 @@ Cards - Table of Contents
   align-items: flex-end;
   margin-top: auto;
   padding-bottom: 0px;
+  padding-right: $uds-size-spacing-4;
 }
 
 .card-content-wrapper:has(.card-arrow-link) {
@@ -474,6 +475,8 @@ Cards - Table of Contents
   display: flex !important;
   align-items: center;
   justify-content: center;
+  font-size: $uds-size-font-large;
+  font-weight: $uds-font-weight-bolder;
 
   &::before {
         content: "";
@@ -492,8 +495,7 @@ Cards - Table of Contents
   }
 
   .fa-arrow-right {
-    width: .875rem;
-    height: .875rem;
+    font-size: $uds-size-font-large;
     color: $asu-gray-4;
   }
 
@@ -512,6 +514,7 @@ Cards - Table of Contents
 
     .fa-arrow-right {
       color: inherit;
+      font-size: $uds-size-font-medium;
     }
 
   }

--- a/packages/unity-react-core/src/components/Card/Card.jsx
+++ b/packages/unity-react-core/src/components/Card/Card.jsx
@@ -20,7 +20,7 @@ const gaDefaultObject = {
   region: "main content",
 };
 
-const isEventOrNewsCard = (type) => type === "event" || type === "news";
+const isEventOrNewsCard = type => type === "event" || type === "news";
 
 /**
  * @typedef {import('../../core/types/card-types').CardProps} CardProps
@@ -188,7 +188,7 @@ const BaseCard = ({
     [`borderless`]: !showBorders,
   });
 
-  const shouldShowImage = isEventOrNewsCard(type) ? !!image : true;
+  const shouldShowImage = typeof image === "string" && image.length > 0;
   const shouldIncludeCardLink = !isEventOrNewsCard(type);
 
   return (
@@ -312,11 +312,7 @@ const CardContent = ({
               text: title,
             }}
           >
-            <a
-              href={cardLink}
-              className="card-arrow-link"
-              aria-label={title}
-            >
+            <a href={cardLink} className="card-arrow-link" aria-label={title}>
               <i className="fas fa-arrow-right" aria-hidden="true" />
             </a>
           </GaEventWrapper>

--- a/packages/unity-react-core/src/components/CardArrangement/CardArrangement.stories.jsx
+++ b/packages/unity-react-core/src/components/CardArrangement/CardArrangement.stories.jsx
@@ -5,7 +5,6 @@ import { CardArrangement } from "./CardArrangement";
 
 const img1 = imageAny();
 
-
 export default {
   title: "Components/Card Arrangement",
   component: CardArrangement,
@@ -85,8 +84,9 @@ const eventCards = [
     type: "event",
     image: img1,
     imageAltText: "Event image 1",
-    title: "Innovation Summit 2024",
-    body: "Join us for a day of innovation and collaboration with industry leaders.",
+    title:
+      "Innovation Summit 2024 with a very long title that should wrap to multiple lines and test the card height consistency across cards in the same row",
+    body: "Join us for a day of innovation and collaboration with industry leaders. Also a long body text to test height consistency across cards in the same row.",
     eventFormat: "stack",
     eventTime: "Wed, March 15, 2024<br />9:00 a.m - 5:00 p.m.",
     eventLocation: "Tempe campus",
@@ -198,25 +198,28 @@ const imageCards = [
     src: img1,
     alt: "Image card 1",
     captionTitle: "Image Card One",
-    caption: "This is the body content for the first image card with dropshadow and with cardLink prop provided. Card acts as anchor/link",
+    caption:
+      "This is the body content for the first image card with dropshadow and with cardLink prop provided. Card acts as anchor/link",
     border: true,
     dropShadow: true,
     cardLink: "https://example.com",
-    title: "example"
+    title: "example",
   },
   {
     type: "image",
     src: img1,
     alt: "Image card 2",
     captionTitle: "Image Card Two",
-    caption: "This is the body content for the second image card with no border",
+    caption:
+      "This is the body content for the second image card with no border",
   },
   {
     type: "image",
     src: img1,
     alt: "Image card 3",
     captionTitle: "Image Card Three",
-    caption: "This is the body content for the third image card with no drop shadow.",
+    caption:
+      "This is the body content for the third image card with no drop shadow.",
     border: true,
     dropShadow: false,
   },


### PR DESCRIPTION
Fix icon cards showing empty image along with some minor styling edits for event/news cards.
The logic for the const `shouldShowImage` was flawed and images show only show if a valid src string is  passed in.
Fixes this issue found in testing:
<img width="499" height="192" alt="Screenshot 2026-04-10 at 11 56 59 AM" src="https://github.com/user-attachments/assets/52e803a0-2924-462e-9351-92fbc7ea9c64" />

After fix:
<img width="1406" height="654" alt="Screenshot 2026-04-10 at 11 59 34 AM" src="https://github.com/user-attachments/assets/cbee91cc-2e5d-4f6e-b299-0a167a4aa264" />



Also fixes small changes requested by brand team: https://docs.google.com/spreadsheets/d/15uIIRvxWJGDZ1xr6ddhFWA6-lAkX0Ao2hjjGbP8Jksw/edit?gid=0#gid=0

### Description

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [x] Tests pass for relevant code changes


