### PR TITLE
fix(unity-bootstrap-theme): allow ordered lists to be reversed

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_list.scss
@@ -76,21 +76,21 @@ ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol,
 ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol,
 ol>li>ol>li>ol>li>ol,
 ol {
-  --li-before-content: counter(listcounter) '. ';
+  --li-before-content: counter(list-item) '. ';
 }
 
 ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol,
 ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol,
 ol>li>ol>li>ol>li>ol>li>ol,
 ol>li>ol {
-  --li-before-content: counter(listcounter, lower-alpha) '. ';
+  --li-before-content: counter(list-item, lower-alpha) '. ';
 }
 
 ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol,
 ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol>li>ol,
 ol>li>ol>li>ol>li>ol>li>ol>li>ol,
 ol>li>ol>li>ol {
-  --li-before-content: counter(listcounter, lower-roman) '. ';
+  --li-before-content: counter(list-item, lower-roman) '. ';
 }
 
 /* General UL rules. */
@@ -188,12 +188,9 @@ ol.uds-list,
   // Tweak the mix-in's left padding due to OL's needing more space for double
   // and triple digits. Not supported: > 3 digits.
   --list-padding-left: 3rem;
-  // We manually manage the counter since we need to remove the trailing periods.
-  counter-reset: listcounter;
 
   & > li:before {
     --li-before-font-size: 1rem;
-    counter-increment: listcounter;
     left: -3rem;
     text-align: right;
     position: absolute;
@@ -222,7 +219,7 @@ ol.uds-list,
 
       &:before {
         --li-before-background-color: #{$asu-gray-1};
-        --li-before-content: counter(listcounter); // Remove space because it messes with centering.
+        --li-before-content: counter(list-item); // Remove space because it messes with centering.
         --li-before-color: #{$asu-gray-7};
         --li-before-font-size: 1.25rem;
         border-radius: 50rem;

--- a/packages/unity-bootstrap-theme/stories/atoms/list/list.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/list/list.examples.stories.js
@@ -30,17 +30,32 @@ export default {
         type: "radio",
       },
     },
+    reversed: {
+      name: "Reversed",
+      control: {
+        type: "boolean",
+      },
+    },
   },
   args: {
     bulletColor: "Default",
     backgroundColor: "Default",
+    reversed: false,
   },
 };
 
-export const UnorderedListMultiLevel = ({ bulletColor, backgroundColor }) => {
-  return (
-    <ul className={`uds-list ${bulletColor} ${backgroundColor}`}>
+export const UnorderedListMultiLevel = ({
+  bulletColor,
+  backgroundColor,
+  reversed = false,
+}) => {
+  const html = (
+    <ul
+      className={`uds-list ${bulletColor} ${backgroundColor}`}
+      {...(reversed === true && { reversed: "reversed" })}
+    >
       <li>
+        {Boolean(reversed) && <span>(Reversed has no effect on UL)</span>}
         Lorem ipsum dolor sit amet
         <ul className="uds-list">
           <li>
@@ -97,39 +112,86 @@ export const UnorderedListMultiLevel = ({ bulletColor, backgroundColor }) => {
       <li>Lorem ipsum dolor sit amet</li>
     </ul>
   );
+  // force rerender to apply reversed attribute correctly
+  return reversed ? html : <div>{html}</div>;
 };
 
-export const OrderedListMultiLevel = ({ bulletColor, backgroundColor }) => {
-  return (
-    <ol className={`uds-list ${bulletColor} ${backgroundColor}`}>
+export const OrderedListMultiLevel = ({
+  bulletColor,
+  backgroundColor,
+  reversed = false,
+}) => {
+  const html = (
+    <ol
+      className={`uds-list ${bulletColor} ${backgroundColor}`}
+      {...(reversed === true && { reversed: "reversed" })}
+    >
       <li>
-        Lorem ipsum dolor sit amet
-        <ol className="uds-list">
+        Lorem ipsum dolor sit amet{" "}
+        {Boolean(reversed) && (
+          <span>(Reversed changes Number order, not the html order)</span>
+        )}
+        <ol
+          className="uds-list"
+          {...(reversed === true && { reversed: "reversed" })}
+        >
           <li>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
-            <ol className="uds-list">
+            <ol
+              className="uds-list"
+              {...(reversed === true && { reversed: "reversed" })}
+            >
               <li>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                <ol className="uds-list">
+                <ol
+                  className="uds-list"
+                  {...(reversed === true && { reversed: "reversed" })}
+                >
                   <li>
                     Lorem ipsum dolor sit amet
-                    <ol className="uds-list">
+                    <ol
+                      className="uds-list"
+                      {...(reversed === true && { reversed: "reversed" })}
+                    >
                       <li>
                         Lorem ipsum dolor sit amet
-                        <ol className="uds-list">
+                        <ol
+                          className="uds-list"
+                          {...(reversed === true && { reversed: "reversed" })}
+                        >
                           <li>
                             Lorem ipsum dolor sit amet
-                            <ol className="uds-list">
+                            <ol
+                              className="uds-list"
+                              {...(reversed === true && {
+                                reversed: "reversed",
+                              })}
+                            >
                               <li>
                                 Lorem ipsum dolor sit amet
-                                <ol className="uds-list">
+                                <ol
+                                  className="uds-list"
+                                  {...(reversed === true && {
+                                    reversed: "reversed",
+                                  })}
+                                >
                                   <li>
                                     Lorem ipsum dolor sit amet
-                                    <ol className="uds-list">
+                                    <ol
+                                      className="uds-list"
+                                      {...(reversed === true && {
+                                        reversed: "reversed",
+                                      })}
+                                    >
                                       <li>
                                         Lorem ipsum dolor sit amet
-                                        <ol className="uds-list">
+                                        <ol
+                                          className="uds-list"
+                                          {...(reversed === true && {
+                                            reversed: "reversed",
+                                          })}
+                                        >
                                           <li>Lorem ipsum dolor sit amet</li>
                                           <li>Lorem ipsum dolor sit amet</li>
                                         </ol>
@@ -159,39 +221,214 @@ export const OrderedListMultiLevel = ({ bulletColor, backgroundColor }) => {
       <li>Lorem ipsum dolor sit amet</li>
     </ol>
   );
+  // force rerender to apply reversed attribute correctly
+  return reversed ? html : <div>{html}</div>;
 };
 
-export const MixedListMultiLevel = ({ bulletColor, backgroundColor }) => {
-  return (
-    <ol className={`uds-list ${bulletColor} ${backgroundColor}`}>
+export const ReversedOrderedListMultiLevel = ({
+  bulletColor,
+  backgroundColor,
+  reversed = false,
+}) => {
+  const html = (
+    <>
+      <h2>Basic example:</h2>
+      {Boolean(reversed) && (
+        <p>(Reversed changes Number order, not the html order)</p>
+      )}
+      <ol
+        className={`uds-list ${bulletColor} ${backgroundColor}`}
+        {...(reversed === true && { reversed: "reversed" })}
+      >
+        <li>Lorem ipsum dolor sit amet (1st html element)</li>
+        <li>Lorem ipsum dolor sit amet (2nd html element)</li>
+        <li>Lorem ipsum dolor sit amet (3rd html element)</li>
+        <li>Lorem ipsum dolor sit amet (4th html element)</li>
+        <li>Lorem ipsum dolor sit amet (5th html element)</li>
+      </ol>
+      <hr />
+      <h2>A more Complex example:</h2>
+      <ol
+        className={`uds-list ${bulletColor} ${backgroundColor}`}
+        {...(reversed === true && { reversed: "reversed" })}
+      >
+        <li>
+          Lorem ipsum dolor sit amet{" "}
+          {Boolean(reversed) && (
+            <span>(Reversed changes Number order, not the html order)</span>
+          )}
+          <ol
+            className="uds-list"
+            {...(reversed === true && { reversed: "reversed" })}
+          >
+            <li>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua.
+              <ol
+                className="uds-list"
+                {...(reversed === true && { reversed: "reversed" })}
+              >
+                <li>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  <ol
+                    className="uds-list"
+                    {...(reversed === true && { reversed: "reversed" })}
+                  >
+                    <li>
+                      Lorem ipsum dolor sit amet
+                      <ol
+                        className="uds-list"
+                        {...(reversed === true && { reversed: "reversed" })}
+                      >
+                        <li>
+                          Lorem ipsum dolor sit amet
+                          <ol
+                            className="uds-list"
+                            {...(reversed === true && { reversed: "reversed" })}
+                          >
+                            <li>
+                              Lorem ipsum dolor sit amet
+                              <ol
+                                className="uds-list"
+                                {...(reversed === true && {
+                                  reversed: "reversed",
+                                })}
+                              >
+                                <li>
+                                  Lorem ipsum dolor sit amet
+                                  <ol
+                                    className="uds-list"
+                                    {...(reversed === true && {
+                                      reversed: "reversed",
+                                    })}
+                                  >
+                                    <li>
+                                      Lorem ipsum dolor sit amet
+                                      <ol
+                                        className="uds-list"
+                                        {...(reversed === true && {
+                                          reversed: "reversed",
+                                        })}
+                                      >
+                                        <li>
+                                          Lorem ipsum dolor sit amet
+                                          <ol
+                                            className="uds-list"
+                                            {...(reversed === true && {
+                                              reversed: "reversed",
+                                            })}
+                                          >
+                                            <li>Lorem ipsum dolor sit amet</li>
+                                            <li>Lorem ipsum dolor sit amet</li>
+                                          </ol>
+                                        </li>
+                                        <li>Lorem ipsum dolor sit amet</li>
+                                      </ol>
+                                    </li>
+                                    <li>Lorem ipsum dolor sit amet</li>
+                                  </ol>
+                                </li>
+                                <li>Lorem ipsum dolor sit amet</li>
+                              </ol>
+                            </li>
+                            <li>Lorem ipsum dolor sit amet</li>
+                          </ol>
+                        </li>
+                        <li>Lorem ipsum dolor sit amet</li>
+                      </ol>
+                    </li>
+                  </ol>
+                </li>
+                <li>Lorem ipsum dolor sit amet</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>Lorem ipsum dolor sit amet</li>
+      </ol>
+    </>
+  );
+  // force rerender to apply reversed attribute correctly
+  return reversed ? html : <div>{html}</div>;
+};
+ReversedOrderedListMultiLevel.args = {
+  reversed: true,
+};
+
+export const MixedListMultiLevel = ({
+  bulletColor,
+  backgroundColor,
+  reversed = false,
+}) => {
+  const html = (
+    <ol
+      className={`uds-list ${bulletColor} ${backgroundColor}`}
+      {...(reversed === true && { reversed: "reversed" })}
+    >
       <li>
-        Lorem ipsum dolor sit amet
-        <ol>
+        Lorem ipsum dolor sit amet{" "}
+        {Boolean(reversed) && <span>(Reversed only works on OL)</span>}
+        <ol
+          className="uds-list"
+          {...(reversed === true && { reversed: "reversed" })}
+        >
           <li>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
-            <ol className="uds-list">
+            <ol
+              className="uds-list"
+              {...(reversed === true && { reversed: "reversed" })}
+            >
               <li>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                <ol className="uds-list">
+                <ol
+                  className="uds-list"
+                  {...(reversed === true && { reversed: "reversed" })}
+                >
                   <li>
                     Lorem ipsum dolor sit amet
-                    <ol>
+                    <ol
+                      className="uds-list"
+                      {...(reversed === true && { reversed: "reversed" })}
+                    >
                       <li>
                         Lorem ipsum dolor sit amet
-                        <ul className="uds-list">
+                        <ul
+                          className="uds-list"
+                          {...(reversed === true && { reversed: "reversed" })}
+                        >
                           <li>
                             Lorem ipsum dolor sit amet
-                            <ul className="uds-list">
+                            <ul
+                              className="uds-list"
+                              {...(reversed === true && {
+                                reversed: "reversed",
+                              })}
+                            >
                               <li>
                                 Lorem ipsum dolor sit amet
-                                <ul className="uds-list">
+                                <ul
+                                  className="uds-list"
+                                  {...(reversed === true && {
+                                    reversed: "reversed",
+                                  })}
+                                >
                                   <li>
                                     Lorem ipsum dolor sit amet
-                                    <ol className="uds-list">
+                                    <ol
+                                      className="uds-list"
+                                      {...(reversed === true && {
+                                        reversed: "reversed",
+                                      })}
+                                    >
                                       <li>
                                         Lorem ipsum dolor sit amet
-                                        <ol className="uds-list">
+                                        <ol
+                                          className="uds-list"
+                                          {...(reversed === true && {
+                                            reversed: "reversed",
+                                          })}
+                                        >
                                           <li>Lorem ipsum dolor sit amet</li>
                                           <li>Lorem ipsum dolor sit amet</li>
                                         </ol>
@@ -221,39 +458,82 @@ export const MixedListMultiLevel = ({ bulletColor, backgroundColor }) => {
       <li>Lorem ipsum dolor sit amet</li>
     </ol>
   );
+
+  // force rerender to apply reversed attribute correctly
+  return reversed ? html : <div>{html}</div>;
 };
 
-export const Mixed2ListMultiLevel = ({ bulletColor, backgroundColor }) => {
-  return (
-    <ul className={`uds-list ${bulletColor} ${backgroundColor}`}>
+export const Mixed2ListMultiLevel = ({
+  bulletColor,
+  backgroundColor,
+  reversed = false,
+}) => {
+  const html = (
+    <ul
+      className={`uds-list ${bulletColor} ${backgroundColor}`}
+      {...(reversed === true && { reversed: "reversed" })}
+    >
       <li>
-        Lorem ipsum dolor sit amet
-        <ul>
+        Lorem ipsum dolor sit amet{" "}
+        {Boolean(reversed) && <span>(Reversed has no effect on UL)</span>}
+        <ul {...(reversed === true && { reversed: "reversed" })}>
           <li>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
-            <ul className="uds-list">
+            <ul
+              className="uds-list"
+              {...(reversed === true && { reversed: "reversed" })}
+            >
               <li>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                <ul className="uds-list">
+                <ul
+                  className="uds-list"
+                  {...(reversed === true && { reversed: "reversed" })}
+                >
                   <li>
                     Lorem ipsum dolor sit amet
-                    <ul>
+                    <ul {...(reversed === true && { reversed: "reversed" })}>
                       <li>
                         Lorem ipsum dolor sit amet
-                        <ol className="uds-list">
+                        <ol
+                          className="uds-list"
+                          {...(reversed === true && { reversed: "reversed" })}
+                        >
                           <li>
-                            Lorem ipsum dolor sit amet
-                            <ol className="uds-list">
+                            Lorem ipsum dolor sit amet{" "}
+                            {reversed === true && (
+                              <span>(Reversed only works on OL)</span>
+                            )}
+                            <ol
+                              className="uds-list"
+                              {...(reversed === true && {
+                                reversed: "reversed",
+                              })}
+                            >
                               <li>
                                 Lorem ipsum dolor sit amet
-                                <ol className="uds-list">
+                                <ol
+                                  className="uds-list"
+                                  {...(reversed === true && {
+                                    reversed: "reversed",
+                                  })}
+                                >
                                   <li>
                                     Lorem ipsum dolor sit amet
-                                    <ul className="uds-list">
+                                    <ul
+                                      className="uds-list"
+                                      {...(reversed === true && {
+                                        reversed: "reversed",
+                                      })}
+                                    >
                                       <li>
                                         Lorem ipsum dolor sit amet
-                                        <ul className="uds-list">
+                                        <ul
+                                          className="uds-list"
+                                          {...(reversed === true && {
+                                            reversed: "reversed",
+                                          })}
+                                        >
                                           <li>Lorem ipsum dolor sit amet</li>
                                           <li>Lorem ipsum dolor sit amet</li>
                                         </ul>
@@ -283,4 +563,7 @@ export const Mixed2ListMultiLevel = ({ bulletColor, backgroundColor }) => {
       <li>Lorem ipsum dolor sit amet</li>
     </ul>
   );
+
+  // force rerender to apply reversed attribute correctly
+  return reversed ? html : <div>{html}</div>;
 };


### PR DESCRIPTION
WHMN-334

<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

This resolves an issue where ordered lists were unable to be reversed using the "reversed" attribute. It accompanies and must precede a [merge request](https://code.acquia.com/ArizonaBoardofRegentsSiteFactoryACSFSites/asufactory1/-/merge_requests/1059) in Drupal to fix list reversals in CKEditor.

I can't figure out why my build is failing. I don't have access to Jenkins, so I can't check...

## Checklist

- [ ] Tests pass for relevant code changes

## Important Reminders
<!-- Add meaningful tests -->
<!-- Remove tests that do not provide value -->

### Links

- [JIRA ticket](https://asudev.jira.com/browse/WHMN-334)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)

