### PR TITLE
feat(component-header-footer): add isUnbranded and unbrandedLogo props for unbranded (KE) sites

### DIFF
--- a/packages/component-header-footer/__mocks__/data/props-mock.js
+++ b/packages/component-header-footer/__mocks__/data/props-mock.js
@@ -96,6 +96,21 @@ const partnersState = {
   userName: "",
   breakpoint: "Lg",
 };
+const unbrandedState = {
+  isUnbranded: true,
+  unbrandedLogo: {
+    src: "https://example.com/ke-logo.png",
+    alt: "Knowledge Enterprise logo",
+    brandLink: "https://ke.example.edu",
+  },
+  navTree: basicNavTree,
+  title: "Knowledge Enterprise",
+  loggedIn: false,
+  userName: "",
+  loginLink: "/cas",
+  searchUrl: "https://search.asu.edu/search",
+  breakpoint: "Lg",
+};
 const onHoverState = {
   navTree: basicNavTree,
   title: "Ira A. Fulton Schools of Engineering",
@@ -117,6 +132,7 @@ export {
   emptyStateFooter,
   withButtonsState,
   partnersState,
+  unbrandedState,
   onHoverState,
   social, contactWithColumn, completeState,
 };

--- a/packages/component-header-footer/__mocks__/data/props-mock.js
+++ b/packages/component-header-footer/__mocks__/data/props-mock.js
@@ -104,12 +104,12 @@ const partnersState = {
 const unbrandedState = {
   isUnbranded: true,
   unbrandedLogo: {
-    src: "https://example.com/ke-logo.png",
-    alt: "Knowledge Enterprise logo",
-    brandLink: "https://ke.example.edu",
+    src: "https://example.com/unbranded-logo.png",
+    alt: "Unbranded logo",
+    brandLink: "https://unbranded.example.edu",
   },
   navTree: basicNavTree,
-  title: "Knowledge Enterprise",
+  title: "Unbranded Site",
   loggedIn: false,
   userName: "",
   loginLink: "/cas",

--- a/packages/component-header-footer/__mocks__/data/props-mock.js
+++ b/packages/component-header-footer/__mocks__/data/props-mock.js
@@ -35,6 +35,11 @@ const completeState = {
   ...social,
   ...contact,
 };
+const unbrandedStateFooter = {
+  ...social,
+  ...contact,
+  isUnbranded: true,
+};
 
 
 const defaultState = {
@@ -134,5 +139,5 @@ export {
   partnersState,
   unbrandedState,
   onHoverState,
-  social, contactWithColumn, completeState,
+  social, contactWithColumn, completeState, unbrandedStateFooter,
 };

--- a/packages/component-header-footer/docs/README.props.md
+++ b/packages/component-header-footer/docs/README.props.md
@@ -156,7 +156,7 @@
 | Name | Type | Description |
 | --- | --- | --- |
 | isPartner | <code>boolean</code> |  |
-| [isUnbranded] | <code>boolean</code> | Renders the unbranded (KE) header: the ASU logo is replaced by unbrandedLogo, and the universal navbar keeps only the skip-nav and report-accessibility links, revealed on keyboard focus. |
+| [isUnbranded] | <code>boolean</code> | Renders the unbranded header: the ASU logo is replaced by unbrandedLogo, and the universal navbar keeps only the skip-nav and report-accessibility links, revealed on keyboard focus. |
 | navTree | [<code>Array.&lt;NavTreeProps&gt;</code>](#NavTreeProps) |  |
 | [title] | <code>string</code> |  |
 | [baseUrl] | <code>string</code> |  |
@@ -241,7 +241,7 @@
 
 | Name | Type | Description |
 | --- | --- | --- |
-| [isUnbranded] | <code>boolean</code> | Renders the unbranded (KE) footer: the endorsed social row and the ASU innovation row are not rendered. Contact and legal rows behave exactly as today. |
+| [isUnbranded] | <code>boolean</code> | Renders the unbranded footer: the endorsed social row, the ASU innovation row and the legal colophon are not rendered, and the Contact "Support ASU" contribution button is suppressed. Remaining contact rows behave exactly as today. |
 | social | [<code>Social</code>](#Social) | 
 | contact | [<code>Contact</code>](#Contact) | 
 

--- a/packages/component-header-footer/docs/README.props.md
+++ b/packages/component-header-footer/docs/README.props.md
@@ -156,12 +156,14 @@
 | Name | Type | Description |
 | --- | --- | --- |
 | isPartner | <code>boolean</code> |  |
+| [isUnbranded] | <code>boolean</code> | Renders the unbranded (KE) header: the ASU logo is replaced by unbrandedLogo, and the universal navbar keeps only the skip-nav and report-accessibility links, revealed on keyboard focus. |
 | navTree | [<code>Array.&lt;NavTreeProps&gt;</code>](#NavTreeProps) |  |
 | [title] | <code>string</code> |  |
 | [baseUrl] | <code>string</code> |  |
 | [parentOrg] | <code>string</code> |  |
 | [parentOrgUrl] | <code>string</code> |  |
 | partnerLogo | [<code>Logo</code>](#Logo) |  |
+| [unbrandedLogo] | [<code>Logo</code>](#Logo) | Logo shown instead of the ASU logo when isUnbranded is true (src, alt, brandLink). |
 | logo | [<code>Logo</code>](#Logo) |  |
 | loggedIn | <code>boolean</code> |  |
 | userName | <code>string</code> |  |

--- a/packages/component-header-footer/docs/README.props.md
+++ b/packages/component-header-footer/docs/README.props.md
@@ -239,8 +239,9 @@
 **Kind**: global typedef  
 **Properties**
 
-| Name | Type |
-| --- | --- |
+| Name | Type | Description |
+| --- | --- | --- |
+| [isUnbranded] | <code>boolean</code> | Renders the unbranded (KE) footer: the endorsed social row and the ASU innovation row are not rendered. Contact and legal rows behave exactly as today. |
 | social | [<code>Social</code>](#Social) | 
 | contact | [<code>Contact</code>](#Contact) | 
 

--- a/packages/component-header-footer/src/footer/components/Contact/index.js
+++ b/packages/component-header-footer/src/footer/components/Contact/index.js
@@ -1,5 +1,5 @@
 // @ts-check
-import PropTypes, { shape, arrayOf } from "prop-types";
+import PropTypes, { shape, arrayOf, bool } from "prop-types";
 import React, { useState } from "react";
 
 import { Button } from "../../../header/components/Button";
@@ -8,11 +8,12 @@ import { ColumnSection } from "../ColumnSection";
 /**
  * @typedef {import("../../core/models/types").Contact} Contact
  *
- * @param {{contact: Contact}} props
+ * @param {{contact: Contact, isUnbranded?: boolean}} props
  */
 
 const ContactComponent = ({
   contact: { title = "", contactLink = "", contributionLink = "", columns },
+  isUnbranded = false,
 }) => {
   const [openAccordionIndex, setOpenAccordionIndex] = useState(
     /** @type {number | null} */ (null)
@@ -28,7 +29,7 @@ const ContactComponent = ({
                 <a href={contactLink}>Contact Us</a>
               </p>
             )}
-            {contributionLink && (
+            {!isUnbranded && contributionLink && (
               <p
                 className="contribute-button"
                 data-testid="contact-contribution-link"
@@ -83,6 +84,7 @@ ContactComponent.propTypes = {
       })
     ),
   }),
+  isUnbranded: bool,
 };
 
 export { ContactComponent };

--- a/packages/component-header-footer/src/footer/core/models/types.js
+++ b/packages/component-header-footer/src/footer/core/models/types.js
@@ -35,7 +35,7 @@
 
 /**
  * @typedef {object} ASUFooter
- * @property {boolean} [isUnbranded] - Renders the unbranded (KE) footer: the endorsed social row and the ASU innovation row are not rendered. Contact and legal rows behave exactly as today.
+ * @property {boolean} [isUnbranded] - Renders the unbranded footer: the endorsed social row, the ASU innovation row and the legal colophon are not rendered, and the Contact "Support ASU" contribution button is suppressed. Remaining contact rows behave exactly as today.
  * @property {Social} social
  * @property {Contact} contact
  */

--- a/packages/component-header-footer/src/footer/core/models/types.js
+++ b/packages/component-header-footer/src/footer/core/models/types.js
@@ -35,6 +35,7 @@
 
 /**
  * @typedef {object} ASUFooter
+ * @property {boolean} [isUnbranded] - Renders the unbranded (KE) footer: the endorsed social row and the ASU innovation row are not rendered. Contact and legal rows behave exactly as today.
  * @property {Social} social
  * @property {Contact} contact
  */

--- a/packages/component-header-footer/src/footer/footer.js
+++ b/packages/component-header-footer/src/footer/footer.js
@@ -1,25 +1,29 @@
 // @ts-check
 import { trackReactComponent } from "@asu/shared";
-import { shape } from "prop-types";
+import { bool, shape } from "prop-types";
 import React, { useEffect } from "react";
 
 import { Social, Legal, Innovation, ContactComponent } from "./components";
 import { StyledFooter } from "./index.styles";
 
-const Base = () => {
+const Base = ({ isUnbranded }) => {
   return (
     <>
-      <Innovation />
+      {!isUnbranded && <Innovation />}
       <Legal />
     </>
   );
+};
+
+Base.propTypes = {
+  isUnbranded: bool,
 };
 
 /**
  * @param {import("./core/models/types").ASUFooter} props
  * @returns {JSX.Element}
  */
-const ASUFooter = ({ social, contact }) => {
+const ASUFooter = ({ social, contact, isUnbranded = false }) => {
   useEffect(() => {
     if (typeof window !== "undefined") {
       trackReactComponent({
@@ -36,9 +40,9 @@ const ASUFooter = ({ social, contact }) => {
 
   return (
     <StyledFooter role="contentinfo">
-      {social && <Social social={social} />}
+      {!isUnbranded && social && <Social social={social} />}
       {contact && <ContactComponent contact={contact} />}
-      <Base />
+      <Base isUnbranded={isUnbranded} />
     </StyledFooter>
   );
 };
@@ -46,6 +50,7 @@ const ASUFooter = ({ social, contact }) => {
 ASUFooter.propTypes = {
   social: shape(Social.propTypes),
   contact: shape(ContactComponent.propTypes),
+  isUnbranded: bool,
 };
 
 export { ASUFooter };

--- a/packages/component-header-footer/src/footer/footer.js
+++ b/packages/component-header-footer/src/footer/footer.js
@@ -10,7 +10,7 @@ const Base = ({ isUnbranded }) => {
   return (
     <>
       {!isUnbranded && <Innovation />}
-      <Legal />
+      {!isUnbranded && <Legal />}
     </>
   );
 };
@@ -41,7 +41,9 @@ const ASUFooter = ({ social, contact, isUnbranded = false }) => {
   return (
     <StyledFooter role="contentinfo">
       {!isUnbranded && social && <Social social={social} />}
-      {contact && <ContactComponent contact={contact} />}
+      {contact && (
+        <ContactComponent contact={contact} isUnbranded={isUnbranded} />
+      )}
       <Base isUnbranded={isUnbranded} />
     </StyledFooter>
   );

--- a/packages/component-header-footer/src/footer/footer.stories.js
+++ b/packages/component-header-footer/src/footer/footer.stories.js
@@ -253,3 +253,9 @@ SixColumns.args = {
     ],
   },
 };
+
+export const Unbranded = Template.bind({});
+Unbranded.args = {
+  ...OneColumn.args,
+  isUnbranded: true,
+};

--- a/packages/component-header-footer/src/footer/footer.test.js
+++ b/packages/component-header-footer/src/footer/footer.test.js
@@ -78,13 +78,11 @@ describe("#ASU Unbranded Footer", () => {
   });
   afterAll(cleanup);
 
-  const positiveCases = [
-    [`Contact`, `contact`],
-    [`Legal`, `legal`],
-  ];
+  const positiveCases = [[`Contact`, `contact`]];
   const negativeCases = [
     [`Social`, `social`],
     [`Innovation`, `innovation`],
+    [`Legal`, `legal`],
   ];
 
   test.each(positiveCases)("should %p section be defined", (_, testId) =>
@@ -93,4 +91,10 @@ describe("#ASU Unbranded Footer", () => {
   test.each(negativeCases)("should %p section not be defined", (_, testId) =>
     expect(component.queryByTestId(testId)).not.toBeInTheDocument()
   );
+
+  it("should not render the 'Support ASU' contribution button", () => {
+    expect(
+      component.queryByTestId("contact-contribution-link")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/component-header-footer/src/footer/footer.test.js
+++ b/packages/component-header-footer/src/footer/footer.test.js
@@ -7,6 +7,7 @@ import { ASUFooter } from ".";
 import {
   completeState,
   emptyStateFooter,
+  unbrandedStateFooter,
 } from "../../__mocks__/data/props-mock";
 
 const renderFooter = props => {
@@ -58,6 +59,32 @@ describe("#ASU Footer without social and contact", () => {
   const negativeCases = [
     [`Social`, `social`],
     [`Contact`, `contact`],
+  ];
+
+  test.each(positiveCases)("should %p section be defined", (_, testId) =>
+    expect(component.queryByTestId(testId)).toBeInTheDocument()
+  );
+  test.each(negativeCases)("should %p section not be defined", (_, testId) =>
+    expect(component.queryByTestId(testId)).not.toBeInTheDocument()
+  );
+});
+
+describe("#ASU Unbranded Footer", () => {
+  /** @type {import("@testing-library/react").RenderResult} */
+  let component;
+
+  beforeEach(() => {
+    component = renderFooter(unbrandedStateFooter);
+  });
+  afterAll(cleanup);
+
+  const positiveCases = [
+    [`Contact`, `contact`],
+    [`Legal`, `legal`],
+  ];
+  const negativeCases = [
+    [`Social`, `social`],
+    [`Innovation`, `innovation`],
   ];
 
   test.each(positiveCases)("should %p section be defined", (_, testId) =>

--- a/packages/component-header-footer/src/header/components/HeaderMain/Logo/index.js
+++ b/packages/component-header-footer/src/header/components/HeaderMain/Logo/index.js
@@ -8,7 +8,33 @@ import { CLASS_NAMES } from "../../../core/constants/classNames";
 import { LogoWrapper } from "./index.styles";
 
 const Logo = () => {
-  const { logo } = useAppContext();
+  const { logo, isUnbranded, unbrandedLogo } = useAppContext();
+
+  if (isUnbranded) {
+    return (
+      <LogoWrapper
+        href={unbrandedLogo?.brandLink ?? "/"}
+        className={CLASS_NAMES.NAVBAR_BRAND}
+        data-testid="logo"
+        onFocus={() => trackGAEvent({ text: "unbranded logo" })}
+      >
+        <img
+          className={CLASS_NAMES.LOGO_VERT}
+          src={unbrandedLogo?.src}
+          alt={unbrandedLogo?.alt ?? ""}
+          decoding="async"
+          fetchpriority="high"
+        />
+        <img
+          className={CLASS_NAMES.LOGO_HORIZ}
+          src={unbrandedLogo?.src}
+          alt={unbrandedLogo?.alt ?? ""}
+          decoding="async"
+          fetchpriority="high"
+        />
+      </LogoWrapper>
+    );
+  }
 
   return (
     <LogoWrapper

--- a/packages/component-header-footer/src/header/components/HeaderMain/index.js
+++ b/packages/component-header-footer/src/header/components/HeaderMain/index.js
@@ -20,6 +20,7 @@ const HeaderMain = () => {
   const {
     breakpoint,
     isPartner,
+    isUnbranded,
     hasNavigation,
     itemOpened,
     setItemOpened,
@@ -109,7 +110,7 @@ const HeaderMain = () => {
                 {isPartner ? <Partner /> : <Title />}
                 {!isMobile && <NavbarContainer />}
               </div>
-              {mobileMenuOpen && isMobile && <Search />}
+              {mobileMenuOpen && isMobile && !isUnbranded && <Search />}
               {mobileMenuOpen && isMobile && <NavbarContainer />}
             </div>
           </div>

--- a/packages/component-header-footer/src/header/components/UniversalNavbar/index.js
+++ b/packages/component-header-footer/src/header/components/UniversalNavbar/index.js
@@ -20,7 +20,7 @@ const DEFAULT_GA_EVENT = {
 };
 
 const UniversalNavbar = () => {
-  const { breakpoint } = useAppContext();
+  const { breakpoint, isUnbranded } = useAppContext();
   const isMobile = useIsMobile(breakpoint);
 
   function getURL() {
@@ -41,6 +41,7 @@ const UniversalNavbar = () => {
       ),
       href: "#skip-to-content",
       text: "Skip to main content",
+      isAccessibilityLink: true,
     },
     {
       className: buildClassName(
@@ -49,6 +50,7 @@ const UniversalNavbar = () => {
       ),
       href: `https://accessibility.asu.edu/report#a11yref=${getURL()}`,
       text: "Report an accessibility problem",
+      isAccessibilityLink: true,
     },
     {
       className: CLASS_NAMES.NAV_LINK,
@@ -67,11 +69,20 @@ const UniversalNavbar = () => {
     },
   ];
 
+  // Unbranded (KE) sites keep only the accessibility links; the gray bar is
+  // revealed exclusively while one of them has keyboard focus.
+  const visibleNavLinks = isUnbranded
+    ? universalNavLinks.filter(link => link.isAccessibilityLink)
+    : universalNavLinks;
+
   return (
     <Wrapper
       // @ts-ignore
       breakpoint={breakpoint}
-      className={CLASS_NAMES.UNIVERSAL_NAV}
+      className={buildClassName(
+        CLASS_NAMES.UNIVERSAL_NAV,
+        isUnbranded && CLASS_NAMES.UNIVERSAL_NAV_UNBRANDED
+      )}
       data-testid="universal-navbar"
       data-elastic-exclude="data-elastic-exclude"
     >
@@ -79,7 +90,7 @@ const UniversalNavbar = () => {
         <div className={CLASS_NAMES.HEADER_TOP}>
           <nav className="nav" aria-label="ASU Global">
             <div className={CLASS_NAMES.LINKS_CONTAINER}>
-              {universalNavLinks.map(link => (
+              {visibleNavLinks.map(link => (
                 <a
                   key={link.href}
                   className={link.className}
@@ -91,9 +102,9 @@ const UniversalNavbar = () => {
                   {link.text}
                 </a>
               ))}
-              <Login />
+              {!isUnbranded && <Login />}
             </div>
-            {!isMobile && <Search />}
+            {!isMobile && !isUnbranded && <Search />}
           </nav>
         </div>
       </div>

--- a/packages/component-header-footer/src/header/components/UniversalNavbar/index.styles.js
+++ b/packages/component-header-footer/src/header/components/UniversalNavbar/index.styles.js
@@ -98,6 +98,22 @@ const Wrapper = styled.div`
       grid-template-columns: 1fr 1fr 1fr 1fr;
     }
   }
+
+  /* Unbranded (KE) sites: the gray bar stays visually hidden but keyboard
+  reachable, and is revealed only while a skip/accessibility link has focus. */
+  &.${CLASS_NAMES.UNIVERSAL_NAV_UNBRANDED}:not(:focus-within) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    min-height: 0;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(100%);
+    white-space: nowrap;
+    border: 0;
+  }
 `;
 
 export { Wrapper };

--- a/packages/component-header-footer/src/header/components/UniversalNavbar/index.styles.js
+++ b/packages/component-header-footer/src/header/components/UniversalNavbar/index.styles.js
@@ -99,7 +99,7 @@ const Wrapper = styled.div`
     }
   }
 
-  /* Unbranded (KE) sites: the gray bar stays visually hidden but keyboard
+  /* Unbranded sites: the gray bar stays visually hidden but keyboard
   reachable, and is revealed only while a skip/accessibility link has focus. */
   &.${CLASS_NAMES.UNIVERSAL_NAV_UNBRANDED}:not(:focus-within) {
     position: absolute;

--- a/packages/component-header-footer/src/header/core/constants/classNames.js
+++ b/packages/component-header-footer/src/header/core/constants/classNames.js
@@ -32,6 +32,7 @@ export const CLASS_NAMES = {
 
   // Header sections
   UNIVERSAL_NAV: `${CLASS_PREFIX}universal-nav`,
+  UNIVERSAL_NAV_UNBRANDED: `${CLASS_PREFIX}universal-nav-unbranded`,
   HEADER_TOP: `${CLASS_PREFIX}header-top`,
   LINKS_CONTAINER: `${CLASS_PREFIX}links-container`,
   HEADER_MAIN: `${CLASS_PREFIX}header-main`,

--- a/packages/component-header-footer/src/header/core/models/app-prop-types.js
+++ b/packages/component-header-footer/src/header/core/models/app-prop-types.js
@@ -45,8 +45,10 @@ const NavTreePropTypes = PropTypes.shape({
 
 const HeaderPropTypes = {
   isPartner: PropTypes.bool,
+  isUnbranded: PropTypes.bool,
   navTree: PropTypes.arrayOf(NavTreePropTypes),
   partnerLogo: PropTypes.shape(LogoPropTypes),
+  unbrandedLogo: PropTypes.shape(LogoPropTypes),
   logo: PropTypes.shape(LogoPropTypes),
   title: PropTypes.string,
   parentOrg: TitlePropTypes.parentOrg,

--- a/packages/component-header-footer/src/header/core/models/types.js
+++ b/packages/component-header-footer/src/header/core/models/types.js
@@ -38,12 +38,14 @@
 /**
  * @typedef {object} HeaderProps
  * @property {boolean} isPartner
+ * @property {boolean} [isUnbranded] - Renders the unbranded (KE) header: the ASU logo is replaced by unbrandedLogo, and the universal navbar keeps only the skip-nav and report-accessibility links, revealed on keyboard focus.
  * @property {NavTreeProps[]} navTree
  * @property {string} [title]
  * @property {string} [baseUrl]
  * @property {string} [parentOrg]
  * @property {string} [parentOrgUrl]
  * @property {Logo} partnerLogo
+ * @property {Logo} [unbrandedLogo] - Logo shown instead of the ASU logo when isUnbranded is true (src, alt, brandLink).
  * @property {Logo} logo
  * @property {boolean} loggedIn
  * @property {string} userName

--- a/packages/component-header-footer/src/header/header.js
+++ b/packages/component-header-footer/src/header/header.js
@@ -21,12 +21,14 @@ import { Header, HeaderDiv, GlobalStyle } from "./header.styles";
 
 const ASUHeader = ({
   isPartner = false,
+  isUnbranded = false,
   navTree: rawNavTree,
   title,
   baseUrl = "/",
   parentOrg,
   parentOrgUrl,
   partnerLogo,
+  unbrandedLogo,
   logo,
   loggedIn,
   userName,
@@ -110,6 +112,7 @@ const ASUHeader = ({
         configuration: {
           site,
           isPartner,
+          isUnbranded,
           searchUrl,
           navTree,
           parentOrg,
@@ -153,12 +156,14 @@ const ASUHeader = ({
     <AppContextProvider
       initialValue={{
         isPartner,
+        isUnbranded,
         navTree,
         title,
         baseUrl,
         parentOrg,
         parentOrgUrl,
         partnerLogo,
+        unbrandedLogo,
         logo,
         loggedIn,
         userName,

--- a/packages/component-header-footer/src/header/header.test.js
+++ b/packages/component-header-footer/src/header/header.test.js
@@ -93,11 +93,14 @@ describe("#ASU Unbranded Header", () => {
 
   it("should replace the ASU logo with the unbranded logo", () => {
     const logo = screen.getByTestId("logo");
-    expect(logo).toHaveAttribute("href", "https://ke.example.edu");
-    const images = component.getAllByAltText("Knowledge Enterprise logo");
+    expect(logo).toHaveAttribute("href", "https://unbranded.example.edu");
+    const images = component.getAllByAltText("Unbranded logo");
     expect(images.length).toBeGreaterThan(0);
     images.forEach(img => {
-      expect(img).toHaveAttribute("src", "https://example.com/ke-logo.png");
+      expect(img).toHaveAttribute(
+        "src",
+        "https://example.com/unbranded-logo.png"
+      );
     });
     expect(
       component.queryByAltText("Arizona State University logo")
@@ -127,9 +130,7 @@ describe("#ASU Unbranded Header", () => {
   });
 
   it("should keep title and navigation menu rendering", () => {
-    expect(screen.getByTestId("title")).toHaveTextContent(
-      "Knowledge Enterprise"
-    );
+    expect(screen.getByTestId("title")).toHaveTextContent("Unbranded Site");
     expect(screen.getByTestId("navigation")).toBeInTheDocument();
   });
 });

--- a/packages/component-header-footer/src/header/header.test.js
+++ b/packages/component-header-footer/src/header/header.test.js
@@ -8,6 +8,7 @@ import {
   defaultState,
   emptyStateHeader,
   partnersState,
+  unbrandedState,
   withButtonsState,
 } from "../../__mocks__/data/props-mock";
 
@@ -78,6 +79,58 @@ describe("#ASU Header with button", () => {
       expect(component.queryByTestId("buttons-container")).toBeInTheDocument();
     });
     cleanup();
+  });
+});
+
+describe("#ASU Unbranded Header", () => {
+  /** @type {import("@testing-library/react").RenderResult} */
+  let component;
+
+  beforeEach(() => {
+    component = renderHeader(unbrandedState);
+  });
+  afterEach(cleanup);
+
+  it("should replace the ASU logo with the unbranded logo", () => {
+    const logo = screen.getByTestId("logo");
+    expect(logo).toHaveAttribute("href", "https://ke.example.edu");
+    const images = component.getAllByAltText("Knowledge Enterprise logo");
+    expect(images.length).toBeGreaterThan(0);
+    images.forEach(img => {
+      expect(img).toHaveAttribute("src", "https://example.com/ke-logo.png");
+    });
+    expect(
+      component.queryByAltText("Arizona State University logo")
+    ).toBeNull();
+  });
+
+  it("should keep only the skip-nav and accessibility links in the universal navbar", () => {
+    expect(screen.getByText("Skip to main content")).toBeInTheDocument();
+    expect(
+      screen.getByText("Report an accessibility problem")
+    ).toBeInTheDocument();
+    expect(component.queryByText("ASU Home")).toBeNull();
+    expect(component.queryByText("My ASU")).toBeNull();
+    expect(component.queryByText("Colleges and Schools")).toBeNull();
+  });
+
+  it("should not render sign in, sign out or the ASU search input", () => {
+    expect(component.queryByText("Sign In")).toBeNull();
+    expect(component.queryByText("Sign Out")).toBeNull();
+    expect(component.queryByTestId("universal-nav-search-form")).toBeNull();
+  });
+
+  it("should mark the universal navbar as focus-revealed", () => {
+    expect(screen.getByTestId("universal-navbar")).toHaveClass(
+      "uds-hdr-universal-nav-unbranded"
+    );
+  });
+
+  it("should keep title and navigation menu rendering", () => {
+    expect(screen.getByTestId("title")).toHaveTextContent(
+      "Knowledge Enterprise"
+    );
+    expect(screen.getByTestId("navigation")).toBeInTheDocument();
   });
 });
 

--- a/packages/component-header-footer/src/header/index.stories.js
+++ b/packages/component-header-footer/src/header/index.stories.js
@@ -265,12 +265,12 @@ export const Unbranded = Template.bind({});
 Unbranded.args = {
   isUnbranded: true,
   unbrandedLogo: {
-    src: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='60'><rect width='240' height='60' rx='4' fill='%238C1D40'/><text x='120' y='38' font-family='Arial' font-size='22' fill='%23FFC627' text-anchor='middle'>KE Logo</text></svg>",
-    alt: "ASU Knowledge Enterprise logo",
+    src: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='60'><rect width='240' height='60' rx='4' fill='%238C1D40'/><text x='120' y='38' font-family='Arial' font-size='22' fill='%23FFC627' text-anchor='middle'>Unbranded Logo</text></svg>",
+    alt: "Unbranded logo",
     brandLink: "https://research.asu.edu",
   },
   navTree: basicNavTree,
-  title: "Knowledge Enterprise",
+  title: "Unbranded Site",
   breakpoint: "Xl",
 };
 

--- a/packages/component-header-footer/src/header/index.stories.js
+++ b/packages/component-header-footer/src/header/index.stories.js
@@ -261,6 +261,19 @@ Partner.args = {
   site: "subdomain",
 };
 
+export const Unbranded = Template.bind({});
+Unbranded.args = {
+  isUnbranded: true,
+  unbrandedLogo: {
+    src: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='60'><rect width='240' height='60' rx='4' fill='%238C1D40'/><text x='120' y='38' font-family='Arial' font-size='22' fill='%23FFC627' text-anchor='middle'>KE Logo</text></svg>",
+    alt: "ASU Knowledge Enterprise logo",
+    brandLink: "https://research.asu.edu",
+  },
+  navTree: basicNavTree,
+  title: "Knowledge Enterprise",
+  breakpoint: "Xl",
+};
+
 export const AnimatedTitle = AnimatedTitleTemplate.bind({});
 AnimatedTitle.args = {
   title: "Subdomain name",

--- a/packages/component-header-footer/types/main.d.ts
+++ b/packages/component-header-footer/types/main.d.ts
@@ -89,6 +89,7 @@ export interface Contact {
 }
 
 export interface FooterProps {
+  isUnbranded?: boolean;
   social: Social;
   contact: Contact;
 }

--- a/packages/component-header-footer/types/main.d.ts
+++ b/packages/component-header-footer/types/main.d.ts
@@ -31,12 +31,14 @@ export interface NavTreeProps {
 
 export interface HeaderProps {
   isPartner: boolean;
+  isUnbranded?: boolean;
   navTree: NavTreeProps[];
   title?: string;
   baseUrl?: string;
   parentOrg?:  string;
   parentOrgUrl?: string;
   partnerLogo: Logo;
+  unbrandedLogo?: Logo;
   logo: Logo;
   loggedIn: boolean;
   userName: string;


### PR DESCRIPTION
## Summary

Adds two new optional props to the Global Header (`component-header-footer`), requested by Webspark for the Unbranded (KE) profile work (WS2-2964, WS2-3128). Jira: UDS-2248.

- `isUnbranded` (bool, default `false`)
- `unbrandedLogo` (object: `src`, `alt`, `brandLink`)

When `isUnbranded` is true:

- The ASU logo is replaced by `unbrandedLogo`, mirroring how `partnerLogo` is injected for `isPartner`.
- The universal navbar keeps only the skip-nav link and the report-accessibility link. The gray universal bar is not displayed unless one of those hidden links receives keyboard focus (focus-revealed via `:focus-within`, standard skip-link pattern).
- Sign In / Sign Out, ASU Home, My ASU, Colleges and Schools and the ASU search input are not rendered.
- Everything else (navTree menu, CTA buttons, title, parentOrg) behaves exactly as today.

Rationale: the universal nav links were hardcoded inside the React bundle with no prop to suppress them, so unbranded rendering was impossible without this change.

## Changes

- `ASUHeader`: new `isUnbranded` / `unbrandedLogo` props, wired through the app context, PropTypes, JSDoc typedefs and `types/main.d.ts`.
- `Logo`: renders `unbrandedLogo` (src/alt/brandLink) instead of the ASU logo when unbranded.
- `UniversalNavbar`: filters the nav links down to the two accessibility links, drops `Login` and `Search`, and adds a `uds-hdr-universal-nav-unbranded` class whose CSS visually hides the bar (still keyboard-reachable) except under `:focus-within`.
- `HeaderMain`: the mobile-menu search input is also suppressed when unbranded.
- New `Unbranded` Storybook story, updated `docs/README.props.md`.

## Testing

- 5 new unit tests in `header.test.js` (logo replacement, link reduction, sign-in/search suppression, focus-reveal class, nav/title regression). Full package suite: 51/51 passing, including the Playwright dataLayer tests.
- Verified manually in Storybook: gray bar hidden by default, revealed while tabbing through "Skip to main content" / "Report an accessibility problem", hidden again on blur.
- Note: local `yarn test` at the repo root shows a pre-existing, unrelated failure in `@asu/app-webdir-ui` (`MessageChannel is not defined` jsdom environment issue); this PR touches no files in that package.