### PR TITLE
fix(anchor-menu): keep sticky menu keyboard-reachable at 200% zoom

### DIFF
--- a/packages/unity-bootstrap-theme/src/js/anchor-menu.js
+++ b/packages/unity-bootstrap-theme/src/js/anchor-menu.js
@@ -21,13 +21,33 @@ function initAnchorMenu() {
     return;
   }
 
-  const navbarOriginalParent = navbar.parentNode;
-  const navbarOriginalNextSibling = navbar.nextSibling;
-
   const anchors = Array.from(navbar.getElementsByClassName("nav-link"));
   const anchorTargets = new Map();
-  let previousScrollPosition = window.scrollY;
   let isNavbarAttached = false;
+
+  // Bottom of the (fixed) global header in the viewport — where the menu
+  // should pin so it sits directly below the header instead of under it.
+  const getHeaderBottomOffset = () =>
+    Math.max(globalHeader.getBoundingClientRect().bottom, 0);
+
+  // Attach/detach WITHOUT moving the node in the DOM, so keyboard tab order
+  // is preserved (WCAG 2.1.1 Keyboard, 2.4.3 Focus Order). Mirrors the
+  // unity-react-core AnchorMenu, which fixes the menu in place via
+  // --uds-anchor-menu-top instead of relocating it into the header.
+  const attachNavbar = () => {
+    navbar.style.setProperty(
+      "--uds-anchor-menu-top",
+      getHeaderBottomOffset() + "px"
+    );
+    navbar.classList.add("uds-anchor-menu-attached");
+    isNavbarAttached = true;
+  };
+
+  const detachNavbar = () => {
+    navbar.classList.remove("uds-anchor-menu-attached");
+    navbar.style.removeProperty("--uds-anchor-menu-top");
+    isNavbarAttached = false;
+  };
 
   // These values are for optionally present Drupal admin toolbars. They
   // are not present in Storybook and not required in implementations.
@@ -56,11 +76,11 @@ function initAnchorMenu() {
     }
   }
 
-  const shouldAttachNavbarOnLoad = window.scrollY > navbarInitialTop;
+  // Attach when the menu's original top has scrolled under the header bottom.
+  const shouldAttachNavbarOnLoad =
+    window.scrollY >= navbarInitialTop - getHeaderBottomOffset();
   if (shouldAttachNavbarOnLoad) {
-    globalHeader.appendChild(navbar);
-    isNavbarAttached = true;
-    navbar.classList.add("uds-anchor-menu-attached");
+    attachNavbar();
   }
 
   /**
@@ -139,38 +159,24 @@ function initAnchorMenu() {
         });
     }
 
-    // Handle navbar attachment/detachment
-    const navbarY = navbar.getBoundingClientRect().top;
-    const headerBottom = globalHeader.getBoundingClientRect().bottom;
-    const isScrollingDown = window.scrollY > previousScrollPosition;
+    // Handle navbar attachment/detachment.
+    // Use the stored original offset (navbarInitialTop) rather than the live
+    // rect, because once attached the menu is position:fixed and its rect no
+    // longer reflects its document position.
+    const attachThreshold = navbarInitialTop - getHeaderBottomOffset();
 
-    // If scrolling DOWN and the bottom of globalHeader touches or overlaps the top of navbar
-    if (isScrollingDown && headerBottom >= navbarY) {
-      if (!isNavbarAttached) {
-        // Attach navbar to globalHeader
-        globalHeader.appendChild(navbar);
-        isNavbarAttached = true;
-        navbar.classList.add("uds-anchor-menu-attached");
-      }
+    if (!isNavbarAttached && window.scrollY >= attachThreshold) {
+      attachNavbar();
+    } else if (isNavbarAttached && window.scrollY < attachThreshold) {
+      detachNavbar();
+    } else if (isNavbarAttached) {
+      // Header height can change while scrolled (responsive/shrinking header);
+      // keep the pinned offset in sync.
+      navbar.style.setProperty(
+        "--uds-anchor-menu-top",
+        getHeaderBottomOffset() + "px"
+      );
     }
-
-    // If scrolling UP and the header bottom no longer overlaps with the navbar
-    if (!isScrollingDown && isNavbarAttached) {
-      const currentHeaderBottom = globalHeader.getBoundingClientRect().bottom;
-      const navbarCurrentTop = navbar.getBoundingClientRect().top;
-
-      // Only detach if we're back to the initial navbar position or if header no longer overlaps navbar
-      if (
-        window.scrollY <= navbarInitialTop ||
-        currentHeaderBottom < navbarCurrentTop
-      ) {
-        navbarOriginalParent.insertBefore(navbar, navbarOriginalNextSibling);
-        isNavbarAttached = false;
-        navbar.classList.remove("uds-anchor-menu-attached");
-      }
-    }
-
-    previousScrollPosition = window.scrollY;
   };
 
   let throttledScrollHandler;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_anchor-menu.scss
@@ -15,6 +15,18 @@
     top: 0;
   }
 
+  // Pinned state applied by anchor-menu.js while scrolled. Fixed in place
+  // (the node is NOT moved in the DOM) so keyboard tab order is preserved
+  // (WCAG 2.1.1 Keyboard, 2.4.3 Focus Order). --uds-anchor-menu-top is the
+  // global header's bottom offset, set by the JS so the menu pins directly
+  // below the fixed header.
+  &-attached {
+    position: fixed;
+    top: var(--uds-anchor-menu-top, 0px);
+    left: 0;
+    right: 0;
+  }
+
   // Native <button> nested inside the heading; gives the toggle real
   // keyboard and assistive-tech semantics (WCAG 2.1.1, 4.1.2) while
   // keeping the heading available for screen-reader navigation.


### PR DESCRIPTION
## Description

At 200% desktop zoom, the anchor menu became unreachable by keyboard — tabbing skipped it entirely (accessibility audit, UDS-1638 / UDS-2160).

**Root cause:** the sticky behavior moved the menu node into the global header (`appendChild`). Tab order follows DOM order, so the menu's controls jumped to a point earlier in the document than the user's current focus, and forward Tab never landed on them.

**Fix:** pin the menu with CSS (`position: fixed; top: var(--uds-anchor-menu-top)`) instead of relocating the node, with attach/detach driven by a scroll threshold. This matches how the unity-react-core `AnchorMenu` already positions itself. Fixes WCAG 2.1.1 (Keyboard) and 2.4.3 (Focus Order).

## Testing Steps

1. Open Atoms → Anchor Menu in the unity-bootstrap-theme Storybook.
2. Set browser zoom to 200% (or narrow the window below ~640px) — the menu collapses to the "On This Page:" bar.
3. Scroll down so the menu sticks below the header, then Tab from the top of the page. **Expected:** focus reaches the "On This Page:" toggle and its links. Before this change, Tab skipped the menu.
4. Regression check at normal zoom: expanded menu still sticks, links reachable, click-to-scroll and active-link highlighting work, menu detaches when scrolling back to top.

## Checklist

- [x] Tests pass for relevant code changes

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1638)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)
