### PR TITLE
fix(component-header-footer): uds-2264 - search input padding

### DIFF
--- a/packages/component-header-footer/src/header/components/UniversalNavbar/Search/SearchInput.js
+++ b/packages/component-header-footer/src/header/components/UniversalNavbar/Search/SearchInput.js
@@ -44,7 +44,7 @@ const SearchInput = ({
     onChange: handleInputChange,
     onBlur: onBlur,
     style: {
-      paddingLeft: hasInputValue && isMobile ? "1rem" : undefined,
+      paddingLeft: hasInputValue ? ".5rem" : undefined,
       ...style,
     },
   };


### PR DESCRIPTION
<!-- PREFLIGHT CHECK - to be deleted before submitting PR -->
<!--   - CHECK: Do tests need to be added or updated? -->
<!--   - CHECK: Are data layer additions or updates needed? -->

### Padding-left for the search input box should be .5rem on both desktop and mobile.

To reproduce - Type some text into the top right universal search field (gray bar) and view the padding-left via browser inspector - should be .5rem, or 8px.

### Links

- [JIRA ticket](https://asudev.jira.com/browse/UDS-2264)

