### PR TITLE
fix(unity-bootstrap-theme): form field validation

### DIFF
--- a/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
+++ b/packages/unity-bootstrap-theme/src/scss/extends/_form-fields.scss
@@ -227,9 +227,16 @@ form.uds-form {
         border-bottom: 8px solid var(--invalid-feedback-light-background) !important;
       }
     }
+    .form-control:invalid ~ .invalid-feedback,
+    .form-select:invalid ~ .invalid-feedback {
+      display: inline-block;
+    }
     // Radios and checks individual labels shouldn't be colored.
     .form-check-input:invalid ~ .form-check-label {
       color: $asu-gray-1;
+    }
+    .form-check-input:invalid ~ .invalid-feedback {
+      display: inline-block;
     }
 
     //&.was-validated .form-control:valid {
@@ -243,9 +250,16 @@ form.uds-form {
         border-bottom: 8px solid $uds-color-font-dark-success !important;
       }
     }
+    .form-control:valid ~ .valid-feedback,
+    .form-select:valid ~ .valid-feedback {
+      display: inline-block;
+    }
     // Radios and checks individual labels shouldn't be colored.
     .form-check-input:valid ~ .form-check-label {
       color: $asu-gray-1;
+    }
+    .form-check-input:valid ~ .valid-feedback {
+      display: inline-block;
     }
   }
 
@@ -265,6 +279,13 @@ form.uds-form {
       border-bottom: 8px solid var(--invalid-feedback-light-background) !important;
     }
   }
+  // Show feedback via sibling selector (server-side .is-invalid on input)
+  .is-invalid ~ .invalid-feedback {
+    display: inline-block;
+  }
+  .is-valid ~ .valid-feedback {
+    display: inline-block;
+  }
   /* checks and radios */
   small.is-invalid,
   div.is-invalid {
@@ -281,13 +302,18 @@ form.uds-form {
     color: var(--invalid-feedback-light-background);
   }
   .invalid-feedback {
-    display: inline-block;
     font-weight: bold;
     svg, i, span {
       // We don't implement svg icons as bkg images due to need for color
       // manipulation.
       color: var(--invalid-feedback-light-background);
       margin-right: $uds-size-spacing-1;
+    }
+    // Legacy UDS pattern: .is-invalid applied directly on the feedback element
+    // (server-side validation). Bootstrap's sibling selector won't catch this,
+    // so we force display here.
+    &.is-invalid {
+      display: inline-block;
     }
   }
 
@@ -320,13 +346,18 @@ form.uds-form {
     color: $uds-color-font-dark-success;
   }
   .valid-feedback {
-    display: inline-block;
     font-weight: bold;
     svg, i, span {
       // We don't implement svg icons as bkg images due to need for color
       // manipulation.
       color: $uds-color-font-dark-success;
       margin-right: $uds-size-spacing-1;
+    }
+    // Legacy UDS pattern: .is-valid applied directly on the feedback element
+    // (server-side validation). Bootstrap's sibling selector won't catch this,
+    // so we force display here.
+    &.is-valid {
+      display: inline-block;
     }
   }
 

--- a/packages/unity-bootstrap-theme/stories/atoms/form-fields/form-fields.examples.stories.js
+++ b/packages/unity-bootstrap-theme/stories/atoms/form-fields/form-fields.examples.stories.js
@@ -1,11 +1,26 @@
 import React from "react";
 import { defaultDecorator } from "@asu/shared";
 
+const backgroundOptions = {
+  "Default (none)": "",
+  "White": "uds-form-white",
+  "Faint (gray 1)": "uds-form-faint-bg",
+  "Light (gray 2)": "uds-form-light-bg",
+  "Dark (gray 7)": "uds-form-dark-bg",
+};
+
+const backgroundColors = {
+  "": undefined,
+  "uds-form-white": "white",
+  "uds-form-faint-bg": "#fafafa",
+  "uds-form-light-bg": "#e8e8e8",
+  "uds-form-dark-bg": "#191919",
+};
+
 export default {
   title: "Atoms/Form Fields/Examples",
   decorators: [defaultDecorator],
   parameters: {
-    controls: { disable: true },
     docs: {
       description: {
         component:
@@ -13,125 +28,28 @@ export default {
       },
     },
   },
+  args: {
+    background: "",
+  },
+  argTypes: {
+    background: {
+      name: "Background",
+      options: Object.keys(backgroundOptions),
+      mapping: backgroundOptions,
+      control: { type: "select" },
+    },
+  },
 };
 
-export const TextInputs = () => (
-  <form className="uds-form">
-    <div className="form-group">
-      <label for="exampleDefaultInput">Default text input label</label>
-      <input
-        type="text"
-        className="form-control"
-        id="exampleDefaultInput"
-        placeholder="Helper text"
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      />
-    </div>
-
-    <div className="form-group">
-      <label for="exampleFocusInput">Focus text input label</label>
-      <input
-        type="text"
-        className="form-control"
-        id="exampleFocusInput"
-        placeholder="Helper text"
-        value="Focus me to see focus style"
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      />
-    </div>
-
-    <div className="form-group">
-      <label for="exampleDisabledInput" className="uds-form-label-disabled">
-        Disabled text input label
-      </label>
-      <input
-        type="text"
-        className="form-control"
-        id="exampleDisabledInput"
-        placeholder="Helper text"
-        disabled
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      />
-    </div>
-
-    <div className="form-group">
-      <label for="exampleErrorInput">
-        <span
-          title="Required"
-          className="fa fa-icon fa-circle uds-field-required"
-        ></span>
-        Error text input label on a required field
-      </label>
-      <input
-        type="text"
-        className="form-control is-invalid"
-        id="exampleErrorInput"
-        aria-describedby="errorHelp"
-        placeholder="Helper text"
-        aria-required="true"
-        required
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      />
-      <small id="errorHelp" className="form-text invalid-feedback">
-        <span
-          title="Alert"
-          className="fa fa-icon fa-exclamation-triangle"
-        ></span>
-        Form error message
-      </small>
-    </div>
-
-    <div className="form-group">
-      <label for="exampleSuccessInput">Success text input label</label>
-      <input
-        type="text"
-        className="form-control is-valid"
-        id="exampleSuccessInput"
-        aria-describedby="successHelp"
-        placeholder="Helper text"
-        value="Input text"
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      />
-      <small id="successHelp" className="form-text valid-feedback">
-        <span title="Success" className="fa fa-icon fa-check-circle"></span>
-        Success message
-      </small>
-    </div>
-
-    <div className="form-group">
-      <label for="exampleTrailingIconInput">
-        Trailing icon text input label
-      </label>
-      <div className="input-group input-group-trailing-icon">
+export const TextInputs = args => (
+  <div style={{ backgroundColor: backgroundColors[args.background] }}>
+    <form className={`uds-form ${args.background}`}>
+      <div className="form-group">
+        <label htmlFor="exampleDefaultInput">Default text input label</label>
         <input
           type="text"
           className="form-control"
-          id="exampleTrailingIconInput"
+          id="exampleDefaultInput"
           placeholder="Helper text"
           data-ga-input="blur"
           data-ga-input-name="onclick"
@@ -140,1411 +58,279 @@ export const TextInputs = () => (
           data-ga-input-region="main content"
           data-ga-input-section="text label"
         />
-        <span className="far fa-icon fa-calendar" aria-hidden="true"></span>
       </div>
-    </div>
 
-    {/* TODO Implement js code to set focus on exampleFocusInput when page loads
-      Should only run and be packaged for storybook preview.
-      <script>
-      document.getElementById('exampleFocusInput').focus();
-      </script>
-      */}
-  </form>
-);
+      <div className="form-group">
+        <label htmlFor="exampleFocusInput">Focus text input label</label>
+        <input
+          type="text"
+          className="form-control"
+          id="exampleFocusInput"
+          placeholder="Helper text"
+          defaultValue="Focus me to see focus style"
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        />
+      </div>
 
-export const TextInputsVariousBackgrounds = () => (
-  <div>
-    <div style={{ backgroundColor: "white" }}>
-      {/* This div for Storybook display only. */}
-      <form className="uds-form uds-form-white">
-        <div className="form-group">
-          <label for="exampleDefaultInputWhite">Default text input label</label>
+      <div className="form-group">
+        <label
+          htmlFor="exampleDisabledInput"
+          className="uds-form-label-disabled"
+        >
+          Disabled text input label
+        </label>
+        <input
+          type="text"
+          className="form-control"
+          id="exampleDisabledInput"
+          placeholder="Helper text"
+          disabled
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="exampleErrorInput">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          Error text input label on a required field
+        </label>
+        <input
+          type="text"
+          className="form-control is-invalid"
+          id="exampleErrorInput"
+          aria-describedby="errorHelp"
+          placeholder="Helper text"
+          aria-required="true"
+          required
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        />
+        <small id="errorHelp" className="form-text invalid-feedback">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="exampleSuccessInput">Success text input label</label>
+        <input
+          type="text"
+          className="form-control is-valid"
+          id="exampleSuccessInput"
+          aria-describedby="successHelp"
+          placeholder="Helper text"
+          defaultValue="Input text"
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        />
+        <small id="successHelp" className="form-text valid-feedback">
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="exampleTrailingIconInput">
+          Trailing icon text input label
+        </label>
+        <div className="input-group input-group-trailing-icon">
           <input
             type="text"
             className="form-control"
-            id="exampleDefaultInputWhite"
+            id="exampleTrailingIconInput"
             placeholder="Helper text"
+            data-ga-input="blur"
+            data-ga-input-name="onclick"
+            data-ga-input-event="form"
+            data-ga-input-action="click"
+            data-ga-input-region="main content"
+            data-ga-input-section="text label"
           />
+          <span className="far fa-icon fa-calendar" aria-hidden="true"></span>
         </div>
-
-        <div className="form-group">
-          <label for="exampleFocusInputWhite">Focus text input label</label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleFocusInputWhite"
-            placeholder="Helper text"
-            value="Focus me to see focus style"
-          />
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleDisabledInputWhite"
-            className="uds-form-label-disabled"
-          >
-            Disabled text input label
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleDisabledInputWhite"
-            placeholder="Helper text"
-            disabled
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleErrorInputWhite">Error text input label</label>
-          <input
-            type="text"
-            className="form-control is-invalid"
-            id="exampleErrorInputWhite"
-            aria-describedby="errorHelp"
-            placeholder="Helper text"
-          />
-          <small id="errorHelp" className="form-text invalid-feedback">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleSuccessInputWhite">Success text input label</label>
-          <input
-            type="text"
-            className="form-control is-valid"
-            id="exampleSuccessInputWhite"
-            aria-describedby="successHelp"
-            placeholder="Helper text"
-            value="Input text"
-          />
-          <small id="successHelp" className="form-text valid-feedback">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleTrailingIconInputWhite">
-            Trailing icon text input label
-          </label>
-          <div className="input-group input-group-trailing-icon">
-            <input
-              type="text"
-              className="form-control"
-              id="exampleTrailingIconInputWhite"
-              placeholder="Helper text"
-            />
-            <span className="far fa-icon fa-calendar" aria-hidden="true"></span>
-          </div>
-        </div>
-      </form>
-    </div>
-
-    <div style={{ backgroundColor: "#fafafa" }}>
-      {/* This div for Storybook display only. */}
-      <form className="uds-form uds-form-faint-bg">
-        <div className="form-group">
-          <label for="exampleDefaultInputGray1">Default text input label</label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleDefaultInputGray1"
-            placeholder="Helper text"
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFocusInputGray1">Focus text input label</label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleFocusInputGray1"
-            placeholder="Helper text"
-            value="Focus me to see focus style"
-          />
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleDisabledInputGray1"
-            className="uds-form-label-disabled"
-          >
-            Disabled text input label
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleDisabledInputGray1"
-            placeholder="Helper text"
-            disabled
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleErrorInputGray1">Error text input label</label>
-          <input
-            type="text"
-            className="form-control is-invalid"
-            id="exampleErrorInputGray1"
-            aria-describedby="errorHelpGray1"
-            placeholder="Helper text"
-          />
-          <small id="errorHelpGray1" className="form-text invalid-feedback">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleSuccessInputGray1">Success text input label</label>
-          <input
-            type="text"
-            className="form-control is-valid"
-            id="exampleSuccessInputGray1"
-            aria-describedby="successHelpGray1"
-            placeholder="Helper text"
-            value="Input text"
-          />
-          <small id="successHelpGray1" className="form-text valid-feedback">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleTrailingIconInputGray1">
-            Trailing icon text input label
-          </label>
-          <div className="input-group input-group-trailing-icon">
-            <input
-              type="text"
-              className="form-control"
-              id="exampleTrailingIconInputGray1"
-              placeholder="Helper text"
-            />
-            <span className="far fa-icon fa-calendar" aria-hidden="true"></span>
-          </div>
-        </div>
-      </form>
-    </div>
-
-    <div style={{ backgroundColor: "#e8e8e8" }}>
-      {/* This div for Storybook display only. */}
-      <form className="uds-form uds-form-light-bg">
-        <div className="form-group">
-          <label for="exampleDefaultInputGray2">Default text input label</label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleDefaultInputGray2"
-            placeholder="Helper text"
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFocusInputGray2">Focus text input label</label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleFocusInputGray2"
-            placeholder="Helper text"
-            value="Focus me to see focus style"
-          />
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleDisabledInputGray2"
-            className="uds-form-label-disabled"
-          >
-            Disabled text input label
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleDisabledInputGray2"
-            placeholder="Helper text"
-            disabled
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleErrorInputGray2">Error text input label</label>
-          <input
-            type="text"
-            className="form-control is-invalid"
-            id="exampleErrorInputGray2"
-            aria-describedby="errorHelpGray2"
-            placeholder="Helper text"
-          />
-          <small id="errorHelpGray2" className="form-text invalid-feedback">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleSuccessInputGray2">Success text input label</label>
-          <input
-            type="text"
-            className="form-control is-valid"
-            id="exampleSuccessInputGray2"
-            aria-describedby="successHelpGray2"
-            placeholder="Helper text"
-            value="Input text"
-          />
-          <small id="successHelpGray2" className="form-text valid-feedback">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleTrailingIconInputGray2">
-            Trailing icon text input label
-          </label>
-          <div className="input-group input-group-trailing-icon">
-            <input
-              type="text"
-              className="form-control"
-              id="exampleTrailingIconInputGray2"
-              placeholder="Helper text"
-            />
-            <span className="far fa-icon fa-calendar" aria-hidden="true"></span>
-          </div>
-        </div>
-      </form>
-    </div>
-
-    <div style={{ backgroundColor: "#191919" }}>
-      {/* This div for Storybook display only. */}
-      <form className="uds-form uds-form-dark-bg">
-        <div className="form-group">
-          <label for="exampleDefaultInputGray7">Default text input label</label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleDefaultInputGray7"
-            placeholder="Helper text"
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFocusInputGray7">Focus text input label</label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleFocusInputGray7"
-            placeholder="Helper text"
-            value="Focus me to see focus style"
-          />
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleDisabledInputGray7"
-            className="uds-form-label-disabled"
-          >
-            Disabled text input label
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="exampleDisabledInputGray7"
-            placeholder="Helper text"
-            disabled
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleErrorInputGray7">Error text input label</label>
-          <input
-            type="text"
-            className="form-control is-invalid"
-            id="exampleErrorInputGray7"
-            aria-describedby="errorHelpGray7"
-            placeholder="Helper text"
-          />
-          <small id="errorHelpGray7" className="form-text invalid-feedback">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleSuccessInputGray7">Success text input label</label>
-          <input
-            type="text"
-            className="form-control is-valid"
-            id="exampleSuccessInputGray7"
-            aria-describedby="successHelpGray7"
-            placeholder="Helper text"
-            value="Input text"
-          />
-          <small id="successHelpGray7" className="form-text valid-feedback">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleTrailingIconInputGray7">
-            Trailing icon text input label
-          </label>
-          <div className="input-group input-group-trailing-icon">
-            <input
-              type="text"
-              className="form-control"
-              id="exampleTrailingIconInputGray7"
-              placeholder="Helper text"
-            />
-            <span className="far fa-icon fa-calendar" aria-hidden="true"></span>
-          </div>
-        </div>
-      </form>
-    </div>
+      </div>
+    </form>
   </div>
 );
 
-export const Textareas = () => (
-  <form className="uds-form">
-    <div className="form-group">
-      <label for="exampleFormControlTextareaDefault">Default textarea</label>
-      <textarea
-        className="form-control"
-        id="exampleFormControlTextareaDefault"
-        rows="3"
-        placeholder="Enter your textarea content..."
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      ></textarea>
-    </div>
+export const Textareas = args => (
+  <div style={{ backgroundColor: backgroundColors[args.background] }}>
+    <form className={`uds-form ${args.background}`}>
+      <div className="form-group">
+        <label htmlFor="exampleFormControlTextareaDefault">
+          Default textarea
+        </label>
+        <textarea
+          className="form-control"
+          id="exampleFormControlTextareaDefault"
+          rows="3"
+          placeholder="Enter your textarea content..."
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        ></textarea>
+      </div>
 
-    <div className="form-group">
-      <label for="exampleFormControlTextareaFocus">Focus textarea</label>
-      <textarea
-        className="form-control"
-        id="exampleFormControlTextareaFocus"
-        rows="3"
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      >
-        Focus here to see the focus state.
-      </textarea>
-    </div>
+      <div className="form-group">
+        <label htmlFor="exampleFormControlTextareaFocus">Focus textarea</label>
+        <textarea
+          className="form-control"
+          id="exampleFormControlTextareaFocus"
+          rows="3"
+          defaultValue="Focus here to see the focus state."
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        ></textarea>
+      </div>
 
-    <div className="form-group">
-      <label
-        for="exampleFormControlTextareaDisabled"
-        className="uds-form-label-disabled"
-      >
-        Disabled textarea
-      </label>
-      <textarea
-        className="form-control"
-        id="exampleFormControlTextareaDisabled"
-        rows="3"
-        placeholder="I got some content."
-        disabled
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      ></textarea>
-    </div>
+      <div className="form-group">
+        <label
+          htmlFor="exampleFormControlTextareaDisabled"
+          className="uds-form-label-disabled"
+        >
+          Disabled textarea
+        </label>
+        <textarea
+          className="form-control"
+          id="exampleFormControlTextareaDisabled"
+          rows="3"
+          placeholder="I got some content."
+          disabled
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        ></textarea>
+      </div>
 
-    <div className="form-group">
-      <label for="exampleFormControlTextareaError">Error textarea</label>
-      <textarea
-        className="form-control is-invalid"
-        aria-describedby="errorTextareaHelp"
-        id="exampleFormControlTextareaError"
-        rows="3"
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      ></textarea>
-      <small id="errorTextareaHelp" className="form-textarea invalid-feedback">
-        <span
-          title="Alert"
-          className="fa fa-icon fa-exclamation-triangle"
-        ></span>
-        Form error message
-      </small>
-    </div>
+      <div className="form-group">
+        <label htmlFor="exampleFormControlTextareaError">Error textarea</label>
+        <textarea
+          className="form-control is-invalid"
+          aria-describedby="errorTextareaHelp"
+          id="exampleFormControlTextareaError"
+          rows="3"
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        ></textarea>
+        <small
+          id="errorTextareaHelp"
+          className="form-textarea invalid-feedback"
+        >
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
+      </div>
 
-    <div className="form-group">
-      <label for="exampleFormControlTextareaSuccess">Success textarea</label>
-      <textarea
-        className="form-control is-valid"
-        aria-describedby="successTextareaHelp"
-        id="exampleFormControlTextareaSuccess"
-        rows="3"
-        data-ga-input="blur"
-        data-ga-input-name="onclick"
-        data-ga-input-event="form"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="text label"
-      >
-        Agreeable content was entered.
-      </textarea>
-      <small id="successTextareaHelp" className="form-textarea valid-feedback">
-        <span title="Success" className="fa fa-icon fa-check-circle"></span>
-        Success message
-      </small>
-    </div>
-  </form>
-);
-
-export const TextareasMultipleBackgrounds = () => (
-  <div>
-    <div style={{ backgroundColor: "white" }}>
-      {/* This div for Storybook display only. */}
-      <form className="uds-form uds-form-white">
-        <div className="form-group">
-          <label for="exampleFormControlTextareaDefaultWhite">
-            Default textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDefaultWhite"
-            rows="3"
-            placeholder="Enter your textarea content..."
-          ></textarea>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaFocusWhite">
-            Focus textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaFocusWhite"
-            rows="3"
-          >
-            Focus here to see the focus state.
-          </textarea>
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleFormControlTextareaDisabledWhite"
-            className="uds-form-label-disabled"
-          >
-            Disabled textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDisabledWhite"
-            rows="3"
-            placeholder="I got some content."
-            disabled
-          ></textarea>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaErrorWhite">
-            Error textarea
-          </label>
-          <textarea
-            className="form-control is-invalid"
-            aria-describedby="errorTextareaHelpWhite"
-            id="exampleFormControlTextareaErrorWhite"
-            rows="3"
-          ></textarea>
-          <small
-            id="errorTextareaHelpWhite"
-            className="form-textarea invalid-feedback"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaSuccessWhite">
-            Success textarea
-          </label>
-          <textarea
-            className="form-control is-valid"
-            aria-describedby="successTextareaHelpWhite"
-            id="exampleFormControlTextareaSuccessWhite"
-            rows="3"
-          >
-            Agreeable content was entered.
-          </textarea>
-          <small
-            id="successTextareaHelpWhite"
-            className="form-textarea valid-feedback"
-          >
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-      </form>
-    </div>
-
-    <div style={{ backgroundColor: "#fafafa" }}>
-      {/* This div for Storybook display only. */}
-      <form className="uds-form uds-form-faint-bg">
-        <div className="form-group">
-          <label for="exampleFormControlTextareaDefaultGray1">
-            Default textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDefaultGray1"
-            rows="3"
-            placeholder="Enter your textarea content..."
-          ></textarea>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaFocusGray1">
-            Focus textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaFocusGray1"
-            rows="3"
-          >
-            Focus here to see the focus state.
-          </textarea>
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleFormControlTextareaDisabledGray1"
-            className="uds-form-label-disabled"
-          >
-            Disabled textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDisabledGray1"
-            rows="3"
-            placeholder="I got some content."
-            disabled
-          ></textarea>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaErrorGray1">
-            Error textarea
-          </label>
-          <textarea
-            className="form-control is-invalid"
-            aria-describedby="errorTextareaHelpGray1"
-            id="exampleFormControlTextareaErrorGray1"
-            rows="3"
-          ></textarea>
-          <small
-            id="errorTextareaHelpGray1"
-            className="form-textarea invalid-feedback"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaSuccessGray1">
-            Success textarea
-          </label>
-          <textarea
-            className="form-control is-valid"
-            aria-describedby="successTextareaHelpGray1"
-            id="exampleFormControlTextareaSuccessGray1"
-            rows="3"
-          >
-            Agreeable content was entered.
-          </textarea>
-          <small
-            id="successTextareaHelpGray1"
-            className="form-textarea valid-feedback"
-          >
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-      </form>
-    </div>
-
-    <div style={{ backgroundColor: "#e8e8e8" }}>
-      {/* This div for Storybook display only. */}
-      <form className="uds-form uds-form-light-bg">
-        <div className="form-group">
-          <label for="exampleFormControlTextareaDefaultGray2">
-            Default textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDefaultGray2"
-            rows="3"
-            placeholder="Enter your textarea content..."
-          ></textarea>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaFocusGray2">
-            Focus textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaFocusGray2"
-            rows="3"
-          >
-            Focus here to see the focus state.
-          </textarea>
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleFormControlTextareaDisabledGray2"
-            className="uds-form-label-disabled"
-          >
-            Disabled textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDisabledGray2"
-            rows="3"
-            placeholder="I got some content."
-            disabled
-          ></textarea>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaErrorGray2">
-            Error textarea
-          </label>
-          <textarea
-            className="form-control is-invalid"
-            aria-describedby="errorTextareaHelpGray2"
-            id="exampleFormControlTextareaErrorGray2"
-            rows="3"
-          ></textarea>
-          <small
-            id="errorTextareaHelpGray2"
-            className="form-textarea invalid-feedback"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaSuccessGray2">
-            Success textarea
-          </label>
-          <textarea
-            className="form-control is-valid"
-            aria-describedby="successTextareaHelpGray2"
-            id="exampleFormControlTextareaSuccessGray2"
-            rows="3"
-          >
-            Agreeable content was entered.
-          </textarea>
-          <small
-            id="successTextareaHelpGray2"
-            className="form-textarea valid-feedback"
-          >
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-      </form>
-    </div>
-
-    <div style={{ backgroundColor: "#191919" }}>
-      {/* This div for Storybook display only. */}
-      <form className="uds-form uds-form-dark-bg">
-        <div className="form-group">
-          <label for="exampleFormControlTextareaDefaultGray7">
-            Default textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDefaultGray7"
-            rows="3"
-            placeholder="Enter your textarea content..."
-          ></textarea>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaFocusGray7">
-            Focus textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaFocusGray7"
-            rows="3"
-          >
-            Focus here to see the focus state.
-          </textarea>
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleFormControlTextareaDisabledGray7"
-            className="uds-form-label-disabled"
-          >
-            Disabled textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDisabledGray7"
-            rows="3"
-            placeholder="I got some content."
-            disabled
-          ></textarea>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaErrorGray7">
-            Error textarea
-          </label>
-          <textarea
-            className="form-control is-invalid"
-            aria-describedby="errorTextareaHelpGray7"
-            id="exampleFormControlTextareaErrorGray7"
-            rows="3"
-          ></textarea>
-          <small
-            id="errorTextareaHelpGray7"
-            className="form-textarea invalid-feedback"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaSuccessGray7">
-            Success textarea
-          </label>
-          <textarea
-            className="form-control is-valid"
-            aria-describedby="successTextareaHelpGray7"
-            id="exampleFormControlTextareaSuccessGray7"
-            rows="3"
-          >
-            Agreeable content was entered.
-          </textarea>
-          <small
-            id="successTextareaHelpGray7"
-            className="form-textarea valid-feedback"
-          >
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-      </form>
-    </div>
+      <div className="form-group">
+        <label htmlFor="exampleFormControlTextareaSuccess">
+          Success textarea
+        </label>
+        <textarea
+          className="form-control is-valid"
+          aria-describedby="successTextareaHelp"
+          id="exampleFormControlTextareaSuccess"
+          rows="3"
+          defaultValue="Agreeable content was entered."
+          data-ga-input="blur"
+          data-ga-input-name="onclick"
+          data-ga-input-event="form"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="text label"
+        ></textarea>
+        <small
+          id="successTextareaHelp"
+          className="form-textarea valid-feedback"
+        >
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+      </div>
+    </form>
   </div>
 );
 
-export const Checkboxes = () => (
-  <form className="uds-form">
-    <div className="form-check">
-      <input
-        className="form-check-input"
-        type="checkbox"
-        id="loneCheckbox1"
-        value="option1"
-        data-ga-input="checkbox"
-        data-ga-input-name="onclick"
-        data-ga-input-event="select"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="I like checkboxes"
-      />
-      <label className="form-check-label" for="loneCheckbox1">
-        I like checkboxes
-      </label>
-    </div>
-
-    <div className="form-check">
-      <input
-        className="form-check-input"
-        type="checkbox"
-        id="loneCheckbox2"
-        value="option1"
-        data-ga-input="checkbox"
-        data-ga-input-name="onclick"
-        data-ga-input-event="select"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="Multi-line content Multi-line content Multi-line content..."
-      />
-      <label className="form-check-label" for="loneCheckbox2">
-        Multi-line content Multi-line content Multi-line content Multi-line
-        content Multi-line content Multi-line content Multi-line content
-        Multi-line content Multi-line content Multi-line content Multi-line
-        content Multi-line content Multi-line content Multi-line content
-        Multi-line content Multi-line content Multi-line content Multi-line
-        content Multi-line content Multi-line content Multi-line content
-        Multi-line content Multi-line content Multi-line content Multi-line
-        content Multi-line content Multi-line content Multi-line content
-        Multi-line content Multi-line content Multi-line content Multi-line
-        content Multi-line content Multi-line content Multi-line content
-        Multi-line content Multi-line content Multi-line content Multi-line
-        content Multi-line content Multi-line content Multi-line content
-        Multi-line content Multi-line content
-      </label>
-    </div>
-
-    <div className="form-check">
-      <input
-        className="form-check-input"
-        type="checkbox"
-        aria-describedby="myValidCheckMsg"
-        id="validLoneCheckbox"
-        value="option1"
-        checked
-        data-ga-input="checkbox"
-        data-ga-input-name="onclick"
-        data-ga-input-event="select"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="I accept"
-      />
-      <label className="form-check-label" for="validLoneCheckbox">
-        I accept
-      </label>
-      <small id="myValidCheckMsg" className="valid-feedback is-valid">
-        <span title="Success" className="fa fa-icon fa-check-circle"></span>
-        Success message
-      </small>
-    </div>
-
-    <div className="form-check">
-      <input
-        className="form-check-input"
-        type="checkbox"
-        aria-describedby="myInvalidCheckMsg"
-        id="invalidLoneCheckbox"
-        value="option1"
-        data-ga-input="checkbox"
-        data-ga-input-name="onclick"
-        data-ga-input-event="select"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-        data-ga-input-section="I also accept"
-      />
-      <label className="form-check-label" for="invalidLoneCheckbox">
-        I also accept
-      </label>
-      <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
-        <span
-          title="Alert"
-          className="fa fa-icon fa-exclamation-triangle"
-        ></span>
-        Form error message
-      </small>
-    </div>
-
-    <fieldset>
-      <legend>A Group of Checkboxes</legend>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="checkbox1"
-          value="option1"
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="1"
-        />
-        <label className="form-check-label" for="checkbox1">
-          1
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="checkbox2"
-          value="option2"
-          checked
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="2"
-        />
-        <label className="form-check-label" for="checkbox2">
-          2
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="checkbox3"
-          value="option3"
-          disabled
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="3"
-        />
-        <label className="form-check-label" for="checkbox3">
-          3 (disabled)
-        </label>
-      </div>
-    </fieldset>
-
-    <fieldset>
-      <legend>A Group of Valid Checkboxes</legend>
-      <small id="myValidCheckboxMsg" className="valid-feedback is-valid">
-        <span title="Success" className="fa fa-icon fa-check-circle"></span>
-        Success message
-      </small>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myValidCheckboxMsg"
-          id="validCheckbox1"
-          value="option1"
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="1"
-        />
-        <label className="form-check-label" for="validCheckbox1">
-          1
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myValidCheckboxMsg"
-          id="validCheckbox2"
-          value="option2"
-          checked
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="2"
-        />
-        <label className="form-check-label" for="validCheckbox2">
-          2
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myValidCheckboxMsg"
-          id="validCheckbox3"
-          value="option3"
-          disabled
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="3"
-        />
-        <label className="form-check-label" for="validCheckbox3">
-          3 (disabled)
-        </label>
-      </div>
-    </fieldset>
-
-    <fieldset>
-      <legend>A Group of Invalid Checkboxes</legend>
-      <small id="myInvalidCheckboxMsg" className="invalid-feedback is-invalid">
-        <span
-          title="Alert"
-          className="fa fa-icon fa-exclamation-triangle"
-        ></span>
-        Form error message
-      </small>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myInvalidCheckboxMsg"
-          id="invalidCheckbox1"
-          value="option1"
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="1"
-        />
-        <label className="form-check-label" for="invalidCheckbox1">
-          1
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myInvalidCheckboxMsg"
-          id="invalidCheckbox2"
-          value="option2"
-          checked
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="2"
-        />
-        <label className="form-check-label" for="invalidCheckbox2">
-          2
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myInvalidCheckboxMsg"
-          id="invalidCheckbox3"
-          value="option3"
-          disabled
-          data-ga-input="checkbox"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="3"
-        />
-        <label className="form-check-label" for="invalidCheckbox3">
-          3 (disabled)
-        </label>
-      </div>
-    </fieldset>
-  </form>
-);
-
-export const Radios = () => (
-  <form className="uds-form">
-    <fieldset>
-      <legend>A Group of Radios</legend>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="exampleRadios"
-          id="exampleRadios1"
-          value="option1"
-          checked
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Default radio"
-        />
-        <label className="form-check-label" for="exampleRadios1">
-          Default radio
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="exampleRadios"
-          id="exampleRadios2"
-          value="option2"
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Second default radio"
-        />
-        <label className="form-check-label" for="exampleRadios2">
-          Second default radio
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="exampleRadios"
-          id="exampleRadios3"
-          value="option3"
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Third default radio"
-        />
-        <label className="form-check-label" for="exampleRadios3">
-          Third default radio
-        </label>
-      </div>
-      <div className="form-check disabled">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="exampleRadios"
-          id="exampleRadios4"
-          value="option4"
-          disabled
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Disabled radio"
-        />
-        <label className="form-check-label" for="exampleRadios4">
-          Disabled radio
-        </label>
-      </div>
-    </fieldset>
-
-    <fieldset>
-      <legend>A Group of Invalid Radios</legend>
-      <small id="myInvalidRadiosMsg" className="invalid-feedback is-invalid">
-        <span
-          title="Alert"
-          className="fa fa-icon fa-exclamation-triangle"
-        ></span>
-        Form error message
-      </small>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="invalidRadios"
-          aria-describedby="myInvalidRadiosMsg"
-          id="invalidRadios1"
-          value="option1"
-          checked
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Default radio"
-        />
-        <label className="form-check-label" for="invalidRadios1">
-          Default radio
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="invalidRadios"
-          aria-describedby="myInvalidRadiosMsg"
-          id="invalidRadios2"
-          value="option2"
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Second default radio"
-        />
-        <label className="form-check-label" for="invalidRadios2">
-          Second default radio
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="invalidRadios"
-          aria-describedby="myInvalidRadiosMsg"
-          id="invalidRadios3"
-          value="option3"
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Third default radio"
-        />
-        <label className="form-check-label" for="invalidRadios3">
-          Third default radio
-        </label>
-      </div>
-      <div className="form-check disabled">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="invalidRadios"
-          aria-describedby="myInvalidRadiosMsg"
-          id="invalidRadios4"
-          value="option4"
-          disabled
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Disabled radio"
-        />
-        <label className="form-check-label" for="invalidRadios4">
-          Disabled radio
-        </label>
-      </div>
-    </fieldset>
-
-    <fieldset>
-      <legend>A Group of Valid Radios</legend>
-      <small id="myValidRadiosMsg" className="valid-feedback is-valid">
-        <span title="Success" className="fa fa-icon fa-check-circle"></span>
-        Success message
-      </small>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="validRadios"
-          aria-describedby="myValidRadiosMsg"
-          id="validRadios1"
-          value="option1"
-          checked
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Default radio"
-        />
-        <label className="form-check-label" for="validRadios1">
-          Default radio
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="validRadios"
-          aria-describedby="myValidRadiosMsg"
-          id="validRadios2"
-          value="option2"
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Second default radio"
-        />
-        <label className="form-check-label" for="validRadios2">
-          Second default radio
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="validRadios"
-          aria-describedby="myValidRadiosMsg"
-          id="validRadios3"
-          value="option3"
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Third default radio"
-        />
-        <label className="form-check-label" for="validRadios3">
-          Third default radio
-        </label>
-      </div>
-      <div className="form-check disabled">
-        <input
-          className="form-check-input"
-          type="radio"
-          name="validRadios"
-          aria-describedby="myValidRadiosMsg"
-          id="validRadios4"
-          value="option4"
-          disabled
-          data-ga-input="radio button"
-          data-ga-input-name="onclick"
-          data-ga-input-event="select"
-          data-ga-input-action="click"
-          data-ga-input-region="main content"
-          data-ga-input-section="Disabled radio"
-        />
-        <label className="form-check-label" for="validRadios4">
-          Disabled radio
-        </label>
-      </div>
-    </fieldset>
-  </form>
-);
-
-export const CheckboxesAndRadiosWhiteBackground = () => (
-  <div style={{ backgroundColor: "white" }}>
-    {/* This div for Storybook display only. */}
-    <form className="uds-form uds-form-white">
+export const Checkboxes = args => (
+  <div style={{ backgroundColor: backgroundColors[args.background] }}>
+    <form className={`uds-form ${args.background}`}>
       <div className="form-check">
         <input
           className="form-check-input"
           type="checkbox"
           id="loneCheckbox1"
           value="option1"
+          data-ga-input="checkbox"
+          data-ga-input-name="onclick"
+          data-ga-input-event="select"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="I like checkboxes"
         />
-        <label className="form-check-label" for="loneCheckbox1">
+        <label className="form-check-label" htmlFor="loneCheckbox1">
           I like checkboxes
+        </label>
+      </div>
+
+      <div className="form-check">
+        <input
+          className="form-check-input"
+          type="checkbox"
+          id="loneCheckbox2"
+          value="option1"
+          data-ga-input="checkbox"
+          data-ga-input-name="onclick"
+          data-ga-input-event="select"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="Multi-line content..."
+        />
+        <label className="form-check-label" htmlFor="loneCheckbox2">
+          Multi-line content Multi-line content Multi-line content Multi-line
+          content Multi-line content Multi-line content Multi-line content
+          Multi-line content Multi-line content Multi-line content Multi-line
+          content Multi-line content Multi-line content Multi-line content
+          Multi-line content Multi-line content
         </label>
       </div>
 
@@ -1555,9 +341,15 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
           aria-describedby="myValidCheckMsg"
           id="validLoneCheckbox"
           value="option1"
-          checked
+          defaultChecked
+          data-ga-input="checkbox"
+          data-ga-input-name="onclick"
+          data-ga-input-event="select"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="I accept"
         />
-        <label className="form-check-label" for="validLoneCheckbox">
+        <label className="form-check-label" htmlFor="validLoneCheckbox">
           I accept
         </label>
         <small id="myValidCheckMsg" className="valid-feedback is-valid">
@@ -1573,8 +365,14 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
           aria-describedby="myInvalidCheckMsg"
           id="invalidLoneCheckbox"
           value="option1"
+          data-ga-input="checkbox"
+          data-ga-input-name="onclick"
+          data-ga-input-event="select"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+          data-ga-input-section="I also accept"
         />
-        <label className="form-check-label" for="invalidLoneCheckbox">
+        <label className="form-check-label" htmlFor="invalidLoneCheckbox">
           I also accept
         </label>
         <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
@@ -1595,7 +393,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             id="checkbox1"
             value="option1"
           />
-          <label className="form-check-label" for="checkbox1">
+          <label className="form-check-label" htmlFor="checkbox1">
             1
           </label>
         </div>
@@ -1605,9 +403,9 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             type="checkbox"
             id="checkbox2"
             value="option2"
-            checked
+            defaultChecked
           />
-          <label className="form-check-label" for="checkbox2">
+          <label className="form-check-label" htmlFor="checkbox2">
             2
           </label>
         </div>
@@ -1619,7 +417,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             value="option3"
             disabled
           />
-          <label className="form-check-label" for="checkbox3">
+          <label className="form-check-label" htmlFor="checkbox3">
             3 (disabled)
           </label>
         </div>
@@ -1639,7 +437,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             id="validCheckbox1"
             value="option1"
           />
-          <label className="form-check-label" for="validCheckbox1">
+          <label className="form-check-label" htmlFor="validCheckbox1">
             1
           </label>
         </div>
@@ -1650,9 +448,9 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             aria-describedby="myValidCheckboxMsg"
             id="validCheckbox2"
             value="option2"
-            checked
+            defaultChecked
           />
-          <label className="form-check-label" for="validCheckbox2">
+          <label className="form-check-label" htmlFor="validCheckbox2">
             2
           </label>
         </div>
@@ -1665,7 +463,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             value="option3"
             disabled
           />
-          <label className="form-check-label" for="validCheckbox3">
+          <label className="form-check-label" htmlFor="validCheckbox3">
             3 (disabled)
           </label>
         </div>
@@ -1691,7 +489,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             id="invalidCheckbox1"
             value="option1"
           />
-          <label className="form-check-label" for="invalidCheckbox1">
+          <label className="form-check-label" htmlFor="invalidCheckbox1">
             1
           </label>
         </div>
@@ -1702,9 +500,9 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             aria-describedby="myInvalidCheckboxMsg"
             id="invalidCheckbox2"
             value="option2"
-            checked
+            defaultChecked
           />
-          <label className="form-check-label" for="invalidCheckbox2">
+          <label className="form-check-label" htmlFor="invalidCheckbox2">
             2
           </label>
         </div>
@@ -1717,12 +515,18 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             value="option3"
             disabled
           />
-          <label className="form-check-label" for="invalidCheckbox3">
+          <label className="form-check-label" htmlFor="invalidCheckbox3">
             3 (disabled)
           </label>
         </div>
       </fieldset>
+    </form>
+  </div>
+);
 
+export const Radios = args => (
+  <div style={{ backgroundColor: backgroundColors[args.background] }}>
+    <form className={`uds-form ${args.background}`}>
       <fieldset>
         <legend>A Group of Radios</legend>
         <div className="form-check">
@@ -1732,9 +536,15 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             name="exampleRadios"
             id="exampleRadios1"
             value="option1"
-            checked
+            defaultChecked
+            data-ga-input="radio button"
+            data-ga-input-name="onclick"
+            data-ga-input-event="select"
+            data-ga-input-action="click"
+            data-ga-input-region="main content"
+            data-ga-input-section="Default radio"
           />
-          <label className="form-check-label" for="exampleRadios1">
+          <label className="form-check-label" htmlFor="exampleRadios1">
             Default radio
           </label>
         </div>
@@ -1745,8 +555,14 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             name="exampleRadios"
             id="exampleRadios2"
             value="option2"
+            data-ga-input="radio button"
+            data-ga-input-name="onclick"
+            data-ga-input-event="select"
+            data-ga-input-action="click"
+            data-ga-input-region="main content"
+            data-ga-input-section="Second default radio"
           />
-          <label className="form-check-label" for="exampleRadios2">
+          <label className="form-check-label" htmlFor="exampleRadios2">
             Second default radio
           </label>
         </div>
@@ -1757,8 +573,14 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             name="exampleRadios"
             id="exampleRadios3"
             value="option3"
+            data-ga-input="radio button"
+            data-ga-input-name="onclick"
+            data-ga-input-event="select"
+            data-ga-input-action="click"
+            data-ga-input-region="main content"
+            data-ga-input-section="Third default radio"
           />
-          <label className="form-check-label" for="exampleRadios3">
+          <label className="form-check-label" htmlFor="exampleRadios3">
             Third default radio
           </label>
         </div>
@@ -1770,8 +592,14 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             id="exampleRadios4"
             value="option4"
             disabled
+            data-ga-input="radio button"
+            data-ga-input-name="onclick"
+            data-ga-input-event="select"
+            data-ga-input-action="click"
+            data-ga-input-region="main content"
+            data-ga-input-section="Disabled radio"
           />
-          <label className="form-check-label" for="exampleRadios4">
+          <label className="form-check-label" htmlFor="exampleRadios4">
             Disabled radio
           </label>
         </div>
@@ -1794,9 +622,9 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             aria-describedby="myInvalidRadiosMsg"
             id="invalidRadios1"
             value="option1"
-            checked
+            defaultChecked
           />
-          <label className="form-check-label" for="invalidRadios1">
+          <label className="form-check-label" htmlFor="invalidRadios1">
             Default radio
           </label>
         </div>
@@ -1809,7 +637,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             id="invalidRadios2"
             value="option2"
           />
-          <label className="form-check-label" for="invalidRadios2">
+          <label className="form-check-label" htmlFor="invalidRadios2">
             Second default radio
           </label>
         </div>
@@ -1822,7 +650,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             id="invalidRadios3"
             value="option3"
           />
-          <label className="form-check-label" for="invalidRadios3">
+          <label className="form-check-label" htmlFor="invalidRadios3">
             Third default radio
           </label>
         </div>
@@ -1836,7 +664,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             value="option4"
             disabled
           />
-          <label className="form-check-label" for="invalidRadios4">
+          <label className="form-check-label" htmlFor="invalidRadios4">
             Disabled radio
           </label>
         </div>
@@ -1856,9 +684,9 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             aria-describedby="myValidRadiosMsg"
             id="validRadios1"
             value="option1"
-            checked
+            defaultChecked
           />
-          <label className="form-check-label" for="validRadios1">
+          <label className="form-check-label" htmlFor="validRadios1">
             Default radio
           </label>
         </div>
@@ -1871,7 +699,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             id="validRadios2"
             value="option2"
           />
-          <label className="form-check-label" for="validRadios2">
+          <label className="form-check-label" htmlFor="validRadios2">
             Second default radio
           </label>
         </div>
@@ -1884,7 +712,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             id="validRadios3"
             value="option3"
           />
-          <label className="form-check-label" for="validRadios3">
+          <label className="form-check-label" htmlFor="validRadios3">
             Third default radio
           </label>
         </div>
@@ -1898,7 +726,7 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
             value="option4"
             disabled
           />
-          <label className="form-check-label" for="validRadios4">
+          <label className="form-check-label" htmlFor="validRadios4">
             Disabled radio
           </label>
         </div>
@@ -1907,1293 +735,526 @@ export const CheckboxesAndRadiosWhiteBackground = () => (
   </div>
 );
 
-export const CheckboxesAndRadiosGray1Background = () => (
-  <div style={{ backgroundColor: "#fafafa" }}>
-    {/* This div for Storybook display only. */}
-    <form className="uds-form uds-form-faint-bg">
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="loneCheckbox1"
-          value="option1"
-        />
-        <label className="form-check-label" for="loneCheckbox1">
-          I like checkboxes
-        </label>
-      </div>
-
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myValidCheckMsg"
-          id="validLoneCheckbox"
-          value="option1"
-          checked
-        />
-        <label className="form-check-label" for="validLoneCheckbox">
-          I accept
-        </label>
-        <small id="myValidCheckMsg" className="valid-feedback is-valid">
-          <span title="Success" className="fa fa-icon fa-check-circle"></span>
-          Success message
-        </small>
-      </div>
-
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myInvalidCheckMsg"
-          id="invalidLoneCheckbox"
-          value="option1"
-        />
-        <label className="form-check-label" for="invalidLoneCheckbox">
-          I also accept
-        </label>
-        <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
-          <span
-            title="Alert"
-            className="fa fa-icon fa-exclamation-triangle"
-          ></span>
-          Form error message
-        </small>
-      </div>
-
-      <fieldset>
-        <legend>A Group of Checkboxes</legend>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="checkbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="checkbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="checkbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Valid Checkboxes</legend>
-        <small id="myValidCheckboxMsg" className="valid-feedback is-valid">
-          <span title="Success" className="fa fa-icon fa-check-circle"></span>
-          Success message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="validCheckbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="validCheckbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="validCheckbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Invalid Checkboxes</legend>
-        <small
-          id="myInvalidCheckboxMsg"
-          className="invalid-feedback is-invalid"
+export const Selects = args => (
+  <div style={{ backgroundColor: backgroundColors[args.background] }}>
+    <form className={`uds-form ${args.background}`}>
+      <div className="form-group">
+        <label htmlFor="exampleFormControlSelect1">Example select</label>
+        <select
+          className="form-select"
+          id="exampleFormControlSelect1"
+          data-ga-input="select"
+          data-ga-input-name="onclick"
+          data-ga-input-event="select"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
         >
-          <span
-            title="Alert"
-            className="fa fa-icon fa-exclamation-triangle"
-          ></span>
-          Form error message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="invalidCheckbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="invalidCheckbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="invalidCheckbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Radios</legend>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="exampleRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="exampleRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="exampleRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="exampleRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Invalid Radios</legend>
-        <small id="myInvalidRadiosMsg" className="invalid-feedback is-invalid">
-          <span
-            title="Alert"
-            className="fa fa-icon fa-exclamation-triangle"
-          ></span>
-          Form error message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="invalidRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="invalidRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="invalidRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="invalidRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Valid Radios</legend>
-        <small id="myValidRadiosMsg" className="valid-feedback is-valid">
-          <span title="Success" className="fa fa-icon fa-check-circle"></span>
-          Success message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="validRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="validRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="validRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="validRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
-    </form>
-  </div>
-);
-
-export const CheckboxesAndRadiosGray2Background = () => (
-  <div style={{ backgroundColor: "#e8e8e8" }}>
-    {/* This div for Storybook display only. */}
-    <form className="uds-form uds-form-light-bg">
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="loneCheckbox1"
-          value="option1"
-        />
-        <label className="form-check-label" for="loneCheckbox1">
-          I like checkboxes
-        </label>
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
       </div>
 
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myValidCheckMsg"
-          id="validLoneCheckbox"
-          value="option1"
-          checked
-        />
-        <label className="form-check-label" for="validLoneCheckbox">
-          I accept
+      <div className="form-group">
+        <label htmlFor="exampleFormControlSelect3">
+          Example select with server-side validation
         </label>
-        <small id="myValidCheckMsg" className="valid-feedback is-valid">
-          <span title="Success" className="fa fa-icon fa-check-circle"></span>
-          Success message
-        </small>
-      </div>
-
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myInvalidCheckMsg"
-          id="invalidLoneCheckbox"
-          value="option1"
-        />
-        <label className="form-check-label" for="invalidLoneCheckbox">
-          I also accept
-        </label>
-        <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
-          <span
-            title="Alert"
-            className="fa fa-icon fa-exclamation-triangle"
-          ></span>
-          Form error message
-        </small>
-      </div>
-
-      <fieldset>
-        <legend>A Group of Checkboxes</legend>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="checkbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="checkbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="checkbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Valid Checkboxes</legend>
-        <small id="myValidCheckboxMsg" className="valid-feedback is-valid">
-          <span title="Success" className="fa fa-icon fa-check-circle"></span>
-          Success message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="validCheckbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="validCheckbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="validCheckbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Invalid Checkboxes</legend>
-        <small
-          id="myInvalidCheckboxMsg"
-          className="invalid-feedback is-invalid"
+        <select
+          className="form-select is-valid"
+          id="exampleFormControlSelect3"
+          aria-describedby="myValidSelectMsg"
+          data-ga-input="select"
+          data-ga-input-name="onclick"
+          data-ga-input-event="select"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
         >
-          <span
-            title="Alert"
-            className="fa fa-icon fa-exclamation-triangle"
-          ></span>
-          Form error message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="invalidCheckbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="invalidCheckbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="invalidCheckbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Radios</legend>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="exampleRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="exampleRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="exampleRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="exampleRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Invalid Radios</legend>
-        <small id="myInvalidRadiosMsg" className="invalid-feedback is-invalid">
-          <span
-            title="Alert"
-            className="fa fa-icon fa-exclamation-triangle"
-          ></span>
-          Form error message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="invalidRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="invalidRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="invalidRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="invalidRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Valid Radios</legend>
-        <small id="myValidRadiosMsg" className="valid-feedback is-valid">
-          <span title="Success" className="fa fa-icon fa-check-circle"></span>
-          Success message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="validRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="validRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="validRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="validRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
-    </form>
-  </div>
-);
-
-export const CheckboxesAndRadiosGray7Background = () => (
-  <div style={{ backgroundColor: "#191919" }}>
-    {/* This div for Storybook display only. */}
-    <form className="uds-form uds-form-dark-bg">
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="loneCheckbox1"
-          value="option1"
-        />
-        <label className="form-check-label" for="loneCheckbox1">
-          I like checkboxes
-        </label>
-      </div>
-
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myValidCheckMsg"
-          id="validLoneCheckbox"
-          value="option1"
-          checked
-        />
-        <label className="form-check-label" for="validLoneCheckbox">
-          I accept
-        </label>
-        <small id="myValidCheckMsg" className="valid-feedback is-valid">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+        <small id="myValidSelectMsg" className="valid-feedback is-valid">
           <span title="Success" className="fa fa-icon fa-check-circle"></span>
           Success message
         </small>
       </div>
 
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          aria-describedby="myInvalidCheckMsg"
-          id="invalidLoneCheckbox"
-          value="option1"
-        />
-        <label className="form-check-label" for="invalidLoneCheckbox">
-          I also accept
-        </label>
-        <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
+      <div className="alert alert-info" role="alert">
+        <div className="alert-icon">
           <span
-            title="Alert"
-            className="fa fa-icon fa-exclamation-triangle"
+            title="Information"
+            className="fa fa-icon fa-info-circle"
           ></span>
-          Form error message
-        </small>
+        </div>
+        <div className="alert-content">
+          Wherever possible, use checkboxes instead of multi-selects because of
+          the difficulty they present to people using assistive technologies and
+          keyboard only. For a deep dive into the issues with multi-selects as
+          well as recommendations, see{" "}
+          <a href="https://www.24a11y.com/2019/select-your-poison/">
+            https://www.24a11y.com/2019/select-your-poison/
+          </a>
+          .
+        </div>
+        <div className="alert-close">
+          <button
+            type="button"
+            className="btn btn-circle btn-circle-alt-white close"
+            aria-label="Close"
+          >
+            <i className="fa fa-times"></i>
+          </button>
+        </div>
       </div>
 
-      <fieldset>
-        <legend>A Group of Checkboxes</legend>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="checkbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="checkbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            id="checkbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="checkbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Valid Checkboxes</legend>
-        <small id="myValidCheckboxMsg" className="valid-feedback is-valid">
-          <span title="Success" className="fa fa-icon fa-check-circle"></span>
-          Success message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="validCheckbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="validCheckbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckboxMsg"
-            id="validCheckbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="validCheckbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Invalid Checkboxes</legend>
-        <small
-          id="myInvalidCheckboxMsg"
-          className="invalid-feedback is-invalid"
+      <div className="form-group">
+        <label htmlFor="exampleFormControlSelect2">
+          Example multiple select
+        </label>
+        <select
+          multiple
+          className="form-select"
+          id="exampleFormControlSelect2"
+          data-ga-input="select"
+          data-ga-input-name="onclick"
+          data-ga-input-event="select"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
         >
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="exampleFormControlSelect4">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          Example multiple select - required with server-side invalidation
+        </label>
+        <select
+          multiple
+          className="form-select is-invalid"
+          id="exampleFormControlSelect4"
+          aria-describedby="myInvalidSelectMsg"
+          aria-required="true"
+          required
+          data-ga-input="select"
+          data-ga-input-name="onclick"
+          data-ga-input-event="select"
+          data-ga-input-action="click"
+          data-ga-input-region="main content"
+        >
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+        <small id="myInvalidSelectMsg" className="invalid-feedback is-invalid">
           <span
             title="Alert"
             className="fa fa-icon fa-exclamation-triangle"
           ></span>
           Form error message
         </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox1"
-            value="option1"
-          />
-          <label className="form-check-label" for="invalidCheckbox1">
-            1
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox2"
-            value="option2"
-            checked
-          />
-          <label className="form-check-label" for="invalidCheckbox2">
-            2
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckboxMsg"
-            id="invalidCheckbox3"
-            value="option3"
-            disabled
-          />
-          <label className="form-check-label" for="invalidCheckbox3">
-            3 (disabled)
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Radios</legend>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="exampleRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="exampleRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="exampleRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="exampleRadios"
-            id="exampleRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="exampleRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Invalid Radios</legend>
-        <small id="myInvalidRadiosMsg" className="invalid-feedback is-invalid">
-          <span
-            title="Alert"
-            className="fa fa-icon fa-exclamation-triangle"
-          ></span>
-          Form error message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="invalidRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="invalidRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="invalidRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="invalidRadios"
-            aria-describedby="myInvalidRadiosMsg"
-            id="invalidRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="invalidRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset>
-        <legend>A Group of Valid Radios</legend>
-        <small id="myValidRadiosMsg" className="valid-feedback is-valid">
-          <span title="Success" className="fa fa-icon fa-check-circle"></span>
-          Success message
-        </small>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios1"
-            value="option1"
-            checked
-          />
-          <label className="form-check-label" for="validRadios1">
-            Default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios2"
-            value="option2"
-          />
-          <label className="form-check-label" for="validRadios2">
-            Second default radio
-          </label>
-        </div>
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios3"
-            value="option3"
-          />
-          <label className="form-check-label" for="validRadios3">
-            Third default radio
-          </label>
-        </div>
-        <div className="form-check disabled">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="validRadios"
-            aria-describedby="myValidRadiosMsg"
-            id="validRadios4"
-            value="option4"
-            disabled
-          />
-          <label className="form-check-label" for="validRadios4">
-            Disabled radio
-          </label>
-        </div>
-      </fieldset>
+      </div>
     </form>
   </div>
 );
 
-export const Selects = () => (
-  <form className="uds-form">
-    <div className="form-group">
-      <label for="exampleFormControlSelect1">Example select</label>
-      <select
-        className="form-select"
-        id="exampleFormControlSelect1"
-        data-ga-input="select"
-        data-ga-input-name="onclick"
-        data-ga-input-event="select"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-      >
-        <option>1</option>
-        <option>2</option>
-        <option>3</option>
-        <option>4</option>
-        <option>5</option>
-      </select>
-    </div>
+export const KitchenSinkForm = args => {
+  const handleSubmit = event => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.target.classList.add("was-validated");
+  };
 
-    <div className="form-group">
-      <label for="exampleFormControlSelect3">
-        Example select with server-side validation
-      </label>
-      <select
-        className="form-select is-valid"
-        id="exampleFormControlSelect3"
-        aria-describedby="myValidSelectMsg"
-        data-ga-input="select"
-        data-ga-input-name="onclick"
-        data-ga-input-event="select"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-      >
-        <option>1</option>
-        <option>2</option>
-        <option>3</option>
-        <option>4</option>
-        <option>5</option>
-      </select>
-      <small id="myValidSelectMsg" className="valid-feedback is-valid">
-        <span title="Success" className="fa fa-icon fa-check-circle"></span>
-        Success message
-      </small>
-    </div>
-
-    <div className="alert alert-info" role="alert">
-      <div className="alert-icon">
-        <span title="Information" className="fa fa-icon fa-info-circle"></span>
-      </div>
-      <div className="alert-content">
-        Wherever possible, use checkboxes instead of multi-selects because of
-        the difficulty they present to people using assistive technologies and
-        keyboard only. For a deep dive into the issues with multi-selects as
-        well as recommendations, see{" "}
-        <a href="https://www.24a11y.com/2019/select-your-poison/">
-          https://www.24a11y.com/2019/select-your-poison/
+  return (
+    <div style={{ backgroundColor: backgroundColors[args.background] }}>
+      <p>
+        <a href="https://getbootstrap.com/docs/5.0/forms/overview/">
+          Bootstrap 5 form docs
         </a>
-        .
-      </div>
-      <div className="alert-close">
-        <button
-          type="button"
-          className="btn btn-circle btn-circle-alt-white close"
-          aria-label="Close"
-          onclick="event.target.parentNode.parentNode.style.display='none';"
-        >
-          <i className="fa fa-times"></i>
-        </button>
-      </div>
-    </div>
+      </p>
+      <p>
+        Click <strong>Submit</strong> to trigger native browser validation. The
+        form adds the <code>was-validated</code> class on submit, which
+        activates Bootstrap&apos;s <code>:valid</code> / <code>:invalid</code>{" "}
+        pseudo-class styling on all fields.
+      </p>
 
-    <div className="form-group">
-      <label for="exampleFormControlSelect2">Example multiple select</label>
-      <select
-        multiple
-        className="form-select"
-        id="exampleFormControlSelect2"
-        data-ga-input="select"
-        data-ga-input-name="onclick"
-        data-ga-input-event="select"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
+      <form
+        className={`uds-form needs-validation ${args.background}`}
+        noValidate
+        onSubmit={handleSubmit}
       >
-        <option>1</option>
-        <option>2</option>
-        <option>3</option>
-        <option>4</option>
-        <option>5</option>
-      </select>
-    </div>
+        <div className="form-group">
+          <label htmlFor="ksTextInput">
+            <span
+              title="Required"
+              className="fa fa-icon fa-circle uds-field-required"
+            ></span>
+            Text input (required)
+          </label>
+          <input
+            type="text"
+            className="form-control"
+            id="ksTextInput"
+            placeholder="Enter some text"
+            aria-describedby="ksTextInputFeedback"
+            aria-required="true"
+            required
+          />
+          <small
+            id="ksTextInputFeedback"
+            className="form-text invalid-feedback"
+          >
+            <span
+              title="Alert"
+              className="fa fa-icon fa-exclamation-triangle"
+            ></span>
+            This field is required.
+          </small>
+        </div>
 
-    <div className="form-group">
-      <label for="exampleFormControlSelect4">
-        <span
-          title="Required"
-          className="fa fa-icon fa-circle uds-field-required"
-        ></span>
-        Example multiple select - required with server-side invalidation
-      </label>
-      <select
-        multiple
-        className="form-select is-invalid"
-        id="exampleFormControlSelect4"
-        aria-describedby="myInvalidSelectMsg"
-        aria-required="true"
-        required
-        data-ga-input="select"
-        data-ga-input-name="onclick"
-        data-ga-input-event="select"
-        data-ga-input-action="click"
-        data-ga-input-region="main content"
-      >
-        <option>1</option>
-        <option>2</option>
-        <option>3</option>
-        <option>4</option>
-        <option>5</option>
-      </select>
-      <small id="myInvalidSelectMsg" className="invalid-feedback is-invalid">
-        <span
-          title="Alert"
-          className="fa fa-icon fa-exclamation-triangle"
-        ></span>
-        Form error message
-      </small>
-    </div>
-  </form>
-);
+        <div className="form-group">
+          <label htmlFor="ksEmailInput">
+            <span
+              title="Required"
+              className="fa fa-icon fa-circle uds-field-required"
+            ></span>
+            Email input (required)
+          </label>
+          <input
+            type="email"
+            className="form-control"
+            id="ksEmailInput"
+            placeholder="name@example.com"
+            aria-describedby="ksEmailFeedback"
+            aria-required="true"
+            required
+          />
+          <small id="ksEmailFeedback" className="form-text invalid-feedback">
+            <span
+              title="Alert"
+              className="fa fa-icon fa-exclamation-triangle"
+            ></span>
+            Please enter a valid email address.
+          </small>
+        </div>
 
-export const KitchenSinkForm = () => (
-  <div>
+        <div className="form-group">
+          <label htmlFor="ksLgInput">Large input (optional)</label>
+          <input
+            type="text"
+            className="form-control form-control-lg"
+            id="ksLgInput"
+            placeholder="Optional large input"
+            aria-describedby="ksLgInputFeedback"
+          />
+          <small id="ksLgInputFeedback" className="form-text valid-feedback">
+            <span title="Success" className="fa fa-icon fa-check-circle"></span>
+            Looks good!
+          </small>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="ksSmInput" className="uds-form-label-disabled">
+            Small input (disabled)
+          </label>
+          <input
+            type="text"
+            className="form-control form-control-sm"
+            id="ksSmInput"
+            placeholder="Disabled field"
+            disabled
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="ksTextarea">
+            <span
+              title="Required"
+              className="fa fa-icon fa-circle uds-field-required"
+            ></span>
+            Textarea (required)
+          </label>
+          <textarea
+            className="form-control"
+            id="ksTextarea"
+            rows="3"
+            placeholder="Tell us more..."
+            aria-describedby="ksTextareaFeedback"
+            aria-required="true"
+            required
+          ></textarea>
+          <small
+            id="ksTextareaFeedback"
+            className="form-textarea invalid-feedback"
+          >
+            <span
+              title="Alert"
+              className="fa fa-icon fa-exclamation-triangle"
+            ></span>
+            Please provide a response.
+          </small>
+        </div>
+
+        <fieldset>
+          <legend>
+            <span
+              title="Required"
+              className="fa fa-icon fa-circle uds-field-required"
+            ></span>
+            Radio group (required)
+          </legend>
+          <div className="form-check">
+            <input
+              className="form-check-input"
+              type="radio"
+              name="ksRadios"
+              id="ksRadio1"
+              value="option1"
+              aria-required="true"
+              required
+            />
+            <label className="form-check-label" htmlFor="ksRadio1">
+              Option 1
+            </label>
+          </div>
+          <div className="form-check">
+            <input
+              className="form-check-input"
+              type="radio"
+              name="ksRadios"
+              id="ksRadio2"
+              value="option2"
+              aria-required="true"
+              required
+            />
+            <label className="form-check-label" htmlFor="ksRadio2">
+              Option 2
+            </label>
+          </div>
+          <div className="form-check">
+            <input
+              className="form-check-input"
+              type="radio"
+              name="ksRadios"
+              id="ksRadio3"
+              value="option3"
+              aria-required="true"
+              required
+            />
+            <label className="form-check-label" htmlFor="ksRadio3">
+              Option 3
+            </label>
+            <small className="invalid-feedback">
+              <span
+                title="Alert"
+                className="fa fa-icon fa-exclamation-triangle"
+              ></span>
+              Please select an option.
+            </small>
+          </div>
+        </fieldset>
+
+        <div className="form-group">
+          <label htmlFor="ksSelect">
+            <span
+              title="Required"
+              className="fa fa-icon fa-circle uds-field-required"
+            ></span>
+            Select (required)
+          </label>
+          <select
+            className="form-select"
+            id="ksSelect"
+            aria-describedby="ksSelectFeedback"
+            aria-required="true"
+            required
+            defaultValue=""
+          >
+            <option value="" disabled>
+              Choose an option...
+            </option>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+          </select>
+          <small id="ksSelectFeedback" className="form-text invalid-feedback">
+            <span
+              title="Alert"
+              className="fa fa-icon fa-exclamation-triangle"
+            ></span>
+            Please select a value.
+          </small>
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="ksMultiSelect">Multiple select (optional)</label>
+          <select
+            multiple
+            className="form-select"
+            id="ksMultiSelect"
+            aria-describedby="ksMultiSelectFeedback"
+          >
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+            <option value="4">Option 4</option>
+            <option value="5">Option 5</option>
+          </select>
+          <small
+            id="ksMultiSelectFeedback"
+            className="form-text valid-feedback"
+          >
+            <span title="Success" className="fa fa-icon fa-check-circle"></span>
+            Looks good!
+          </small>
+        </div>
+
+        <div className="form-check">
+          <input
+            className="form-check-input"
+            type="checkbox"
+            id="ksCheckbox1"
+            value="terms"
+            aria-describedby="ksCheckboxFeedback"
+            aria-required="true"
+            required
+          />
+          <label className="form-check-label" htmlFor="ksCheckbox1">
+            <span
+              title="Required"
+              className="fa fa-icon fa-circle uds-field-required"
+            ></span>
+            I agree to the terms and conditions (required)
+          </label>
+          <small id="ksCheckboxFeedback" className="invalid-feedback">
+            <span
+              title="Alert"
+              className="fa fa-icon fa-exclamation-triangle"
+            ></span>
+            You must agree before submitting.
+          </small>
+        </div>
+
+        <div className="form-check">
+          <input
+            className="form-check-input"
+            type="checkbox"
+            id="ksCheckbox2"
+            value="newsletter"
+          />
+          <label className="form-check-label" htmlFor="ksCheckbox2">
+            Subscribe to newsletter (optional)
+          </label>
+        </div>
+
+        <div className="mt-3">
+          <button type="submit" className="btn btn-maroon">
+            Submit
+          </button>
+          <button type="reset" className="btn btn-gray ms-2">
+            Reset
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+KitchenSinkForm.storyName = "Kitchen Sink Form (Working Validation)";
+
+export const ClientSideValidationNeedsValidation = args => (
+  <div style={{ backgroundColor: backgroundColors[args.background] }}>
     <p>
-      <a href="https://getbootstrap.com/docs/5.0/forms/overview/">
-        Bootstrap 5 form docs
+      <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
+        Bootstrap 5 form docs regarding validation
       </a>
     </p>
 
-    <form className="uds-form">
+    <p>
+      When the form is marked with class &quot;was-validated&quot;,
+      browser-based validation styles based on input element type attribute are
+      triggered and displayed. This story shows the form <strong>before</strong>{" "}
+      validation (needs-validation class).
+    </p>
+
+    <form className={`uds-form needs-validation ${args.background}`}>
       <div className="form-group">
-        <label for="myTextInput">Text input</label>
+        <label htmlFor="myTextInput">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          Text input required field
+        </label>
         <input
           type="text"
           className="form-control"
           id="myTextInput"
+          aria-describedby="errorHelp1"
           placeholder="Helper text"
+          aria-required="true"
+          required
         />
+        <small id="errorHelp1" className="form-text invalid-feedback">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
       </div>
 
       <div className="form-group">
-        <label for="myLgInput">Large input</label>
+        <label htmlFor="myEmailInput">Email input</label>
+        <input
+          type="email"
+          className="form-control"
+          id="myEmailInput"
+          aria-describedby="errorHelp2"
+          placeholder="Helper text"
+          defaultValue="notAnEmail"
+        />
+        <small id="errorHelp2" className="form-text invalid-feedback">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="myLgInput">Large input</label>
         <input
           type="text"
           className="form-control form-control-lg"
           id="myLgInput"
+          aria-describedby="successHelp1"
           placeholder="Helper text"
-          value="Input text"
+          defaultValue="Input text"
         />
+        <small id="successHelp1" className="form-text valid-feedback">
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
       </div>
+
       <div className="form-group">
-        <label for="mySmInput" className="uds-form-label-disabled">
+        <label htmlFor="mySmInput" className="uds-form-label-disabled">
           Small input
         </label>
         <input
@@ -3206,26 +1267,129 @@ export const KitchenSinkForm = () => (
       </div>
 
       <div className="form-group">
-        <label for="exampleFormControlTextarea1">Example textarea</label>
+        <label htmlFor="exampleFormControlTextareaError">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          Error textarea required field
+        </label>
         <textarea
           className="form-control"
-          id="exampleFormControlTextarea1"
+          aria-describedby="errorTextareaHelp"
+          id="exampleFormControlTextareaError"
           rows="3"
+          required
         ></textarea>
+        <small
+          id="errorTextareaHelp"
+          className="form-textarea invalid-feedback"
+        >
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="exampleFormControlTextareaSuccess">
+          Success textarea
+        </label>
+        <textarea
+          className="form-control"
+          aria-describedby="successTextareaHelp"
+          id="exampleFormControlTextareaSuccess"
+          rows="3"
+          defaultValue="Agreeable content was entered."
+        ></textarea>
+        <small
+          id="successTextareaHelp"
+          className="form-textarea valid-feedback"
+        >
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+      </div>
+
+      <div className="form-check">
+        <input
+          className="form-check-input"
+          type="checkbox"
+          aria-describedby="myValidCheckMsg"
+          id="validLoneCheckbox"
+          value="option1"
+          defaultChecked
+          aria-required="true"
+          required
+        />
+        <label className="form-check-label" htmlFor="validLoneCheckbox">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          I accept (required field)
+        </label>
+        <small id="myValidCheckMsg" className="valid-feedback is-valid">
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+      </div>
+
+      <div className="form-check">
+        <input
+          className="form-check-input"
+          type="checkbox"
+          aria-describedby="myInvalidCheckMsg"
+          id="invalidLoneCheckbox"
+          value="option1"
+          aria-required="true"
+          required
+        />
+        <label className="form-check-label" htmlFor="invalidLoneCheckbox">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          I also accept (required field)
+        </label>
+        <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
       </div>
 
       <fieldset>
-        <legend>A Group of Radios</legend>
+        <legend>
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          A Group of Invalid Radios - required
+        </legend>
+        <small id="myInvalidRadiosMsg" className="invalid-feedback is-invalid">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
         <div className="form-check">
           <input
             className="form-check-input"
             type="radio"
-            name="exampleRadios"
-            id="exampleRadios1"
+            name="invalidRadios"
+            aria-describedby="myInvalidRadiosMsg"
+            id="invalidRadios1"
             value="option1"
-            checked
+            aria-required="true"
+            required
           />
-          <label className="form-check-label" for="exampleRadios1">
+          <label className="form-check-label" htmlFor="invalidRadios1">
             Default radio
           </label>
         </div>
@@ -3233,11 +1397,14 @@ export const KitchenSinkForm = () => (
           <input
             className="form-check-input"
             type="radio"
-            name="exampleRadios"
-            id="exampleRadios2"
+            name="invalidRadios"
+            aria-describedby="myInvalidRadiosMsg"
+            id="invalidRadios2"
             value="option2"
+            aria-required="true"
+            required
           />
-          <label className="form-check-label" for="exampleRadios2">
+          <label className="form-check-label" htmlFor="invalidRadios2">
             Second default radio
           </label>
         </div>
@@ -3245,19 +1412,20 @@ export const KitchenSinkForm = () => (
           <input
             className="form-check-input"
             type="radio"
-            name="exampleRadios"
-            id="exampleRadios3"
-            value="option3"
+            name="invalidRadios"
+            aria-describedby="myInvalidRadiosMsg"
+            id="invalidRadios4"
+            value="option4"
             disabled
           />
-          <label className="form-check-label" for="exampleRadios3">
+          <label className="form-check-label" htmlFor="invalidRadios4">
             Disabled radio
           </label>
         </div>
       </fieldset>
 
       <div className="form-group">
-        <label for="exampleFormControlSelect1">Example select</label>
+        <label htmlFor="exampleFormControlSelect1">Example select</label>
         <select className="form-select" id="exampleFormControlSelect1">
           <option>1</option>
           <option>2</option>
@@ -3267,2064 +1435,384 @@ export const KitchenSinkForm = () => (
         </select>
       </div>
       <div className="form-group">
-        <label for="exampleFormControlSelect2">Example multiple select</label>
-        <select multiple className="form-select" id="exampleFormControlSelect2">
+        <label htmlFor="exampleFormControlSelect2">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          Example multiple select - required
+        </label>
+        <select
+          multiple
+          className="form-select"
+          id="exampleFormControlSelect2"
+          aria-describedby="myInvalidSelectMsg"
+          aria-required="true"
+          required
+        >
           <option>1</option>
           <option>2</option>
           <option>3</option>
           <option>4</option>
           <option>5</option>
         </select>
-      </div>
-
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="checkbox1"
-          value="option1"
-        />
-        <label className="form-check-label" for="checkbox1">
-          1
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="checkbox2"
-          value="option2"
-          checked
-        />
-        <label className="form-check-label" for="checkbox2">
-          2
-        </label>
-      </div>
-      <div className="form-check">
-        <input
-          className="form-check-input"
-          type="checkbox"
-          id="checkbox3"
-          value="option3"
-          disabled
-        />
-        <label className="form-check-label" for="checkbox3">
-          3 (disabled)
-        </label>
+        <small id="myInvalidSelectMsg" className="invalid-feedback is-invalid">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
       </div>
     </form>
   </div>
 );
+ClientSideValidationNeedsValidation.storyName =
+  "Client-Side Validation (needs-validation)";
 
-export const KitchenSinkFormClientSideValidationWithInvalidAndValidNotYetValidatedFormInNeedsValidationState =
-  () => (
-    <div>
-      <p>
-        <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
-          Bootstrap 5 form docs regarding validation
-        </a>
-      </p>
+export const ClientSideValidationWasValidated = args => (
+  <div style={{ backgroundColor: backgroundColors[args.background] }}>
+    <p>
+      <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
+        Bootstrap 5 form docs regarding validation
+      </a>
+    </p>
 
-      <p>
-        When the form is marked with class "was-validated", browser-based
-        validation styles based on input element type attribute are triggered
-        and displayed.
-      </p>
+    <p>
+      When the form is marked with class &quot;was-validated&quot;,
+      browser-based validation styles based on input element type attribute are
+      triggered and displayed. This story shows the form <strong>after</strong>{" "}
+      validation (was-validated class).
+    </p>
 
-      <form className="uds-form needs-validation">
-        <div className="form-group">
-          <label for="myTextInput">
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            Text input required field
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="myTextInput"
-            aria-describedby="errorHelp1"
-            placeholder="Helper text"
-            aria-required="true"
-            required
-          />
-          <small id="errorHelp1" className="form-text invalid-feedback">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="myEmailInput">Email input</label>
-          <input
-            type="email"
-            className="form-control"
-            id="myEmailInput"
-            aria-describedby="errorHelp2"
-            placeholder="Helper text"
-            value="notAnEmail"
-          />
-          <small id="errorHelp2" className="form-text invalid-feedback">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="myLgInput">Large input</label>
-          <input
-            type="text"
-            className="form-control form-control-lg"
-            id="myLgInput"
-            aria-describedby="successHelp1"
-            placeholder="Helper text"
-            value="Input text"
-          />
-          <small id="successHelp1" className="form-text valid-feedback">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="mySmInput" className="uds-form-label-disabled">
-            Small input
-          </label>
-          <input
-            type="text"
-            className="form-control form-control-sm"
-            id="mySmInput"
-            placeholder="Helper text"
-            disabled
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaError">
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            Error textarea required field
-          </label>
-          <textarea
-            className="form-control"
-            aria-describedby="errorTextareaHelp"
-            id="exampleFormControlTextareaError"
-            rows="3"
-            required
-          ></textarea>
-          <small
-            id="errorTextareaHelp"
-            className="form-textarea invalid-feedback"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaSuccess">
-            Success textarea
-          </label>
-          <textarea
-            className="form-control"
-            aria-describedby="successTextareaHelp"
-            id="exampleFormControlTextareaSuccess"
-            rows="3"
-          >
-            Agreeable content was entered.
-          </textarea>
-          <small
-            id="successTextareaHelp"
-            className="form-textarea valid-feedback"
-          >
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleFormControlTextareaDisabled"
-            className="uds-form-label-disabled"
-          >
-            Disabled textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDisabled"
-            rows="3"
-            placeholder="I got some content."
-            disabled
-          ></textarea>
-        </div>
-
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckMsg"
-            id="validLoneCheckbox"
-            value="option1"
-            checked
-            aria-required="true"
-            required
-          />
-          <label className="form-check-label" for="validLoneCheckbox">
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            I accept (required field)
-          </label>
-          <small id="myValidCheckMsg" className="valid-feedback is-valid">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckMsg"
-            id="invalidLoneCheckbox"
-            value="option1"
-            aria-required="true"
-            required
-          />
-          <label className="form-check-label" for="invalidLoneCheckbox">
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            I also accept (required field)
-          </label>
-          <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <fieldset>
-          <legend>A Group of Valid Checkboxes</legend>
-          <small id="myValidCheckboxMsg" className="valid-feedback is-valid">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myValidCheckboxMsg"
-              id="validCheckbox1"
-              value="option1"
-            />
-            <label className="form-check-label" for="validCheckbox1">
-              1
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myValidCheckboxMsg"
-              id="validCheckbox2"
-              value="option2"
-              checked
-            />
-            <label className="form-check-label" for="validCheckbox2">
-              2
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myValidCheckboxMsg"
-              id="validCheckbox3"
-              value="option3"
-              disabled
-            />
-            <label className="form-check-label" for="validCheckbox3">
-              3 (disabled)
-            </label>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend>
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            A Group of Invalid Checkboxes - required
-          </legend>
-          <small
-            id="myInvalidCheckboxMsg"
-            className="invalid-feedback is-invalid"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myInvalidCheckboxMsg"
-              id="invalidCheckbox1"
-              value="option1"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidCheckbox1">
-              1
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myInvalidCheckboxMsg"
-              id="invalidCheckbox2"
-              value="option2"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidCheckbox2">
-              2
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myInvalidCheckboxMsg"
-              id="invalidCheckbox3"
-              value="option3"
-              disabled
-            />
-            <label className="form-check-label" for="invalidCheckbox3">
-              3 (disabled)
-            </label>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend>
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            A Group of Invalid Radios - required
-          </legend>
-          <small
-            id="myInvalidRadiosMsg"
-            className="invalid-feedback is-invalid"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="invalidRadios"
-              aria-describedby="myInvalidRadiosMsg"
-              id="invalidRadios1"
-              value="option1"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidRadios1">
-              Default radio
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="invalidRadios"
-              aria-describedby="myInvalidRadiosMsg"
-              id="invalidRadios2"
-              value="option2"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidRadios2">
-              Second default radio
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="invalidRadios"
-              aria-describedby="myInvalidRadiosMsg"
-              id="invalidRadios3"
-              value="option3"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidRadios3">
-              Third default radio
-            </label>
-          </div>
-          <div className="form-check disabled">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="invalidRadios"
-              aria-describedby="myInvalidRadiosMsg"
-              id="invalidRadios4"
-              value="option4"
-              disabled
-            />
-            <label className="form-check-label" for="invalidRadios4">
-              Disabled radio
-            </label>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend>A Group of Valid Radios</legend>
-          <small id="myValidRadiosMsg" className="valid-feedback is-valid">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="validRadios"
-              aria-describedby="myValidRadiosMsg"
-              id="validRadios1"
-              value="option1"
-              checked
-            />
-            <label className="form-check-label" for="validRadios1">
-              Default radio
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="validRadios"
-              aria-describedby="myValidRadiosMsg"
-              id="validRadios2"
-              value="option2"
-            />
-            <label className="form-check-label" for="validRadios2">
-              Second default radio
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="validRadios"
-              aria-describedby="myValidRadiosMsg"
-              id="validRadios3"
-              value="option3"
-            />
-            <label className="form-check-label" for="validRadios3">
-              Third default radio
-            </label>
-          </div>
-          <div className="form-check disabled">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="validRadios"
-              aria-describedby="myValidRadiosMsg"
-              id="validRadios4"
-              value="option4"
-              disabled
-            />
-            <label className="form-check-label" for="validRadios4">
-              Disabled radio
-            </label>
-          </div>
-        </fieldset>
-
-        <div className="form-group">
-          <label for="exampleFormControlSelect1">Example select</label>
-          <select className="form-select" id="exampleFormControlSelect1">
-            <option>1</option>
-            <option>2</option>
-            <option>3</option>
-            <option>4</option>
-            <option>5</option>
-          </select>
-        </div>
-        <div className="form-group">
-          <label for="exampleFormControlSelect2">Example multiple select</label>
-          <select
-            multiple
-            className="form-select"
-            id="exampleFormControlSelect2"
-          >
-            <option>1</option>
-            <option>2</option>
-            <option>3</option>
-            <option>4</option>
-            <option>5</option>
-          </select>
-        </div>
-      </form>
-    </div>
-  );
-
-export const KitchenSinkFormClientSideValidationWithInvalidAndValidValidatedFormInWasValidatedState =
-  () => (
-    <div>
-      <p>
-        <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
-          Bootstrap 5 form docs regarding validation
-        </a>
-      </p>
-
-      <p>
-        When the form is marked with class "was-validated", browser-based
-        validation styles based on input element type attribute are triggered
-        and displayed.
-      </p>
-
-      <form className="uds-form was-validated">
-        <div className="form-group">
-          <label for="myTextInput">
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            Text input required field
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="myTextInput"
-            aria-describedby="errorHelp1"
-            placeholder="Helper text"
-            aria-required="true"
-            required
-          />
-          <small id="errorHelp1" className="form-text invalid-feedback">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="myEmailInput">Email input</label>
-          <input
-            type="email"
-            className="form-control"
-            id="myEmailInput"
-            aria-describedby="errorHelp2"
-            placeholder="Helper text"
-            value="notAnEmail"
-          />
-          <small id="errorHelp2" className="form-text invalid-feedback">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="myLgInput">Large input</label>
-          <input
-            type="text"
-            className="form-control form-control-lg"
-            id="myLgInput"
-            aria-describedby="successHelp1"
-            placeholder="Helper text"
-            value="Input text"
-          />
-          <small id="successHelp1" className="form-text valid-feedback">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="mySmInput" className="uds-form-label-disabled">
-            Small input
-          </label>
-          <input
-            type="text"
-            className="form-control form-control-sm"
-            id="mySmInput"
-            placeholder="Helper text"
-            disabled
-          />
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaError">
-            Error textarea required
-          </label>
-          <textarea
-            className="form-control"
-            aria-describedby="errorTextareaHelp"
-            id="exampleFormControlTextareaError"
-            rows="3"
-            required
-          ></textarea>
-          <small
-            id="errorTextareaHelp"
-            className="form-textarea invalid-feedback"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label for="exampleFormControlTextareaSuccess">
-            Success textarea
-          </label>
-          <textarea
-            className="form-control"
-            aria-describedby="successTextareaHelp"
-            id="exampleFormControlTextareaSuccess"
-            rows="3"
-          >
-            Agreeable content was entered.
-          </textarea>
-          <small
-            id="successTextareaHelp"
-            className="form-textarea valid-feedback"
-          >
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-group">
-          <label
-            for="exampleFormControlTextareaDisabled"
-            className="uds-form-label-disabled"
-          >
-            Disabled textarea
-          </label>
-          <textarea
-            className="form-control"
-            id="exampleFormControlTextareaDisabled"
-            rows="3"
-            placeholder="I got some content."
-            disabled
-          ></textarea>
-        </div>
-
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myValidCheckMsg"
-            id="validLoneCheckbox"
-            value="option1"
-            checked
-            aria-required="true"
-            required
-          />
-          <label className="form-check-label" for="validLoneCheckbox">
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            I accept (required)
-          </label>
-          <small id="myValidCheckMsg" className="valid-feedback is-valid">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-
-        <div className="form-check">
-          <input
-            className="form-check-input"
-            type="checkbox"
-            aria-describedby="myInvalidCheckMsg"
-            id="invalidLoneCheckbox"
-            value="option1"
-            aria-required="true"
-            required
-          />
-          <label className="form-check-label" for="invalidLoneCheckbox">
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            I also accept (required)
-          </label>
-          <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-
-        <fieldset>
-          <legend>A Group of Valid Checkboxes</legend>
-          <small id="myValidCheckboxMsg" className="valid-feedback is-valid">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myValidCheckboxMsg"
-              id="validCheckbox1"
-              value="option1"
-            />
-            <label className="form-check-label" for="validCheckbox1">
-              1
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myValidCheckboxMsg"
-              id="validCheckbox2"
-              value="option2"
-              checked
-            />
-            <label className="form-check-label" for="validCheckbox2">
-              2
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myValidCheckboxMsg"
-              id="validCheckbox3"
-              value="option3"
-              disabled
-            />
-            <label className="form-check-label" for="validCheckbox3">
-              3 (disabled)
-            </label>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend>
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            A Group of Invalid Checkboxes - required
-          </legend>
-          <small
-            id="myInvalidCheckboxMsg"
-            className="invalid-feedback is-invalid"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myInvalidCheckboxMsg"
-              id="invalidCheckbox1"
-              value="option1"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidCheckbox1">
-              1
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myInvalidCheckboxMsg"
-              id="invalidCheckbox2"
-              value="option2"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidCheckbox2">
-              2
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myInvalidCheckboxMsg"
-              id="invalidCheckbox3"
-              value="option3"
-              disabled
-            />
-            <label className="form-check-label" for="invalidCheckbox3">
-              3 (disabled)
-            </label>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend>
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            A Group of Invalid Radios - required
-          </legend>
-          <small
-            id="myInvalidRadiosMsg"
-            className="invalid-feedback is-invalid"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="invalidRadios"
-              aria-describedby="myInvalidRadiosMsg"
-              id="invalidRadios1"
-              value="option1"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidRadios1">
-              Default radio
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="invalidRadios"
-              aria-describedby="myInvalidRadiosMsg"
-              id="invalidRadios2"
-              value="option2"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidRadios2">
-              Second default radio
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="invalidRadios"
-              aria-describedby="myInvalidRadiosMsg"
-              id="invalidRadios3"
-              value="option3"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidRadios3">
-              Third default radio
-            </label>
-          </div>
-          <div className="form-check disabled">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="invalidRadios"
-              aria-describedby="myInvalidRadiosMsg"
-              id="invalidRadios4"
-              value="option4"
-              disabled
-            />
-            <label className="form-check-label" for="invalidRadios4">
-              Disabled radio
-            </label>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend>A Group of Valid Radios</legend>
-          <small id="myValidRadiosMsg" className="valid-feedback is-valid">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="validRadios"
-              aria-describedby="myValidRadiosMsg"
-              id="validRadios1"
-              value="option1"
-              checked
-            />
-            <label className="form-check-label" for="validRadios1">
-              Default radio
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="validRadios"
-              aria-describedby="myValidRadiosMsg"
-              id="validRadios2"
-              value="option2"
-            />
-            <label className="form-check-label" for="validRadios2">
-              Second default radio
-            </label>
-          </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="validRadios"
-              aria-describedby="myValidRadiosMsg"
-              id="validRadios3"
-              value="option3"
-            />
-            <label className="form-check-label" for="validRadios3">
-              Third default radio
-            </label>
-          </div>
-          <div className="form-check disabled">
-            <input
-              className="form-check-input"
-              type="radio"
-              name="validRadios"
-              aria-describedby="myValidRadiosMsg"
-              id="validRadios4"
-              value="option4"
-              disabled
-            />
-            <label className="form-check-label" for="validRadios4">
-              Disabled radio
-            </label>
-          </div>
-        </fieldset>
-
-        <div className="form-group">
-          <label for="exampleFormControlSelect1">Example select</label>
-          <select
-            className="form-select"
-            id="exampleFormControlSelect1"
-            aria-describedby="myValidSelectMsg"
-          >
-            <option>1</option>
-            <option>2</option>
-            <option>3</option>
-            <option>4</option>
-            <option>5</option>
-          </select>
-          <small id="myValidSelectMsg" className="valid-feedback is-valid">
-            <span title="Success" className="fa fa-icon fa-check-circle"></span>
-            Success message
-          </small>
-        </div>
-        <div className="form-group">
-          <label for="exampleFormControlSelect2">
-            <span
-              title="Required"
-              className="fa fa-icon fa-circle uds-field-required"
-            ></span>
-            Example multiple select - required
-          </label>
-          <select
-            multiple
-            className="form-select"
-            id="exampleFormControlSelect2"
-            aria-describedby="myInvalidSelectMsg"
-            aria-required="true"
-            required
-          >
-            <option>1</option>
-            <option>2</option>
-            <option>3</option>
-            <option>4</option>
-            <option>5</option>
-          </select>
-          <small
-            id="myInvalidSelectMsg"
-            className="invalid-feedback is-invalid"
-          >
-            <span
-              title="Alert"
-              className="fa fa-icon fa-exclamation-triangle"
-            ></span>
-            Form error message
-          </small>
-        </div>
-      </form>
-    </div>
-  );
-
-export const KitchenSinkFormClientSideValidationWithInvalidAndValidNotYetValidatedFormInNeedsValidationStateGray7Background =
-  () => (
-    <div>
-      <p>
-        <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
-          Bootstrap 5 form docs regarding validation
-        </a>
-      </p>
-
-      <p>
-        When the form is marked with class "was-validated", browser-based
-        validation styles based on input element type attribute are triggered
-        and displayed.
-      </p>
-
-      <div style={{ backgroundColor: "#191919" }}>
-        {/* This div for Storybook display only. */}
-        <form className="uds-form needs-validation uds-form-dark-bg">
-          <div className="form-group">
-            <label for="myTextInput">
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              Text input required field
-            </label>
-            <input
-              type="text"
-              className="form-control"
-              id="myTextInput"
-              aria-describedby="errorHelp1"
-              placeholder="Helper text"
-              aria-required="true"
-              required
-            />
-            <small id="errorHelp1" className="form-text invalid-feedback">
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label for="myEmailInput">Email input</label>
-            <input
-              type="email"
-              className="form-control"
-              id="myEmailInput"
-              aria-describedby="errorHelp2"
-              placeholder="Helper text"
-              value="notAnEmail"
-            />
-            <small id="errorHelp2" className="form-text invalid-feedback">
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label for="myLgInput">Large input</label>
-            <input
-              type="text"
-              className="form-control form-control-lg"
-              id="myLgInput"
-              aria-describedby="successHelp1"
-              placeholder="Helper text"
-              value="Input text"
-            />
-            <small id="successHelp1" className="form-text valid-feedback">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label for="mySmInput" className="uds-form-label-disabled">
-              Small input
-            </label>
-            <input
-              type="text"
-              className="form-control form-control-sm"
-              id="mySmInput"
-              placeholder="Helper text"
-              disabled
-            />
-          </div>
-
-          <div className="form-group">
-            <label for="exampleFormControlTextareaError">
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              Error textarea required field
-            </label>
-            <textarea
-              className="form-control"
-              aria-describedby="errorTextareaHelp"
-              id="exampleFormControlTextareaError"
-              rows="3"
-              required
-            ></textarea>
-            <small
-              id="errorTextareaHelp"
-              className="form-textarea invalid-feedback"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label for="exampleFormControlTextareaSuccess">
-              Success textarea
-            </label>
-            <textarea
-              className="form-control"
-              aria-describedby="successTextareaHelp"
-              id="exampleFormControlTextareaSuccess"
-              rows="3"
-            >
-              Agreeable content was entered.
-            </textarea>
-            <small
-              id="successTextareaHelp"
-              className="form-textarea valid-feedback"
-            >
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label
-              for="exampleFormControlTextareaDisabled"
-              className="uds-form-label-disabled"
-            >
-              Disabled textarea
-            </label>
-            <textarea
-              className="form-control"
-              id="exampleFormControlTextareaDisabled"
-              rows="3"
-              placeholder="I got some content."
-              disabled
-            ></textarea>
-          </div>
-
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myValidCheckMsg"
-              id="validLoneCheckbox"
-              value="option1"
-              checked
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="validLoneCheckbox">
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              I accept (required field)
-            </label>
-            <small id="myValidCheckMsg" className="valid-feedback is-valid">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-          </div>
-
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myInvalidCheckMsg"
-              id="invalidLoneCheckbox"
-              value="option1"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidLoneCheckbox">
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              I also accept (required field)
-            </label>
-            <small
-              id="myInvalidCheckMsg"
-              className="invalid-feedback is-invalid"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-
-          <fieldset>
-            <legend>A Group of Valid Checkboxes</legend>
-            <small id="myValidCheckboxMsg" className="valid-feedback is-valid">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myValidCheckboxMsg"
-                id="validCheckbox1"
-                value="option1"
-              />
-              <label className="form-check-label" for="validCheckbox1">
-                1
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myValidCheckboxMsg"
-                id="validCheckbox2"
-                value="option2"
-                checked
-              />
-              <label className="form-check-label" for="validCheckbox2">
-                2
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myValidCheckboxMsg"
-                id="validCheckbox3"
-                value="option3"
-                disabled
-              />
-              <label className="form-check-label" for="validCheckbox3">
-                3 (disabled)
-              </label>
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend>
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              A Group of Invalid Checkboxes - required
-            </legend>
-            <small
-              id="myInvalidCheckboxMsg"
-              className="invalid-feedback is-invalid"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myInvalidCheckboxMsg"
-                id="invalidCheckbox1"
-                value="option1"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidCheckbox1">
-                1
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myInvalidCheckboxMsg"
-                id="invalidCheckbox2"
-                value="option2"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidCheckbox2">
-                2
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myInvalidCheckboxMsg"
-                id="invalidCheckbox3"
-                value="option3"
-                disabled
-              />
-              <label className="form-check-label" for="invalidCheckbox3">
-                3 (disabled)
-              </label>
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend>
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              A Group of Invalid Radios - required
-            </legend>
-            <small
-              id="myInvalidRadiosMsg"
-              className="invalid-feedback is-invalid"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="invalidRadios"
-                aria-describedby="myInvalidRadiosMsg"
-                id="invalidRadios1"
-                value="option1"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidRadios1">
-                Default radio
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="invalidRadios"
-                aria-describedby="myInvalidRadiosMsg"
-                id="invalidRadios2"
-                value="option2"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidRadios2">
-                Second default radio
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="invalidRadios"
-                aria-describedby="myInvalidRadiosMsg"
-                id="invalidRadios3"
-                value="option3"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidRadios3">
-                Third default radio
-              </label>
-            </div>
-            <div className="form-check disabled">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="invalidRadios"
-                aria-describedby="myInvalidRadiosMsg"
-                id="invalidRadios4"
-                value="option4"
-                disabled
-              />
-              <label className="form-check-label" for="invalidRadios4">
-                Disabled radio
-              </label>
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend>A Group of Valid Radios</legend>
-            <small id="myValidRadiosMsg" className="valid-feedback is-valid">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="validRadios"
-                aria-describedby="myValidRadiosMsg"
-                id="validRadios1"
-                value="option1"
-                checked
-              />
-              <label className="form-check-label" for="validRadios1">
-                Default radio
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="validRadios"
-                aria-describedby="myValidRadiosMsg"
-                id="validRadios2"
-                value="option2"
-              />
-              <label className="form-check-label" for="validRadios2">
-                Second default radio
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="validRadios"
-                aria-describedby="myValidRadiosMsg"
-                id="validRadios3"
-                value="option3"
-              />
-              <label className="form-check-label" for="validRadios3">
-                Third default radio
-              </label>
-            </div>
-            <div className="form-check disabled">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="validRadios"
-                aria-describedby="myValidRadiosMsg"
-                id="validRadios4"
-                value="option4"
-                disabled
-              />
-              <label className="form-check-label" for="validRadios4">
-                Disabled radio
-              </label>
-            </div>
-          </fieldset>
-
-          <div className="form-group">
-            <label for="exampleFormControlSelect1">Example select</label>
-            <select className="form-select" id="exampleFormControlSelect1">
-              <option>1</option>
-              <option>2</option>
-              <option>3</option>
-              <option>4</option>
-              <option>5</option>
-            </select>
-          </div>
-          <div className="form-group">
-            <label for="exampleFormControlSelect2">
-              Example multiple select
-            </label>
-            <select
-              multiple
-              className="form-select"
-              id="exampleFormControlSelect2"
-            >
-              <option>1</option>
-              <option>2</option>
-              <option>3</option>
-              <option>4</option>
-              <option>5</option>
-            </select>
-          </div>
-        </form>
+    <form className={`uds-form was-validated ${args.background}`}>
+      <div className="form-group">
+        <label htmlFor="myTextInput">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          Text input required field
+        </label>
+        <input
+          type="text"
+          className="form-control"
+          id="myTextInput"
+          aria-describedby="errorHelp1"
+          placeholder="Helper text"
+          aria-required="true"
+          required
+        />
+        <small id="errorHelp1" className="form-text invalid-feedback">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
       </div>
-    </div>
-  );
 
-export const KitchenSinkFormClientSideValidationWithInvalidAndValidValidatedFormInWasValidatedStateGray7Background =
-  () => (
-    <div>
-      <p>
-        <a href="https://getbootstrap.com/docs/5.0/forms/validation/">
-          Bootstrap 5 form docs regarding validation
-        </a>
-      </p>
-
-      <p>
-        When the form is marked with class "was-validated", browser-based
-        validation styles based on input element type attribute are triggered
-        and displayed.
-      </p>
-
-      <div style={{ backgroundColor: "#191919" }}>
-        {/* This div for Storybook display only. */}
-        <form className="uds-form was-validated uds-form-dark-bg">
-          <div className="form-group">
-            <label for="myTextInput">
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              Text input required field
-            </label>
-            <input
-              type="text"
-              className="form-control"
-              id="myTextInput"
-              aria-describedby="errorHelp1"
-              placeholder="Helper text"
-              aria-required="true"
-              required
-            />
-            <small id="errorHelp1" className="form-text invalid-feedback">
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label for="myEmailInput">Email input</label>
-            <input
-              type="email"
-              className="form-control"
-              id="myEmailInput"
-              aria-describedby="errorHelp2"
-              placeholder="Helper text"
-              value="notAnEmail"
-            />
-            <small id="errorHelp2" className="form-text invalid-feedback">
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label for="myLgInput">Large input</label>
-            <input
-              type="text"
-              className="form-control form-control-lg"
-              id="myLgInput"
-              aria-describedby="successHelp1"
-              placeholder="Helper text"
-              value="Input text"
-            />
-            <small id="successHelp1" className="form-text valid-feedback">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label for="mySmInput" className="uds-form-label-disabled">
-              Small input
-            </label>
-            <input
-              type="text"
-              className="form-control form-control-sm"
-              id="mySmInput"
-              placeholder="Helper text"
-              disabled
-            />
-          </div>
-
-          <div className="form-group">
-            <label for="exampleFormControlTextareaError">
-              Error textarea required
-            </label>
-            <textarea
-              className="form-control"
-              aria-describedby="errorTextareaHelp"
-              id="exampleFormControlTextareaError"
-              rows="3"
-              required
-            ></textarea>
-            <small
-              id="errorTextareaHelp"
-              className="form-textarea invalid-feedback"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label for="exampleFormControlTextareaSuccess">
-              Success textarea
-            </label>
-            <textarea
-              className="form-control"
-              aria-describedby="successTextareaHelp"
-              id="exampleFormControlTextareaSuccess"
-              rows="3"
-            >
-              Agreeable content was entered.
-            </textarea>
-            <small
-              id="successTextareaHelp"
-              className="form-textarea valid-feedback"
-            >
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-          </div>
-
-          <div className="form-group">
-            <label
-              for="exampleFormControlTextareaDisabled"
-              className="uds-form-label-disabled"
-            >
-              Disabled textarea
-            </label>
-            <textarea
-              className="form-control"
-              id="exampleFormControlTextareaDisabled"
-              rows="3"
-              placeholder="I got some content."
-              disabled
-            ></textarea>
-          </div>
-
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myValidCheckMsg"
-              id="validLoneCheckbox"
-              value="option1"
-              checked
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="validLoneCheckbox">
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              I accept (required)
-            </label>
-            <small id="myValidCheckMsg" className="valid-feedback is-valid">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-          </div>
-
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              aria-describedby="myInvalidCheckMsg"
-              id="invalidLoneCheckbox"
-              value="option1"
-              aria-required="true"
-              required
-            />
-            <label className="form-check-label" for="invalidLoneCheckbox">
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              I also accept (required)
-            </label>
-            <small
-              id="myInvalidCheckMsg"
-              className="invalid-feedback is-invalid"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-
-          <fieldset>
-            <legend>A Group of Valid Checkboxes</legend>
-            <small id="myValidCheckboxMsg" className="valid-feedback is-valid">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myValidCheckboxMsg"
-                id="validCheckbox1"
-                value="option1"
-              />
-              <label className="form-check-label" for="validCheckbox1">
-                1
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myValidCheckboxMsg"
-                id="validCheckbox2"
-                value="option2"
-                checked
-              />
-              <label className="form-check-label" for="validCheckbox2">
-                2
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myValidCheckboxMsg"
-                id="validCheckbox3"
-                value="option3"
-                disabled
-              />
-              <label className="form-check-label" for="validCheckbox3">
-                3 (disabled)
-              </label>
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend>
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              A Group of Invalid Checkboxes - required
-            </legend>
-            <small
-              id="myInvalidCheckboxMsg"
-              className="invalid-feedback is-invalid"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myInvalidCheckboxMsg"
-                id="invalidCheckbox1"
-                value="option1"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidCheckbox1">
-                1
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myInvalidCheckboxMsg"
-                id="invalidCheckbox2"
-                value="option2"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidCheckbox2">
-                2
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                aria-describedby="myInvalidCheckboxMsg"
-                id="invalidCheckbox3"
-                value="option3"
-                disabled
-              />
-              <label className="form-check-label" for="invalidCheckbox3">
-                3 (disabled)
-              </label>
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend>
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              A Group of Invalid Radios - required
-            </legend>
-            <small
-              id="myInvalidRadiosMsg"
-              className="invalid-feedback is-invalid"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="invalidRadios"
-                aria-describedby="myInvalidRadiosMsg"
-                id="invalidRadios1"
-                value="option1"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidRadios1">
-                Default radio
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="invalidRadios"
-                aria-describedby="myInvalidRadiosMsg"
-                id="invalidRadios2"
-                value="option2"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidRadios2">
-                Second default radio
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="invalidRadios"
-                aria-describedby="myInvalidRadiosMsg"
-                id="invalidRadios3"
-                value="option3"
-                aria-required="true"
-                required
-              />
-              <label className="form-check-label" for="invalidRadios3">
-                Third default radio
-              </label>
-            </div>
-            <div className="form-check disabled">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="invalidRadios"
-                aria-describedby="myInvalidRadiosMsg"
-                id="invalidRadios4"
-                value="option4"
-                disabled
-              />
-              <label className="form-check-label" for="invalidRadios4">
-                Disabled radio
-              </label>
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend>A Group of Valid Radios</legend>
-            <small id="myValidRadiosMsg" className="valid-feedback is-valid">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="validRadios"
-                aria-describedby="myValidRadiosMsg"
-                id="validRadios1"
-                value="option1"
-                checked
-              />
-              <label className="form-check-label" for="validRadios1">
-                Default radio
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="validRadios"
-                aria-describedby="myValidRadiosMsg"
-                id="validRadios2"
-                value="option2"
-              />
-              <label className="form-check-label" for="validRadios2">
-                Second default radio
-              </label>
-            </div>
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="validRadios"
-                aria-describedby="myValidRadiosMsg"
-                id="validRadios3"
-                value="option3"
-              />
-              <label className="form-check-label" for="validRadios3">
-                Third default radio
-              </label>
-            </div>
-            <div className="form-check disabled">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="validRadios"
-                aria-describedby="myValidRadiosMsg"
-                id="validRadios4"
-                value="option4"
-                disabled
-              />
-              <label className="form-check-label" for="validRadios4">
-                Disabled radio
-              </label>
-            </div>
-          </fieldset>
-
-          <div className="form-group">
-            <label for="exampleFormControlSelect1">Example select</label>
-            <select
-              className="form-select"
-              id="exampleFormControlSelect1"
-              aria-describedby="myValidSelectMsg"
-            >
-              <option>1</option>
-              <option>2</option>
-              <option>3</option>
-              <option>4</option>
-              <option>5</option>
-            </select>
-            <small id="myValidSelectMsg" className="valid-feedback is-valid">
-              <span
-                title="Success"
-                className="fa fa-icon fa-check-circle"
-              ></span>
-              Success message
-            </small>
-          </div>
-          <div className="form-group">
-            <label for="exampleFormControlSelect2">
-              <span
-                title="Required"
-                className="fa fa-icon fa-circle uds-field-required"
-              ></span>
-              Example multiple select - required
-            </label>
-            <select
-              multiple
-              className="form-select"
-              id="exampleFormControlSelect2"
-              aria-describedby="myInvalidSelectMsg"
-              aria-required="true"
-              required
-            >
-              <option>1</option>
-              <option>2</option>
-              <option>3</option>
-              <option>4</option>
-              <option>5</option>
-            </select>
-            <small
-              id="myInvalidSelectMsg"
-              className="invalid-feedback is-invalid"
-            >
-              <span
-                title="Alert"
-                className="fa fa-icon fa-exclamation-triangle"
-              ></span>
-              Form error message
-            </small>
-          </div>
-        </form>
+      <div className="form-group">
+        <label htmlFor="myEmailInput">Email input</label>
+        <input
+          type="email"
+          className="form-control"
+          id="myEmailInput"
+          aria-describedby="errorHelp2"
+          placeholder="Helper text"
+          defaultValue="notAnEmail"
+        />
+        <small id="errorHelp2" className="form-text invalid-feedback">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
       </div>
-    </div>
-  );
+
+      <div className="form-group">
+        <label htmlFor="myLgInput">Large input</label>
+        <input
+          type="text"
+          className="form-control form-control-lg"
+          id="myLgInput"
+          aria-describedby="successHelp1"
+          placeholder="Helper text"
+          defaultValue="Input text"
+        />
+        <small id="successHelp1" className="form-text valid-feedback">
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="mySmInput" className="uds-form-label-disabled">
+          Small input
+        </label>
+        <input
+          type="text"
+          className="form-control form-control-sm"
+          id="mySmInput"
+          placeholder="Helper text"
+          disabled
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="exampleFormControlTextareaError">
+          Error textarea required
+        </label>
+        <textarea
+          className="form-control"
+          aria-describedby="errorTextareaHelp"
+          id="exampleFormControlTextareaError"
+          rows="3"
+          required
+        ></textarea>
+        <small
+          id="errorTextareaHelp"
+          className="form-textarea invalid-feedback"
+        >
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="exampleFormControlTextareaSuccess">
+          Success textarea
+        </label>
+        <textarea
+          className="form-control"
+          aria-describedby="successTextareaHelp"
+          id="exampleFormControlTextareaSuccess"
+          rows="3"
+          defaultValue="Agreeable content was entered."
+        ></textarea>
+        <small
+          id="successTextareaHelp"
+          className="form-textarea valid-feedback"
+        >
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+      </div>
+
+      <div className="form-check">
+        <input
+          className="form-check-input"
+          type="checkbox"
+          aria-describedby="myValidCheckMsg"
+          id="validLoneCheckbox"
+          value="option1"
+          defaultChecked
+          aria-required="true"
+          required
+        />
+        <label className="form-check-label" htmlFor="validLoneCheckbox">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          I accept (required)
+        </label>
+        <small id="myValidCheckMsg" className="valid-feedback is-valid">
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+      </div>
+
+      <div className="form-check">
+        <input
+          className="form-check-input"
+          type="checkbox"
+          aria-describedby="myInvalidCheckMsg"
+          id="invalidLoneCheckbox"
+          value="option1"
+          aria-required="true"
+          required
+        />
+        <label className="form-check-label" htmlFor="invalidLoneCheckbox">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          I also accept (required)
+        </label>
+        <small id="myInvalidCheckMsg" className="invalid-feedback is-invalid">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
+      </div>
+
+      <fieldset>
+        <legend>
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          A Group of Invalid Radios - required
+        </legend>
+        <small id="myInvalidRadiosMsg" className="invalid-feedback is-invalid">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
+        <div className="form-check">
+          <input
+            className="form-check-input"
+            type="radio"
+            name="invalidRadios"
+            aria-describedby="myInvalidRadiosMsg"
+            id="invalidRadios1"
+            value="option1"
+            aria-required="true"
+            required
+          />
+          <label className="form-check-label" htmlFor="invalidRadios1">
+            Default radio
+          </label>
+        </div>
+        <div className="form-check">
+          <input
+            className="form-check-input"
+            type="radio"
+            name="invalidRadios"
+            aria-describedby="myInvalidRadiosMsg"
+            id="invalidRadios2"
+            value="option2"
+            aria-required="true"
+            required
+          />
+          <label className="form-check-label" htmlFor="invalidRadios2">
+            Second default radio
+          </label>
+        </div>
+        <div className="form-check disabled">
+          <input
+            className="form-check-input"
+            type="radio"
+            name="invalidRadios"
+            aria-describedby="myInvalidRadiosMsg"
+            id="invalidRadios4"
+            value="option4"
+            disabled
+          />
+          <label className="form-check-label" htmlFor="invalidRadios4">
+            Disabled radio
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>A Group of Valid Radios</legend>
+        <small id="myValidRadiosMsg" className="valid-feedback is-valid">
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+        <div className="form-check">
+          <input
+            className="form-check-input"
+            type="radio"
+            name="validRadios"
+            aria-describedby="myValidRadiosMsg"
+            id="validRadios1"
+            value="option1"
+            defaultChecked
+          />
+          <label className="form-check-label" htmlFor="validRadios1">
+            Default radio
+          </label>
+        </div>
+        <div className="form-check">
+          <input
+            className="form-check-input"
+            type="radio"
+            name="validRadios"
+            aria-describedby="myValidRadiosMsg"
+            id="validRadios2"
+            value="option2"
+          />
+          <label className="form-check-label" htmlFor="validRadios2">
+            Second default radio
+          </label>
+        </div>
+        <div className="form-check disabled">
+          <input
+            className="form-check-input"
+            type="radio"
+            name="validRadios"
+            aria-describedby="myValidRadiosMsg"
+            id="validRadios4"
+            value="option4"
+            disabled
+          />
+          <label className="form-check-label" htmlFor="validRadios4">
+            Disabled radio
+          </label>
+        </div>
+      </fieldset>
+
+      <div className="form-group">
+        <label htmlFor="exampleFormControlSelect1">Example select</label>
+        <select
+          className="form-select"
+          id="exampleFormControlSelect1"
+          aria-describedby="myValidSelectMsg"
+        >
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+        <small id="myValidSelectMsg" className="valid-feedback is-valid">
+          <span title="Success" className="fa fa-icon fa-check-circle"></span>
+          Success message
+        </small>
+      </div>
+      <div className="form-group">
+        <label htmlFor="exampleFormControlSelect2">
+          <span
+            title="Required"
+            className="fa fa-icon fa-circle uds-field-required"
+          ></span>
+          Example multiple select - required
+        </label>
+        <select
+          multiple
+          className="form-select"
+          id="exampleFormControlSelect2"
+          aria-describedby="myInvalidSelectMsg"
+          aria-required="true"
+          required
+        >
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+        <small id="myInvalidSelectMsg" className="invalid-feedback is-invalid">
+          <span
+            title="Alert"
+            className="fa fa-icon fa-exclamation-triangle"
+          ></span>
+          Form error message
+        </small>
+      </div>
+    </form>
+  </div>
+);
+ClientSideValidationWasValidated.storyName =
+  "Client-Side Validation (was-validated)";


### PR DESCRIPTION
### Description

Bootstrap client side validation in the unity-bootstrap-theme

### Solution
Update Css to allow invalid and valid elements visibility based on submission state and field valid state.
Updated Storybook example with a client side working example
Reduced the amount of stories/repeated code by adding storybook controls for background variations
Moving these form fields still need to migrate to unity-react-core, but I feel this is a bigger effort for fixing this bug

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-1699)
- [Unity reference site](https://asu.github.io/asu-unity-stack/)
- [UDS Guidelines](https://zeroheight.com/9f0b32a56/p/96ab23-getting-started)

