### PR TITLE
fix(app-webdir-ui): ensure filter buttons meet WCAG 2.2 minimum targe…

### DIFF
--- a/packages/app-webdir-ui/src/helpers/Filter/index.styles.js
+++ b/packages/app-webdir-ui/src/helpers/Filter/index.styles.js
@@ -27,6 +27,8 @@ export const FilterContainer = styled.fieldset`
       display: none;
     }
     .choice {
+      min-width: 24px;
+      min-height: 24px;
       &:hover {
         text-decoration: none;
       }


### PR DESCRIPTION
### Title: fix(app-webdir-ui): ensure filter buttons meet WCAG 2.2 minimum target size

 ###  Body:
  ## Summary
  - Add `min-width: 24px` and `min-height: 24px` to `.choice` buttons in the "Filter By Last Initial" component
  - Ensures compliance with WCAG 2.2 Target Size (Minimum) criterion
  - No visual or behavioral changes — buttons already meet the minimum via existing padding

  ## Test plan
  - [ ] Open Storybook for `app-webdir-ui` Web Directory Templates story
  - [ ] Enable `alphaFilter` in Controls panel
  - [ ] Verify filter buttons (A–Z) render at least 24x24px using DevTools
  - [ ] Confirm no visual regression in button appearance
