### PR TITLE
fix(component-header-footer): fix header dropdown height

### DIFF
--- a/packages/component-header-footer/src/header/components/HeaderMain/NavbarContainer/DropdownItem/index.styles.js
+++ b/packages/component-header-footer/src/header/components/HeaderMain/NavbarContainer/DropdownItem/index.styles.js
@@ -50,13 +50,16 @@ const DropdownWrapper = styled.div`
       --span: 1; /* component overrides using inline style */
       --col: 1; /* component overrides using inline style */
       width: calc(var(--container-width) / var(--cols) * var(--span));
-      height: fit-content;
-      height: -webkit-fill-available;
       padding: var(--gap);
+      padding-bottom: 0;
       display: flex;
       flex-direction: column;
       justify-content: flex-start;
       row-gap: var(--gap);
+
+      & > *:last-child {
+        padding-bottom: var(--gap);
+      }
 
       &:not(:last-child) {
         border-right: 1px solid ${ASU_GRAY5};

--- a/packages/component-header-footer/src/header/components/UniversalNavbar/index.styles.js
+++ b/packages/component-header-footer/src/header/components/UniversalNavbar/index.styles.js
@@ -80,7 +80,7 @@ const Wrapper = styled.div`
             display: flex;
             align-items: center;
             justify-content: center;
-            height: stretch;
+            height: 100%;
 
             &.visually-hidden-focusable:not(:focus):not(:active) {
               border: none;


### PR DESCRIPTION
<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

- lots of extra space in drop-downs on desktop

- on mobile - ASU global nav area takes over

- switching between mobile and desktop, sometimes dropdown items get cut off and turned into scroll items
  1. open any dropdown on desktop, leave open
  2. switch to mobile view
  3. open mobile menu
  4. switch to desktop view
  5. The 2 column dropdown gains a scroll bar. Single column drop-downs are unaffected



## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2180)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)

