### PR TITLE
fix(anchor-menu): use native button for the mobile toggle (WCAG 2.1.1…

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
@@ -15,6 +15,28 @@
     top: 0;
   }
 
+  // Native <button> nested inside the heading; gives the toggle real
+  // keyboard and assistive-tech semantics (WCAG 2.1.1, 4.1.2) while
+  // keeping the heading available for screen-reader navigation.
+  .mobile-menu-toggler {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    width: 100%;
+    text-align: inherit;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &[aria-expanded='true'] {
+      svg,
+      i {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
   h4, h2 {
     font-size: 1rem;
     padding: 0 !important;

--- a/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/anchor-menu/anchor-menu.examples.stories.js
@@ -53,17 +53,21 @@ export const AnchorMenu = () => {
         >
           <div className="container">
             <div className="uds-anchor-menu-wrapper">
-              <h2
-                data-bs-toggle="collapse"
-                data-bs-target="#collapseExample"
-                aria-expanded="false"
-                aria-controls="collapseExample"
-                data-ga-name="onclick"
-                data-ga-event="collapse"
-                data-ga-type="click"
-                data-ga="On this page"
-              >
-                On This Page: <span className="fas fa-chevron-down"></span>
+              <h2>
+                <button
+                  type="button"
+                  className="mobile-menu-toggler"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#collapseExample"
+                  aria-expanded="false"
+                  aria-controls="collapseExample"
+                  data-ga-name="onclick"
+                  data-ga-event="collapse"
+                  data-ga-type="click"
+                  data-ga="On this page"
+                >
+                  On This Page: <span className="fas fa-chevron-down"></span>
+                </button>
               </h2>
               <div id="collapseExample" className="card card-body collapse">
                 <nav className="nav" aria-label="Same Page">

--- a/packages/unity-bootstrap-theme/stories/docs/anchor-menu/anchor-menu-usage.mdx
+++ b/packages/unity-bootstrap-theme/stories/docs/anchor-menu/anchor-menu-usage.mdx
@@ -27,13 +27,17 @@ Create an element with ID `uds-anchor-menu`:
 <div id="uds-anchor-menu" class="uds-anchor-menu uds-anchor-menu-expanded-lg">
   <div class="container">
     <div class="uds-anchor-menu-wrapper">
-      <h2
-        data-bs-toggle="collapse"
-        data-bs-target="#anchorMenuNav"
-        aria-expanded="false"
-        aria-controls="anchorMenuNav"
-      >
-        On This Page: <span class="fas fa-chevron-down"></span>
+      <h2>
+        <button
+          type="button"
+          class="mobile-menu-toggler"
+          data-bs-toggle="collapse"
+          data-bs-target="#anchorMenuNav"
+          aria-expanded="false"
+          aria-controls="anchorMenuNav"
+        >
+          On This Page: <span class="fas fa-chevron-down"></span>
+        </button>
       </h2>
       <div id="anchorMenuNav" class="card card-body collapse">
         <nav class="nav" aria-label="Page navigation">
@@ -113,13 +117,17 @@ Here's a complete working example:
   <div id="uds-anchor-menu" class="uds-anchor-menu uds-anchor-menu-expanded-lg">
     <div class="container">
       <div class="uds-anchor-menu-wrapper">
-        <h2
-          data-bs-toggle="collapse"
-          data-bs-target="#anchorMenuNav"
-          aria-expanded="false"
-          aria-controls="anchorMenuNav"
-        >
-          On This Page: <span class="fas fa-chevron-down"></span>
+        <h2>
+          <button
+            type="button"
+            class="mobile-menu-toggler"
+            data-bs-toggle="collapse"
+            data-bs-target="#anchorMenuNav"
+            aria-expanded="false"
+            aria-controls="anchorMenuNav"
+          >
+            On This Page: <span class="fas fa-chevron-down"></span>
+          </button>
         </h2>
         <div id="anchorMenuNav" class="card card-body collapse">
           <nav class="nav" aria-label="Page navigation">

--- a/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.jsx
+++ b/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.jsx
@@ -227,31 +227,32 @@ export const AnchorMenu = ({
         }
       >
         <div className={`${state.containerClass} uds-anchor-menu-wrapper`}>
-          {isSmallDevice ? (
-            <GaEventWrapper
-              gaData={{
-                ...defaultMobileGAEvent,
-                action: state.showMenu ? "close" : "open",
-              }}
-            >
-              <button
-                className={classNames("mobile-menu-toggler", {
-                  [`show-menu`]: state.showMenu,
-                })}
-                type="button"
-                onClick={handleMenuVisibility}
-                data-bs-toggle="collapse"
-                data-bs-target="#collapseAnchorMenu"
-                aria-controls="collapseAnchorMenu"
+          <h2>
+            {isSmallDevice ? (
+              <GaEventWrapper
+                gaData={{
+                  ...defaultMobileGAEvent,
+                  action: state.showMenu ? "close" : "open",
+                }}
               >
-                <h2>
+                <button
+                  className={classNames("mobile-menu-toggler", {
+                    [`show-menu`]: state.showMenu,
+                  })}
+                  type="button"
+                  onClick={handleMenuVisibility}
+                  data-bs-toggle="collapse"
+                  data-bs-target="#collapseAnchorMenu"
+                  aria-controls="collapseAnchorMenu"
+                  aria-expanded={state.showMenu}
+                >
                   {menuTitle}:<i className="fas fa-chevron-down" />
-                </h2>
-              </button>
-            </GaEventWrapper>
-          ) : (
-            <h2>{menuTitle}:</h2>
-          )}
+                </button>
+              </GaEventWrapper>
+            ) : (
+              <>{menuTitle}:</>
+            )}
+          </h2>
 
           <div
             data-testid="anchor-menu-container"

--- a/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.styles.js
+++ b/packages/unity-react-core/src/components/AnchorMenu/AnchorMenu.styles.js
@@ -10,11 +10,13 @@ const AnchorMenuWrapper = styled.div`
   .mobile-menu-toggler {
     background-color: transparent;
     border: none;
-    cursor: default;
-    h4,
-    h2 {
-      align-items: center;
-    }
+    padding: 0;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    text-align: inherit;
     i {
       transition: all 0.3s;
     }


### PR DESCRIPTION
<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

The mobile anchor menu toggle was an `<h2>` element with a `data-bs-toggle="collapse"` click handler. Two WCAG failures:

- **2.1.1 Keyboard (Level A)** — `<h2>` is not focusable, so keyboard-only users cannot open/close the menu.
- **4.1.2 Name, Role, Value (Level A)** — assistive technologies do not expose `<h2>` as a button, so the role and state are wrong.

**Solution:** wrap the toggle in a real `<button type="button">` nested inside the `<h2>` (W3C Disclosure pattern — heading outside, button inside). The button provides correct semantics and native keyboard support while the heading is preserved for screen-reader navigation. Styles for `.mobile-menu-toggler` reset the native button chrome (background, border, padding) and use `display: flex; justify-content: space-between` so the layout stays visually identical to before.

Applied in both paths:

- **Vanilla** (`unity-bootstrap-theme`): SCSS + story example + MDX usage docs.
- **React** (`unity-react-core`): JSX refactor + styled-component update; `aria-expanded` now mirrors `state.showMenu`.

**Testing steps**

1. Open the Anchor Menu story in Storybook at mobile width (≤ 991px).
2. Tab to the "On This Page:" toggle — focus ring must be visible.
3. Press `Enter` or `Space` — menu expands; `aria-expanded` flips to `true`; chevron rotates 180°.
4. Confirm the toggle looks identical to before (no native button background/border).
5. Resize to desktop (≥ 992px) — confirm no layout regression and chevron stays hidden.

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2194)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)
