### PR TITLE
fix(unity-bootstrap-theme): space bar expands/collapses footer accord…

### DIFF
--- a/packages/unity-bootstrap-theme/src/js/collapse.js
+++ b/packages/unity-bootstrap-theme/src/js/collapse.js
@@ -21,7 +21,37 @@ function initCollapse() {
       document.querySelector(".collapsing")
     );
   }
+
+  /**
+   * Accordion toggles built as `<a role="button" data-bs-toggle="collapse">`
+   * (e.g. the global footer columns) activate on Enter but not on Space:
+   * anchors don't fire a click on Space, so the browser scrolls the page
+   * instead of toggling the accordion. Handle Space here so it matches Enter
+   * and native <button> behavior, and stop the default page scroll.
+   * (WCAG 2.1.1 Keyboard, 4.1.2 Name, Role, Value)
+   */
+  function accordionKeydown(event) {
+    const { target, key } = event;
+
+    // Only Space needs help — Enter already activates anchors natively.
+    if (key !== " " && key !== "Spacebar") {
+      return;
+    }
+
+    // Native <button> toggles handle Space themselves; only patch anchors.
+    if (
+      target.tagName !== "A" ||
+      target.getAttribute("data-bs-toggle") !== "collapse"
+    ) {
+      return;
+    }
+
+    event.preventDefault(); // Prevent the default page scroll.
+    target.click(); // Trigger Bootstrap's collapse toggle + scroll adjustment.
+  }
+
   EventHandler.on(document, "click.uds.collapse", accordionClick);
+  EventHandler.on(document, "keydown.uds.collapse", accordionKeydown);
 }
 
 EventHandler.on(window, "load.uds.collapse", initCollapse);


### PR DESCRIPTION
### Description

**Problem**

The global footer column accordions (`unity-bootstrap-theme`) are keyboard-accessible with **Enter** but not with **Space**. The triggers are rendered as `<a role="button" data-bs-toggle="collapse">`, and Bootstrap's collapse plugin toggles on a `click` event. An anchor fires a click on Enter but **not** on Space, so pressing Space falls through to the browser default and **scrolls the page** instead of toggling the section.

This was surfaced in an accessibility audit (reproducible at 200% zoom, which narrows the viewport so the columns become accordions) on https://admission.asu.edu/.

WCAG failures:
- 2.1.1 Keyboard (A)
- 4.1.2 Name, Role, Value (A)

**Solution**

Added a delegated `keydown` handler in `src/js/collapse.js` — the script already shipped in the theme bundle that consumers (Webspark) load, and which already hooks the collapse `click` for scroll adjustment.

When **Space** is pressed on an `<a … data-bs-toggle="collapse">`, it now:
- calls `preventDefault()` to stop the default page scroll, and
- calls `target.click()` to trigger the normal Bootstrap toggle (plus the existing scroll adjustment).

Scoping keeps it safe and universal:
- **Enter** is left untouched (anchors handle it natively).
- Native `<button>` toggles and plain links are skipped — no double-toggle, no behavior change.
- Fixes **every** anchor-based collapse accordion in the theme without requiring CMS consumers to change their markup.

This matches the audit's fallback recommendation (keydown handling) and avoids invasive markup changes to shared CMS templates.

**Testing steps**

1. `cd packages/unity-bootstrap-theme && yarn storybook` (port 9000).
2. Open *Organisms → Global Footer → Examples → Four Columns*.
3. Narrow the viewport below ~1260px (or zoom the browser to 200%) so the columns render as accordions with a chevron.
4. Tab to a column header, press **Enter** → toggles (unchanged).
5. Press **Space** → now **toggles and does not scroll the page** ✅ (previously it scrolled to the bottom).
6. Confirm native `<button>` accordions and ordinary links are unaffected.

Behavior was additionally verified with a jsdom simulation of the handler (Space toggles + prevents scroll; legacy `"Spacebar"` value handled; Enter, native buttons, and plain links left alone).

## Checklist

- [x] Tests pass for relevant code changes

> Note: `unity-bootstrap-theme` has no JS unit-test runner (only Puppeteer visual snapshots that require a running Storybook), so no automated unit test was added for this fix. Behavior was verified manually in Storybook and via a jsdom simulation. `eslint src/js/collapse.js` passes clean.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2159)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)
