### PR TITLE
fix(unity-bootstrap-theme): remove bluefocus artifact that was confus…

### DIFF
--- a/.kiro/skills/asu-brand/SKILL.md
+++ b/.kiro/skills/asu-brand/SKILL.md
@@ -20,7 +20,6 @@ copy of this skill and the Unity-provided CSS variables.)
 | ASU Green | `#78be20` | `$uds-color-base-green` |
 | ASU Orange | `#ff7f32` | `$uds-color-base-orange` |
 | ASU Blue | `#00a3e0` | `$uds-color-base-blue` |
-| Focus Blue (a11y) | `#00baff` | `$uds-color-base-bluefocus` |
 
 Maroon and gold are the primary brand colors. Darkgold `#7f6227` and darkmaroon
 `#440e22` are visited states.

--- a/packages/unity-bootstrap-theme/src/scss/_custom-asu-variables.scss
+++ b/packages/unity-bootstrap-theme/src/scss/_custom-asu-variables.scss
@@ -41,7 +41,6 @@ $uds-color-base-white: #ffffff; // White
 $uds-color-base-green: #78be20; // ASU Green
 $uds-color-base-orange: #ff7f32; // ASU Orange
 $uds-color-base-blue: #00a3e0; // ASU Blue
-$uds-color-base-bluefocus: #00baff; // A11y Focus Blue - used for highlighting the page element with current focus
 $uds-color-base-darkgold: #7f6227; // Visited state of ASU Gold
 $uds-color-base-darkmaroon: #440e22; // Visited state of ASU Maroon
 // Deprecated-start

--- a/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_cards.scss
@@ -70,23 +70,12 @@ Cards - Table of Contents
   cursor: $card-basic-hover-cursor;
 }
 
-.card-hover:focus {
-  outline: 0;
-  box-shadow: 0 0 8px $uds-color-base-bluefocus !important;
-}
-
 .card-hover > button {
   border: none;
   background: transparent;
   text-align: inherit;
   margin: 0;
   padding: 0;
-}
-
-.card-hover > button:focus {
-  outline: 0;
-  box-shadow: 0 0 8px $uds-color-base-bluefocus !important;
-  border: 0;
 }
 
 .card-icon-top {
@@ -503,11 +492,6 @@ Cards - Table of Contents
 
   &:hover {
     color: $uds-color-base-maroon;
-  }
-
-  &:focus-visible {
-    outline: 2px solid $uds-color-base-bluefocus;
-    outline-offset: 2px;
   }
 
   @include media-breakpoint-down(md) {

--- a/packages/unity-bootstrap-theme/src/scss/variables/_colors.scss
+++ b/packages/unity-bootstrap-theme/src/scss/variables/_colors.scss
@@ -31,7 +31,6 @@ $blue: $uds-color-base-blue;
 $green: $uds-color-base-green;
 $orange: $uds-color-base-orange;
 
-$bluefocus: $uds-color-base-bluefocus;
 $darkgold: $uds-color-base-darkgold;
 $darkmaroon: $uds-color-base-darkmaroon;
 
@@ -45,7 +44,6 @@ $colors: map-merge(
     'green': $green,
     'orange': $orange,
     'white': $white,
-    'bluefocus': $bluefocus,
     'darkgold': $darkgold,
     'darkmaroon': $darkmaroon,
   ),
@@ -95,11 +93,6 @@ $link-decoration: underline;
 $link-hover-color: $maroon;
 $link-hover-decoration: none;
 $link-visited-color: $uds-color-base-darkmaroon;
-
-:focus {
-  outline: 0;
-  box-shadow: 0 0 8px $uds-color-base-bluefocus !important;
-}
 
 // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 // $emphasized-link-hover-darken-percentage: 15%;


### PR DESCRIPTION
<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Description

Design token artifact was causing confusion among agents regarding focus.

Removed the references. 

Testing:

- Verify there are no regressions related to card hover... which we're not really using now, if memory serves.
- Verify there are no other regressions with focus styles

## Checklist

- [x] Tests pass for relevant code changes

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2254)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)

