### PR TITLE
chore(unity-react-core): keep react-dom/server out of SB manager

### DIFF
--- a/packages/unity-react-core/.storybook/formatCode.js
+++ b/packages/unity-react-core/.storybook/formatCode.js
@@ -1,0 +1,8 @@
+import { decode } from 'html-entities'
+import prettier from 'prettier'
+import HTMLParser from 'prettier/parser-html'
+
+export const formatCode = (code) => prettier.format(decode(code, { level: "all" }), {
+  parser: 'html',
+  plugins: [HTMLParser],
+});

--- a/packages/unity-react-core/.storybook/manager.jsx
+++ b/packages/unity-react-core/.storybook/manager.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { addons, types, useAddonState, useStorybookApi, useParameter, useChannel, useGlobals } from 'storybook/manager-api';
-import { formatCode } from "./renderToHTML";
+import { formatCode } from "./formatCode";
 import { AddonPanel } from 'storybook/internal/components';
 import { Heading, Source } from '@storybook/addon-docs/blocks';
 

--- a/packages/unity-react-core/.storybook/renderToHTML.jsx
+++ b/packages/unity-react-core/.storybook/renderToHTML.jsx
@@ -1,14 +1,8 @@
 
-import { decode } from 'html-entities'
-import prettier from 'prettier'
-import HTMLParser from 'prettier/parser-html'
-
 import { getBootstrapHTML } from '../src/components/GaEventWrapper/useBaseSpecificFramework.js';
+import { formatCode } from './formatCode.js';
 
-export const formatCode = (code) => prettier.format(decode(code,{level:"all"}), {
-  parser: 'html',
-  plugins: [HTMLParser],
-});
+export { formatCode };
 
 export default (_, storyContext = {}) => {
 


### PR DESCRIPTION
With SB10 upgrade, module graph changed and import behavior caused an error in html panel addon

NO TICKET QUICK FIX