### PR TITLE
UDS-2229: fix(unity-bootstrap-theme): keep hero CTA inside the hero box below md breakpoint

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -213,7 +213,7 @@ div[class^="uds-hero"] {
 
 div.uds-hero-sm {
   min-height: $uds-size-spacing-32;
-  grid-template-rows: 1fr auto auto 3rem;
+  grid-template-rows: 1fr auto auto auto 3rem;
 
   h1,
   a.btn,
@@ -251,16 +251,12 @@ div.uds-hero-sm {
       min-height: $uds-size-spacing-32;
     }
   }
-
-  > a.btn {
-    top: 15rem;
-  }
 }
 
 div.uds-hero-md {
   min-height: 21rem;
   // by design, the hero-md has no content on mobile, change grid template rows and hide .content
-  grid-template-rows: 1fr auto auto 3rem;
+  grid-template-rows: 1fr auto auto auto 3rem;
 
   .content {
     display: none;
@@ -270,17 +266,11 @@ div.uds-hero-md {
     .btn-row {
       flex-wrap: wrap;
       align-self: flex-start;
-      top: 20rem;
     }
 
     .hero-overlay {
       min-height: 21rem;
     }
-  }
-
-  // TODO: Remove, fallback for buttons without btn-row
-  > a.btn {
-    top: 20rem;
   }
 }
 
@@ -307,7 +297,6 @@ div.uds-hero-lg {
 
     .btn-row {
       align-self: flex-start;
-      top: 31rem;
     }
 
     .hero-overlay {
@@ -319,10 +308,30 @@ div.uds-hero-lg {
   &.uds-video-hero .video-hero-controls {
     display: none;
   }
+}
 
-  // TODO: Remove, fallback for buttons without btn-row
-  > a.btn {
-    top: 31rem;
+// WS2-2950: below the md breakpoint, hero CTAs flow in their own auto grid row
+// instead of hanging at a fixed absolute offset that overflows the hero box.
+// Scoped to media-breakpoint-down(md) so tablet/desktop styles are untouched.
+@include media-breakpoint-down(md) {
+  div.uds-hero-md.has-btn-row .btn-row,
+  div.uds-hero-lg.has-btn-row .btn-row {
+    grid-row: 4;
+    position: relative;
+    top: auto;
+    margin-top: 1rem;
+  }
+
+  div.uds-hero-sm,
+  div.uds-hero-md,
+  div.uds-hero-lg {
+    // TODO: Remove, fallback for buttons without btn-row
+    > a.btn {
+      position: relative;
+      top: auto;
+      grid-row: 4;
+      margin-top: 1rem;
+    }
   }
 }
 
@@ -384,6 +393,8 @@ div.uds-hero-lg {
       position: relative;
       top: auto;
       grid-row: 4;
+      margin-top: 1rem;
+      margin-bottom: 1rem;
     }
 
     &.has-btn-row {


### PR DESCRIPTION
## Summary

Follow-up to #1688 (UDS-2171) for **WS2-2950**: below the `md` breakpoint (mobile, or desktop at 200% zoom), hero CTAs still overhang the hero's bottom edge. #1688 only fixed `.uds-hero-sm.has-btn-row .btn-row`; the hero-md/lg `.btn-row`s and the single-button `> a.btn` fallback (the markup Webspark emits for one CTA) were still `position: absolute` with a hardcoded `top` ~1rem short of the hero height.

## Changes — `_heroes.scss` only

- Mobile row templates for hero-sm/md gain an auto row for the CTA (`1fr auto auto auto 3rem`); it collapses to 0 without buttons, and both templates are overridden ≥768px.
- Removed the dead `top: 15|20|31rem` declarations from the mobile blocks.
- New `@include media-breakpoint-down(md)` block applies #1688's in-flow treatment (`grid-row: 4; position: relative; top: auto; margin-top: 1rem`) to hero-md/lg `.btn-row` and `> a.btn` on all sizes — capped at <768px.
- Only ≥768px change: hero-sm `> a.btn` gets `margin-top/bottom: 1rem`, matching the margins `.btn-row` already has (single CTA sat flush against the bottom edge).

## Verification (Storybook, A/B vs baseline)

- 375–764px: overhang of 20px (single CTA) / 64px (md/lg `.btn-row`) → all buttons now 24–64px inside the hero, natural width, both markups.
- ≥768px: pixel-identical except the intended hero-sm single-CTA margins. Heroes without buttons: pixel-identical at every width.
<img width="1090" height="820" alt="image" src="https://github.com/user-attachments/assets/915add03-4883-4c97-bfd2-fac93c3d59b5" />

Refs: WS2-2950, UDS-2171