### PR TITLE
fix(unity-bootstrap-theme): support downstream palette overrides (UDS-2239)

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/_custom-asu-variables.scss
+++ b/packages/unity-bootstrap-theme/src/scss/_custom-asu-variables.scss
@@ -35,58 +35,58 @@ $uds-size-spacing-64: 32rem;
 $uds-size-spacing-half: 0.25rem;
 
 // Colors
-$uds-color-base-gold: #ffc627; // ASU Gold
-$uds-color-base-maroon: #8c1d40; // ASU Maroon
-$uds-color-base-white: #ffffff; // White
-$uds-color-base-green: #78be20; // ASU Green
-$uds-color-base-orange: #ff7f32; // ASU Orange
-$uds-color-base-blue: #00a3e0; // ASU Blue
-$uds-color-base-bluefocus: #00baff; // A11y Focus Blue - used for highlighting the page element with current focus
-$uds-color-base-darkgold: #7f6227; // Visited state of ASU Gold
-$uds-color-base-darkmaroon: #440e22; // Visited state of ASU Maroon
+$uds-color-base-gold: #ffc627 !default; // ASU Gold
+$uds-color-base-maroon: #8c1d40 !default; // ASU Maroon
+$uds-color-base-white: #ffffff !default; // White
+$uds-color-base-green: #78be20 !default; // ASU Green
+$uds-color-base-orange: #ff7f32 !default; // ASU Orange
+$uds-color-base-blue: #00a3e0 !default; // ASU Blue
+$uds-color-base-bluefocus: #00baff !default; // A11y Focus Blue - used for highlighting the page element with current focus
+$uds-color-base-darkgold: #7f6227 !default; // Visited state of ASU Gold
+$uds-color-base-darkmaroon: #440e22 !default; // Visited state of ASU Maroon
 // Deprecated-start
-$uds-color-base-gray-1: #fafafa; // Deprecated use $asu-gray-7 instead.
-$uds-color-base-gray-2: #e8e8e8; // Deprecated use $asu-gray-6 instead.
-$uds-color-base-gray-3: #d0d0d0; // Deprecated use $asu-gray-5 instead.
-$uds-color-base-gray-4: #bfbfbf; // Deprecated use $asu-gray-4 instead.
-$uds-color-base-gray-5: #747474; // Deprecated use $asu-gray-3 instead.
-$uds-color-base-gray-6: #484848; // Deprecated use $asu-gray-2 instead.
-$uds-color-base-gray-7: #191919; // Deprecated use $asu-gray-1 instead.
+$uds-color-base-gray-1: #fafafa !default; // Deprecated use $asu-gray-7 instead.
+$uds-color-base-gray-2: #e8e8e8 !default; // Deprecated use $asu-gray-6 instead.
+$uds-color-base-gray-3: #d0d0d0 !default; // Deprecated use $asu-gray-5 instead.
+$uds-color-base-gray-4: #bfbfbf !default; // Deprecated use $asu-gray-4 instead.
+$uds-color-base-gray-5: #747474 !default; // Deprecated use $asu-gray-3 instead.
+$uds-color-base-gray-6: #484848 !default; // Deprecated use $asu-gray-2 instead.
+$uds-color-base-gray-7: #191919 !default; // Deprecated use $asu-gray-1 instead.
 // Deprecated-end
-$asu-gray-1: #191919; // Brand guideline ASU Gray 1 - Base font color and default black level
-$asu-gray-2: #484848; // Brand guideline ASU Gray 2
-$asu-gray-3: #747474; // Brand guideline ASU Gray 3
-$asu-gray-4: #bfbfbf; // Brand guideline ASU Gray 4
-$asu-gray-5: #d0d0d0; // Brand guideline ASU Gray 5
-$asu-gray-6: #e8e8e8; // Brand guideline ASU Gray 6
-$asu-gray-7: #fafafa; // Brand guideline ASU Gray 7
+$asu-gray-1: #191919 !default; // Brand guideline ASU Gray 1 - Base font color and default black level
+$asu-gray-2: #484848 !default; // Brand guideline ASU Gray 2
+$asu-gray-3: #747474 !default; // Brand guideline ASU Gray 3
+$asu-gray-4: #bfbfbf !default; // Brand guideline ASU Gray 4
+$asu-gray-5: #d0d0d0 !default; // Brand guideline ASU Gray 5
+$asu-gray-6: #e8e8e8 !default; // Brand guideline ASU Gray 6
+$asu-gray-7: #fafafa !default; // Brand guideline ASU Gray 7
 
-$uds-color-brand-gold: $uds-color-base-gold; // ASU Gold brand color
-$uds-color-brand-maroon: $uds-color-base-maroon; // ASU Maroon brand color
+$uds-color-brand-gold: $uds-color-base-gold !default; // ASU Gold brand color
+$uds-color-brand-maroon: $uds-color-base-maroon !default; // ASU Maroon brand color
 
-$uds-color-alerts-error: #cc2f2f; // Error
-$uds-color-alerts-warning: $uds-color-base-orange; // Warning
-$uds-color-alerts-info: $uds-color-base-blue; // Information
-$uds-color-alerts-success: $uds-color-base-green; // Success
+$uds-color-alerts-error: #cc2f2f !default; // Error
+$uds-color-alerts-warning: $uds-color-base-orange !default; // Warning
+$uds-color-alerts-info: $uds-color-base-blue !default; // Information
+$uds-color-alerts-success: $uds-color-base-green !default; // Success
 
-$uds-color-background-white: $uds-color-base-white; // Background - White
-$uds-color-background-gray: $asu-gray-6; // Background - Gray
-$uds-color-background-dark: $asu-gray-1; // Background - Dark
-$uds-color-background-success: #e9f5db; // Background - Success
-$uds-color-background-error: #f7dddd; // Background - Error
-$uds-color-background-warning: #ffeade; // Background - Warning
-$uds-color-background-info: #d6f0fa; // Background - Information
+$uds-color-background-white: $uds-color-base-white !default; // Background - White
+$uds-color-background-gray: $asu-gray-6 !default; // Background - Gray
+$uds-color-background-dark: $asu-gray-1 !default; // Background - Dark
+$uds-color-background-success: #e9f5db !default; // Background - Success
+$uds-color-background-error: #f7dddd !default; // Background - Error
+$uds-color-background-warning: #ffeade !default; // Background - Warning
+$uds-color-background-info: #d6f0fa !default; // Background - Information
 
-$uds-color-font-dark-base: $asu-gray-1; // Default text color on light background
-$uds-color-font-dark-error: #FF7B7D; // Error text on dark background
-$uds-color-font-dark-success: #446d12; // Success text on dark background
-$uds-color-font-light-base: $asu-gray-7; // Default text on dark background
-$uds-color-font-light-link: $uds-color-base-gold; // Link text on dark background
-$uds-color-font-light-visited: #d3a524; // Visited link text on dark background
-$uds-color-font-light-info: #00b0f3; // Information text on dark background
+$uds-color-font-dark-base: $asu-gray-1 !default; // Default text color on light background
+$uds-color-font-dark-error: #FF7B7D !default; // Error text on dark background
+$uds-color-font-dark-success: #446d12 !default; // Success text on dark background
+$uds-color-font-light-base: $asu-gray-7 !default; // Default text on dark background
+$uds-color-font-light-link: $uds-color-base-gold !default; // Link text on dark background
+$uds-color-font-light-visited: #d3a524 !default; // Visited link text on dark background
+$uds-color-font-light-info: #00b0f3 !default; // Information text on dark background
 
-$uds-color-divider-darker: #1e1e1e; // Footer accent - darker
-$uds-color-divider-lighter: #393939; // Footer accent - lighter
+$uds-color-divider-darker: #1e1e1e !default; // Footer accent - darker
+$uds-color-divider-lighter: #393939 !default; // Footer accent - lighter
 
 // Font
 $uds-font-family-base: Arial, Helvetica, 'Nimbus Sans L', 'Liberation Sans', FreeSans, sans-serif;

--- a/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_heroes.scss
@@ -44,8 +44,8 @@ $uds-hero-gradient-overlay: linear-gradient(
 }
 
 @mixin like-h3-highlight-gold {
-  box-shadow: -0.15em 0 0 #ffc627, 0.15em 0 0 #ffc627;
-  background: #ffc627;
+  box-shadow: -0.15em 0 0 $uds-color-base-gold, 0.15em 0 0 $uds-color-base-gold;
+  background: $uds-color-base-gold;
   color: #191919;
 }
 

--- a/packages/unity-bootstrap-theme/src/scss/extends/_ranking-cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_ranking-cards.scss
@@ -15,7 +15,7 @@
     bottom: 0;
     left: 0;
     padding: $uds-size-spacing-2 var(--ranking-card-text-padding) 0;
-    border-top: $uds-size-spacing-1 solid #ffc627;
+    border-top: $uds-size-spacing-1 solid $uds-color-base-gold;
     transition: all 0.3s ease-in-out;
     z-index: 10;
     background-color: white;


### PR DESCRIPTION
## Summary

Enables downstream consumers (Webspark WS2-2964 / WS2-3099, KE Unbranded Profile) to override UDS brand colors at build time via standard Sass variable pre-definition.

- **Add `!default` to all color tokens** in `src/scss/_custom-asu-variables.scss` (base colors, grays, brand, alerts, backgrounds, font colors, dividers). Consumers can now pre-define palette values before importing the theme entry files, and derived variables (`$uds-color-brand-*`, `$uds-color-font-light-link`, etc.) recompute automatically.
- **Variable-ize 3 hardcoded gold literals** (4 occurrences of `#ffc627`) that survived a variable override:
  - `src/scss/extends/_heroes.scss` lines 47-48 — `like-h3-highlight-gold` mixin (box-shadow ×2 + background)
  - `src/scss/extends/_ranking-cards.scss` line 18 — `border-top`

## Verification

- **No-op without overrides**: compiled the full theme before and after the change — output CSS is byte-identical.
- **End-to-end override test**: pre-defined `$uds-color-base-gold: #007a8a` and `$uds-color-base-maroon: #1a2b4a` before importing the theme. Result: **0** occurrences of `#ffc627` and **0** of `#8c1d40` in the compiled CSS (previously 4 gold literals survived), with derived variables recomputing correctly.
- `yarn build` passes for the package; stylelint passes on the three changed files.
