### PR TITLE
fix(unity-bootstrap-theme): hero small CTA overflow at <768px (UDS-2171)

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -237,7 +237,9 @@ div.uds-hero-sm {
     .btn-row {
       align-self: flex-start;
       flex-wrap: wrap;
-      top: 15rem;
+      grid-row: 4;
+      position: relative;
+      margin-top: 1rem;
 
       a.btn {
         margin-top: 0;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -240,6 +240,7 @@ div.uds-hero-sm {
       grid-row: 4;
       position: relative;
       margin-top: 1rem;
+      margin-bottom: 1rem;
 
       a.btn {
         margin-top: 0;


### PR DESCRIPTION
## Summary
- Fixes the QA finding from UDS-2171: at viewports between mobile and the 768px breakpoint (e.g. 764×921, 200% zoom on small screens, mobile DevTools view), the Small Hero CTA button hangs out of the hero image into the section below.
- Root cause: \`.btn-row\` used \`position: absolute; top: 15rem\` (240px) inside a container with \`min-height: 16rem\` (256px) and default \`overflow: visible\` — button bottom (240+~44=284) exceeded the container by ~28-36px until \`min-width: 768px\` swapped to grid placement.
- Fix scoped to \`uds-hero-sm\` only: replace the absolute positioning with the same grid-flow pattern already used at tablet+ (\`grid-row: 4; position: relative; margin-top: 1rem\`). Container now expands naturally to contain the button. \`uds-hero-md\` and \`uds-hero-lg\` are intentionally untouched (not part of the QA report).

## Diff
\`\`\`diff
@@ div.uds-hero-sm.has-btn-row .btn-row @@
       align-self: flex-start;
       flex-wrap: wrap;
-      top: 15rem;
+      grid-row: 4;
+      position: relative;
+      margin-top: 1rem;
\`\`\`

3 lines added, 1 removed. \`yarn css-lint\` passes; full SCSS compiles cleanly.

## Test plan
Tested in Chrome at multiple viewports (computed styles + visual screenshots):

| viewport | hero h | btn position | overflow |
|---|---|---|---|
| 764×921 (the reported bug) | 260px | rel, grid-row:4, mt:16 | **−48px (contained ✓)** |
| 767×921 (just below breakpoint) | 260px | rel, grid-row:4 | −48px ✓ |
| 500×921 (mobile) | 256px | rel, grid-row:4 | −48px ✓ |
| 800×921 (tablet+) | 260px | rel, grid-row:4, mt:16 | −48px ✓ (identical to existing tablet+ behavior) |
| 764×921 Medium Hero | 336px | abs, top:320 (untouched) | unchanged from main |

- [ ] Verify on \`websparkci-dev-asufactory1.acquia.asu.edu/hero\` after deploy
- [ ] Confirm 200% zoom at small screens shows button contained
- [ ] Confirm Medium/Large heroes look unchanged (out of scope for this ticket)