### PR TITLE
fix(unity-bootstrap-theme): add bottom spacing to hero-sm title when no CTA is present

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -380,6 +380,17 @@ div.uds-hero-lg {
   div.uds-hero-sm {
     grid-template-rows: 0px 1fr auto auto;
 
+    // Row 4 collapses to 0 when the hero has no CTA, leaving the h1 flush
+    // against the bottom edge — carry the bottom spacing on the h1 instead.
+    h1 {
+      margin-bottom: $uds-size-spacing-4;
+    }
+
+    &.has-btn-row h1,
+    &:has(> a.btn) h1 {
+      margin-bottom: 0;
+    }
+
     > a.btn {
       position: relative;
       top: auto;


### PR DESCRIPTION
## Description

On md+ viewports, `uds-hero-sm` uses `grid-template-rows: 0px 1fr auto auto` where row 4 holds the CTA. Without a CTA the row collapses to 0 and the h1 sits flush against the hero's bottom edge (UDS-2231).

**Fix:** the h1 now carries `margin-bottom: $uds-size-spacing-4` (2rem), reset to 0 when a CTA is present — via `.has-btn-row` or the `:has(> a.btn)` fallback for direct-child buttons.

## Testing Steps

1. Open Molecules → Heroes → Templates → Hero Small in the unity-bootstrap-theme Storybook, viewport ≥768px.
2. Remove the `.btn-row` element and the `has-btn-row` class from the hero in devtools. **Expected:** 32px of space between the title and the hero's bottom edge (was flush).
3. Regression check: with CTA the h1 margin stays 0; `uds-hero-md`/`uds-hero-lg` and mobile (<768px) are unaffected.

## Checklist

- [x] Tests pass for relevant code changes

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2231)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)