### PR TITLE
fix(anchor-menu): constrain sticky menu height in mobile landscape (W…

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
@@ -161,12 +161,17 @@
 
   // WCAG 1.4.10 Reflow: cap the sticky menu to the viewport and allow
   // internal scrolling so every link stays reachable in mobile landscape.
-  // -attached is the class the JS actually applies when scrolling makes the
-  // navbar stick; -sticky is kept for external consumers that may apply it.
+  // -attached is the class the bootstrap JS applies when scrolling makes the
+  // navbar stick; -sticky is kept for external consumers that may apply it;
+  // .sticky is the class the unity-react-core AnchorMenu component applies.
   .uds-anchor-menu.uds-anchor-menu-attached,
-  .uds-anchor-menu.uds-anchor-menu-sticky {
+  .uds-anchor-menu.uds-anchor-menu-sticky,
+  .uds-anchor-menu.sticky {
     max-height: 100vh;
-    max-height: 100dvh;
+    // Subtract the header offset the React component exposes via
+    // --uds-anchor-menu-top; it defaults to 0px, so this reduces to 100dvh
+    // for the bootstrap/static markup cases.
+    max-height: calc(100dvh - var(--uds-anchor-menu-top, 0px));
     overflow-y: auto;
   }
 }

--- a/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
@@ -158,6 +158,14 @@
     display: flex;
     justify-content: space-between;
   }
+
+  // WCAG 1.4.10 Reflow: cap the sticky menu to the viewport and allow
+  // internal scrolling so every link stays reachable in mobile landscape.
+  .uds-anchor-menu.uds-anchor-menu-sticky {
+    max-height: 100vh;
+    max-height: 100dvh;
+    overflow-y: auto;
+  }
 }
 
 @include media-breakpoint-up(xl) {

--- a/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
@@ -161,6 +161,9 @@
 
   // WCAG 1.4.10 Reflow: cap the sticky menu to the viewport and allow
   // internal scrolling so every link stays reachable in mobile landscape.
+  // -attached is the class the JS actually applies when scrolling makes the
+  // navbar stick; -sticky is kept for external consumers that may apply it.
+  .uds-anchor-menu.uds-anchor-menu-attached,
   .uds-anchor-menu.uds-anchor-menu-sticky {
     max-height: 100vh;
     max-height: 100dvh;

--- a/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.styles.js
+++ b/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.styles.js
@@ -6,12 +6,6 @@ const AnchorMenuWrapper = styled.div`
     top: var(--uds-anchor-menu-top, 0px);
     left: 0;
     width: 100%;
-
-    @media (max-width: 991.98px) {
-      max-height: 100vh;
-      max-height: calc(100dvh - var(--uds-anchor-menu-top, 0px));
-      overflow-y: auto;
-    }
   }
   .mobile-menu-toggler {
     background-color: transparent;

--- a/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.styles.js
+++ b/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.styles.js
@@ -6,6 +6,12 @@ const AnchorMenuWrapper = styled.div`
     top: var(--uds-anchor-menu-top, 0px);
     left: 0;
     width: 100%;
+
+    @media (max-width: 991.98px) {
+      max-height: 100vh;
+      max-height: calc(100dvh - var(--uds-anchor-menu-top, 0px));
+      overflow-y: auto;
+    }
   }
   .mobile-menu-toggler {
     background-color: transparent;


### PR DESCRIPTION
…CAG 1.4.10)

In mobile landscape orientations the sticky anchor menu was position:fixed with no height constraint or overflow handling, so the expanded menu overflowed the viewport and the lower links were unreachable.

Cap the sticky container to the viewport using 100dvh (with 100vh fallback) and enable overflow-y: auto below the lg breakpoint, in both the unity-bootstrap-theme SCSS and the unity-react-core styled-component. The React version subtracts --uds-anchor-menu-top to account for the global header offset.

Fixes WCAG 1.4.10 Reflow (Level AA).

<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

<!-- Description of problem -->
<!-- Solution -->
<!-- Testing Steps -->

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2182)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)

