### PR TITLE
chore: update ACP kiro docs/steering

### DIFF
--- a/.kiro/skills/architecture-lock/SKILL.md
+++ b/.kiro/skills/architecture-lock/SKILL.md
@@ -52,6 +52,24 @@ Auth/authz requirements, input validation boundaries, data exposure risks, trust
 ### 7. Performance Considerations
 Expected load, bottleneck analysis, caching strategy, resource limits.
 
+### 8. Behavioral Matrix (Interactive Components)
+
+For components with user interaction (carousels, tabs, accordions, card stacks, etc.), define:
+
+| User Action | Current State | Next State | Visual Change | Animation |
+|-------------|---------------|------------|---------------|-----------||
+| Click card N | Card M active | Card N active | Card N moves to front | translateX transitions |
+| ArrowLeft | Card N active | Card N-1 active (clamped) | Previous card moves to front | 0.3s ease-out |
+| ArrowRight | Card N active | Card N+1 active (clamped) | Next card moves to front | 0.3s ease-out |
+
+**Positioning Formula** (for fanned/stacked layouts):
+- `offset = index - activeIndex`
+- `translateX = offset * spacing` (e.g., 60px)
+- `rotation = offset * angle` (e.g., 8deg)
+- `zIndex = totalCards - Math.abs(offset)`
+
+This prevents ambiguity in implementation — the coder should not have to guess behavioral intent.
+
 ## Lock Protocol
 
 1. Present design document to human for approval

--- a/.kiro/skills/asu-design-a11y/SKILL.md
+++ b/.kiro/skills/asu-design-a11y/SKILL.md
@@ -78,6 +78,33 @@ Prefer native HTML over ARIA; add ARIA only when necessary.
 People-first, respectful language in all user-facing text; follow ASU Inclusion
 guidelines. No stereotypes about ability/cognition/experience.
 
+## Accessibility Requirements Template (for Design Doc)
+
+The architect MUST include this section in `.pipeline/design-doc.md` for any interactive component:
+
+```markdown
+## Accessibility Requirements
+
+### Keyboard Navigation
+- Tab order: [describe which elements receive focus in what order]
+- Arrow keys: [what ArrowLeft/Right/Up/Down do when focused]
+- Enter/Space: [activation behavior]
+- Escape: [dismiss behavior if applicable]
+
+### Focus Management
+- Pattern: [roving tabindex / aria-activedescendant / standard]
+- Focus moves to: [where focus goes after interaction]
+
+### Screen Reader
+- Live region: [what is announced on state change]
+- Labels: [aria-label pattern for each interactive element]
+
+### Motion
+- Reduced motion: [how component adapts to prefers-reduced-motion]
+```
+
+Failure to specify these leads to implementation guesswork and review rework.
+
 ## Pre-delivery checklist (verify explicitly)
 
 Landmarks + one `h1`; keyboard operable + visible focus + no traps + skip link;

--- a/.kiro/skills/code-quality/SKILL.md
+++ b/.kiro/skills/code-quality/SKILL.md
@@ -43,6 +43,26 @@ Evaluate structural quality, maintainability, and engineering standards.
 - Could a function parameter, adapter, fake, or temp resource be simpler than a new interface?
 - Do tests verify observable behavior rather than implementation choreography?
 
+### 8. CSS Invariants
+
+For components with critical layout properties, verify:
+
+- **Position dependencies documented**: If `position: absolute` is required for stacking, a comment explains why and warns against removal.
+- **No conflicting properties**: Adding `display: flex` to an absolutely positioned element can break layout.
+- **Invariant comments**: Critical CSS should have:
+  ```css
+  /* INVARIANT: position: absolute required for z-index stacking.
+     Do not change to relative or remove without updating JS transforms. */
+  .card {
+    position: absolute;
+  }
+  ```
+
+### CSS Invariant Checklist
+- [ ] Critical positioning properties have invariant comments
+- [ ] No conflicting display/position combinations introduced
+- [ ] Changes to layout CSS verified visually before commit
+
 ## Output Format
 
 ```

--- a/.kiro/skills/qa-verification/SKILL.md
+++ b/.kiro/skills/qa-verification/SKILL.md
@@ -25,6 +25,42 @@ If a full suite is too slow or unavailable, report: command not run, reason, ris
 2. Did any previously passing tests break (regressions)?
 3. Do error conditions produce correct results?
 
+## Browser Interaction Testing (Interactive Components)
+
+For components with user interaction, QA verification includes browser-based testing via Chrome DevTools MCP or agent-browser:
+
+### Required Verifications
+
+1. **Click Navigation**
+   - Click each interactive element
+   - Screenshot each resulting state
+   - Verify state matches Behavioral Matrix from design doc
+
+2. **Keyboard Navigation**
+   - Tab into component, verify focus lands correctly
+   - ArrowLeft/Right through all items
+   - Verify focus ring visible on active element
+   - Tab out, verify exit to correct element
+
+3. **Mobile/Touch**
+   - Resize to 375×667 (iPhone SE)
+   - Verify layout adapts (scroll vs stack)
+   - Test swipe gestures if applicable
+
+4. **Accessibility Audit**
+   - Run `mcp_chrome_devtoo_lighthouse_audit` with mode="snapshot"
+   - Verify Accessibility score ≥ 95 (ideally 100)
+   - Document any issues
+
+### Evidence Required
+```
+## Browser Interaction Results
+- Click navigation: [PASS/FAIL with screenshot paths]
+- Keyboard navigation: [PASS/FAIL with test sequence]
+- Mobile layout: [PASS/FAIL at 375px]
+- Lighthouse a11y: [score]
+```
+
 ## Output
 
 PASS or FAIL with specific test results and evidence.

--- a/.kiro/skills/visual-diff/SKILL.md
+++ b/.kiro/skills/visual-diff/SKILL.md
@@ -15,6 +15,19 @@ spec/QA (that is the structural reviewer's job).
   (Figma Dev Mode MCP, if available).
 - Intended tokens — `.pipeline/design-doc.md` + the `asu-brand` skill.
 
+## Pre-Implementation Visual Analysis (Optional)
+
+Before code is written, the visual agent can analyze `.intake/` references to extract positioning constraints for the architect:
+
+1. **Identify layout pattern**: grid, flex, absolute positioning, stacking
+2. **Measure spacing**: card gaps, offsets, rotations from reference
+3. **Document states**: which visual states are shown (active, hover, stacked)
+4. **Extract formulas**: "cards appear to fan with ~60px horizontal offset and ~8° rotation per index"
+
+Output to `.pipeline/visual-analysis.md` for architect to incorporate into the Behavioral Matrix.
+
+This reduces "it doesn't look like the design" rework after implementation.
+
 ## Capture the build (agent-browser)
 
 `agent-browser` drives Chrome via CDP. Install: `npm i -g agent-browser` then


### PR DESCRIPTION
## Summary

Adds pipeline skill improvements based on lessons learned from building interactive components (RepeatedlyRankedCardStack). These changes reduce iteration cycles by requiring clearer specifications upfront.

## Changes

### architecture-lock
- Added **Behavioral Matrix** section for interactive components
- Defines state transitions, positioning formulas, and animation specs
- Prevents ambiguity in carousel/tabs/accordion implementations

### asu-design-a11y
- Added **Accessibility Requirements Template** for design docs
- Requires architect to specify keyboard nav, focus management, screen reader, and motion handling upfront

### qa-verification
- Added **Browser Interaction Testing** section
- Requires click/keyboard/mobile/Lighthouse verification for interactive components
- Uses Chrome DevTools MCP for automated verification

### visual-diff
- Added **Pre-Implementation Visual Analysis** (optional)
- Allows extracting positioning constraints from design references before coding

### code-quality
- Added **CSS Invariants** section
- Documents critical positioning properties that must not be changed without understanding side effects

## Why

During the RepeatedlyRankedCardStack build, we iterated 3 times on fanning behavior because:
1. Behavioral spec wasn't precise (which direction do cards fan?)
2. A11y requirements weren't specified upfront
3. CSS changes broke layout without warning
4. No browser-based interaction verification in QA

These additions prevent similar rework on future interactive components.

## Testing

- [x] Files identical in `.github/skills/` and `.kiro/skills/`
- [x] YAML frontmatter valid
- [x] Markdown renders correctly
