### PR TITLE
UDS-2251 switch acp-reviewer model

### DIFF
--- a/.kiro/README.md
+++ b/.kiro/README.md
@@ -78,8 +78,9 @@ Validate manually with `.kiro/scripts/validate-handoff.sh <path>`.
 
 ## Notes
 
-- Models are foundry defaults (Opus architect/orchestrator, Sonnet coder, GLM
-  reviewer, Sonnet vision). If a model id isn't available in your Kiro, it falls
+- Models are foundry defaults (Opus architect/orchestrator, Sonnet coder, GPT
+  reviewer, Sonnet vision). The reviewer uses a non-Anthropic family on purpose
+  for adversarial model diversity. If a model id isn't available in your Kiro, it falls
   back to the default — adjust `model` in `agents/acp-*.json` as needed.
 - `asu-brand` / `asu-design-a11y` are shared with Webspark (this copy is
   canonical). `asu-brand` is a candidate to upstream to the foundry later.

--- a/.kiro/agents/acp-reviewer.json
+++ b/.kiro/agents/acp-reviewer.json
@@ -1,6 +1,6 @@
 {
   "name": "acp-reviewer",
-  "model": "glm-5",
+  "model": "gpt-5.6-terra",
   "description": "Three-phase adversarial code reviewer: spec compliance, attack surface analysis, and QA verification.",
   "prompt": "file://prompts/reviewer.md",
   "tools": ["fs_read", "execute_bash", "grep", "glob", "code"],


### PR DESCRIPTION
### Description

acp-reviewer agent used the `glm-5` model which is no longer available to us. Switching to non-open `gpt-5.6-terra` which ought to be comparable in price and performance and maintains the separate models per agent architectural principle. This will avoid falling back to the default model, which may not respect that distinction.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2251)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)

